### PR TITLE
Fix #1261: Remove tmp.py and fix notifiedUsers memory leak in addLevelXp.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ share/
 pyvenv.cfg
 lib64
 
+# Debug / temporary files
+tmp.py
+
 # Mypy Logs
 current_mypy.txt
 mypy_errors.txt

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -56,7 +56,7 @@ class LoopCog(commands.Cog):
     @tasks.loop(seconds=5)
     async def clearNotifiedUsersLoop(self) -> None:
         try:
-            await clearNotifiedUsers(self.bot)  # type: ignore[misc, call-arg, func-returns-value]  # type: ignore[func-returns-value]  # type: ignore[func-returns-value]  # type: ignore[func-returns-value]
+            await clearNotifiedUsers(self.bot)
         except Exception:
             pass
 

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -56,7 +56,7 @@ class LoopCog(commands.Cog):
     @tasks.loop(seconds=5)
     async def clearNotifiedUsersLoop(self) -> None:
         try:
-            await clearNotifiedUsers(self.bot)
+            clearNotifiedUsers(self.bot)
         except Exception:
             pass
 

--- a/minigames/addLevelXp.py
+++ b/minigames/addLevelXp.py
@@ -22,7 +22,8 @@ from api import (
 from localizer import tanjunLocalizer
 from utility import get_level_for_xp  # , checkIfHasPro
 
-notifiedUsers: list[int] = []
+notifiedUsers: set[int] = set()
+_MAX_NOTIFIED_USERS = 10_000
 
 
 async def addLevelXp(message: discord.Message) -> None:
@@ -120,14 +121,16 @@ async def handle_level_up(message: discord.Message, new_level: int) -> None:
     if await get_levelup_message_status(guild_id) and message.author.id not in notifiedUsers:
         channel = await determine_levelup_channel(message, guild_id)
         await channel.send(await format_level_up_message(guild_id, message.author.mention, new_level, message.guild))
-        notifiedUsers.append(message.author.id)
+        notifiedUsers.add(message.author.id)
+        if len(notifiedUsers) > _MAX_NOTIFIED_USERS:
+            notifiedUsers.pop()
 
     await update_user_roles(message, new_level, guild_id)
 
 
-def clearNotifiedUsers() -> None:
+def clearNotifiedUsers(*args: object, **kwargs: object) -> None:
     global notifiedUsers
-    notifiedUsers = []
+    notifiedUsers.clear()
 
 
 async def determine_levelup_channel(message: discord.Message, guild_id: str) -> discord.abc.Messageable:

--- a/tmp.py
+++ b/tmp.py
@@ -1,6 +1,0 @@
-def allowed_words(locale: str) -> list[str]:
-    with open(f"commands/games/wordle_words/{locale}/allowed_words.txt", encoding="utf-8") as file:
-        return file.read().splitlines()
-
-
-print(allowed_words("de"))


### PR DESCRIPTION
## Summary
- Removes `tmp.py` (debug file committed to repo root)
- Adds `tmp.py` to `.gitignore`
- Fixes unbounded memory growth of `notifiedUsers` set in `addLevelXp.py` by using a bounded set with a 10,000-entry limit
- Fixes `clearNotifiedUsers()` function signature so it properly accepts the bot argument passed by the loop task (previously broken — called with args but declared with none)
- Cleans up now-unnecessary `type: ignore` comments in `loops.py`

## Related issue
Closes #1261

## Test plan
1. Verify `tmp.py` is gone from the repo and `.gitignore` prevents re-commit
2. Verify level-up notifications still work (smoke test)
3. Verify the set doesn't grow beyond 10,000 entries under load
4. Verify the `clearNotifiedUsers` loop no longer triggers mypy errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated .gitignore to exclude temporary debug files.
  * Removed temporary development utility.

* **Refactor**
  * Optimized in-memory notification tracking with a bounded limit to improve stability.
  * Streamlined background task behavior for clearer execution.
  * Cleaned up type annotations for better reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->