### PR TITLE
fix: correct _init_ typo and invalid syntax in channel.py and games.py

### DIFF
--- a/extensions/channel.py
+++ b/extensions/channel.py
@@ -289,8 +289,8 @@ class DynamicslowmodeCommands(discord.app_commands.Group):
 
 
 class ChannelCommands(discord.app_commands.Group):
-    def _init_(self) -> None:
-        super()._init_(  # type: ignore[misc]
+    def __init__(self) -> None:
+        super().__init__(  # type: ignore[misc]
             name=app_commands.locale_str("channel_name"),
             description=app_commands.locale_str("channel_description"),
         )

--- a/extensions/games.py
+++ b/extensions/games.py
@@ -99,7 +99,7 @@ class gameCommands(discord.app_commands.Group):
             client=interaction.client,
         )
         size = size.value.split(",") if size != "7,6" else ["7", "6"]  # type: ignore[assignment]
-        await connect4(commandInfo, ctx.user, user, int(size[0, index]), int(size[1, index]))  # type: ignore[name-defined, index]
+        await connect4(commandInfo, ctx.user, user, int(size[0]), int(size[1]))  # type: ignore[name-defined]
 
     @app_commands.command(
         name=app_commands.locale_str("games_akinator_name"),


### PR DESCRIPTION
Two simple syntax fixes:

1. Fixes #1232: ChannelCommands._init_ (single underscores) to __init__ (double underscores). The method was never called during construction.

2. Fixes #1233: int(size[0, index]) to int(size[0]). size is a list from split, proper access is size[0] and size[1].