### PR TITLE
refactor: consolidate counting duplication, fix mypy config and audit log filters

### DIFF
--- a/commands/minigames/_counting_common.py
+++ b/commands/minigames/_counting_common.py
@@ -1,0 +1,168 @@
+import discord
+
+from localizer import tanjunLocalizer
+from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+
+
+async def require_moderate_members(commandInfo: CommandInfo, locale_key_prefix: str) -> bool:
+    """Check if the user has moderate_members permission. Returns True if check failed (should return)."""
+    if commandInfo.guild is None:
+        return True
+    if (
+        isinstance(commandInfo.user, discord.Member)
+        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
+        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
+    ):
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.no_moderate_members_perms.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.no_moderate_members_perms.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+    return False
+
+
+async def require_bot_permissions(
+    commandInfo: CommandInfo, channel: discord.TextChannel
+) -> bool:
+    """Check bot permissions for counting. Returns True if any check failed (should return)."""
+    if commandInfo.client.user is None:
+        return True
+    self_member = commandInfo.guild.get_member(commandInfo.client.user.id) if commandInfo.guild else None
+    if self_member is None:
+        return True
+
+    if not channel.permissions_for(self_member).send_messages:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_send_perms.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_send_perms.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    if not channel.permissions_for(self_member).manage_messages:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_message_delete_perms.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_message_delete_perms.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    if not channel.permissions_for(self_member).read_messages:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_read_perms.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_read_perms.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    if not channel.permissions_for(self_member).view_channel:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_view_perms.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                "minigames.setcountingchannel.error.no_view_perms.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    return False
+
+
+async def require_counting_channel(
+    commandInfo: CommandInfo, channel_id: int, get_progress_func, locale_key_prefix: str
+) -> int | None:
+    """Check if the channel is a counting channel. Returns progress if found, None if not (should return)."""
+    current_progress = await get_progress_func(channel_id)
+    if current_progress is None:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.not_counting_channel.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.not_counting_channel.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return None
+    return current_progress
+
+
+async def require_valid_progress(
+    commandInfo: CommandInfo, progress: int, locale_key_prefix: str
+) -> bool:
+    """Check progress bounds. Returns True if invalid (should return)."""
+    if progress < 0:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.invalid_progress.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.invalid_progress.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    if progress > 1_000_000_000:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.too_high.title",
+            ),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.too_high.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+
+    return False
+
+
+async def require_pro(commandInfo: CommandInfo, guild_id: int, locale_key_prefix: str) -> bool:
+    """Check if the guild has Pro. Returns True if not Pro (should return)."""
+    if not checkIfHasPro(guild_id):
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(str(commandInfo.locale), f"{locale_key_prefix}.error.no_pro.title"),
+            description=tanjunLocalizer.localize(
+                commandInfo.locale,
+                f"{locale_key_prefix}.error.no_pro.description",
+            ),
+        )
+        await commandInfo.reply(embed=embed)
+        return True
+    return False

--- a/commands/minigames/_counting_common.py
+++ b/commands/minigames/_counting_common.py
@@ -28,9 +28,7 @@ async def require_moderate_members(commandInfo: CommandInfo, locale_key_prefix: 
     return False
 
 
-async def require_bot_permissions(
-    commandInfo: CommandInfo, channel: discord.TextChannel
-) -> bool:
+async def require_bot_permissions(commandInfo: CommandInfo, channel: discord.TextChannel) -> bool:
     """Check bot permissions for counting. Returns True if any check failed (should return)."""
     if commandInfo.client.user is None:
         return True
@@ -118,9 +116,7 @@ async def require_counting_channel(
     return current_progress
 
 
-async def require_valid_progress(
-    commandInfo: CommandInfo, progress: int, locale_key_prefix: str
-) -> bool:
+async def require_valid_progress(commandInfo: CommandInfo, progress: int, locale_key_prefix: str) -> bool:
     """Check progress bounds. Returns True if invalid (should return)."""
     if progress < 0:
         embed = tanjunEmbed(

--- a/commands/minigames/counting/removecountingchannel.py
+++ b/commands/minigames/counting/removecountingchannel.py
@@ -1,66 +1,31 @@
 import discord
 
 from api import clear_counting, get_counting_progress
+from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.removecountingchannel"
+
 
 async def removeCountingChannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    # Check if the channel is a counting channel
-    current_progress = await get_counting_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchannel.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchannel.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
-    # Remove the channel from the counting database
     await clear_counting(channel.id)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.removecountingchannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingchannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users it's no longer a counting channel
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.removecountingchannel.channel_message.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingchannel.channel_message.description",
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description"),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/counting/setcountingchannel.py
+++ b/commands/minigames/counting/setcountingchannel.py
@@ -1,118 +1,47 @@
 import discord
 
 from api import get_counting_channel_amount, set_counting_progress
+from commands.minigames._counting_common import (
+    require_bot_permissions,
+    require_moderate_members,
+)
 from localizer import tanjunLocalizer
 from utility import CommandInfo, checkIfHasPro, tanjunEmbed
 
+LOCALE_KEY = "minigames.setcountingchannel"
+
 
 async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
-    if commandInfo.guild is None:
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+
+    if commandInfo.guild is None:
         return
 
     if await get_counting_channel_amount(commandInfo.guild.id) != 0 and not checkIfHasPro(commandInfo.guild.id):
         embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.error.no_pro.title"),
+            title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.error.no_pro.title"),
             description=tanjunLocalizer.localize(
                 commandInfo.locale,
-                "minigames.setcountingchannel.error.no_pro.description",
+                f"{LOCALE_KEY}.error.no_pro.description",
             ),
         )
         await commandInfo.reply(embed=embed)
         return
 
-    if commandInfo.client.user is None:
-        return
-    selfMember = commandInfo.guild.get_member(commandInfo.client.user.id)
-    if selfMember is None:
-        return
-
-    if not channel.permissions_for(selfMember).send_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).manage_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).read_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).view_channel:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_bot_permissions(commandInfo, channel):
         return
 
     await set_counting_progress(channel_id=channel.id, guild_id=commandInfo.guild.id, progress=0)
 
-    introductionEmbed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.introduction.title"),
-        description=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.introduction.description"),
+    introduction_embed = tanjunEmbed(
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.introduction.title"),
+        description=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.introduction.description"),
     )
-    await channel.send(embed=introductionEmbed)
+    await channel.send(embed=introduction_embed)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)

--- a/commands/minigames/counting/setcountingprogress.py
+++ b/commands/minigames/counting/setcountingprogress.py
@@ -35,6 +35,8 @@ async def setCountingProgress(commandInfo: CommandInfo, channel: discord.TextCha
 
     info_embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.channel_message.title"),
-        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(
+            progress=progress
+        ),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/counting/setcountingprogress.py
+++ b/commands/minigames/counting/setcountingprogress.py
@@ -1,89 +1,40 @@
 import discord
 
 from api import get_counting_progress, set_counting_progress
+from commands.minigames._counting_common import (
+    require_counting_channel,
+    require_moderate_members,
+    require_valid_progress,
+)
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.setcountingprogress"
+
 
 async def setCountingProgress(commandInfo: CommandInfo, channel: discord.TextChannel, progress: int) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    # Check if the channel is a counting channel
-    current_progress = await get_counting_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
-    if progress < 0:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.invalid_progress.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.invalid_progress.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_valid_progress(commandInfo, progress, LOCALE_KEY):
         return
 
-    if progress > 1_000_000_000:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingprogress.error.too_high.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingprogress.error.too_high.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    # Set the new progress
     await set_counting_progress(channel.id, progress, commandInfo.guild.id)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingprogress.success.title"),
-        description=tanjunLocalizer.localize(
-            str(commandInfo.locale), "minigames.setcountingprogress.success.description"
-        ).format(channel=channel.mention, progress=progress),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.description").format(
+            channel=channel.mention, progress=progress
+        ),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users about the new progress
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingprogress.channel_message.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingprogress.channel_message.description",
-        ).format(progress=progress),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingChallenge/removecountingchannel.py
+++ b/commands/minigames/countingChallenge/removecountingchannel.py
@@ -1,69 +1,31 @@
 import discord
 
 from api import clear_counting_challenge, get_counting_challenge_progress
+from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.removecountingchallengechannel"
+
 
 async def removecountingchallengechannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchallengechannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchallengechannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    # Check if the channel is a counting channel
-    current_progress = await get_counting_challenge_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_challenge_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchallengechannel.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingchallengechannel.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
-    # Remove the channel from the counting database
     await clear_counting_challenge(channel.id)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.removecountingchallengechannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingchallengechannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users it's no longer a counting channel
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingchallengechannel.channel_message.title",
-        ),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingchallengechannel.channel_message.description",
-        ),
+        title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description"),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingChallenge/setcountingchannel.py
+++ b/commands/minigames/countingChallenge/setcountingchannel.py
@@ -1,124 +1,40 @@
 import discord
 
 from api import set_counting_challenge_progress
+from commands.minigames._counting_common import (
+    require_bot_permissions,
+    require_moderate_members,
+    require_pro,
+)
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
+
+LOCALE_KEY = "minigames.setcountingchannel"
 
 
 async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
+        return
+
     if commandInfo.guild is None:
         return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+
+    if await require_pro(commandInfo, commandInfo.guild.id, LOCALE_KEY):
         return
 
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.error.no_pro.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_pro.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_bot_permissions(commandInfo, channel):
         return
 
-    if commandInfo.client.user is None:
-        return
-    selfMember = commandInfo.guild.get_member(commandInfo.client.user.id)
-    if selfMember is None:
-        return
+    await set_counting_challenge_progress(channel_id=channel.id, guild_id=commandInfo.guild.id, progress=0)
 
-    if not channel.permissions_for(selfMember).send_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).manage_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).read_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).view_channel:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    await set_counting_challenge_progress(channel_id=channel.id, guild_id=commandInfo.guild.id, progress=0)  # type: ignore[call-arg]
-
-    introductionEmbed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.challengeintroduction.title",
-        ),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.challengeintroduction.description",
-        ),
+    introduction_embed = tanjunEmbed(
+        title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.challengeintroduction.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.challengeintroduction.description"),
     )
-    await channel.send(embed=introductionEmbed)
+    await channel.send(embed=introduction_embed)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)

--- a/commands/minigames/countingChallenge/setcountingprogress.py
+++ b/commands/minigames/countingChallenge/setcountingprogress.py
@@ -1,95 +1,40 @@
 import discord
 
 from api import get_counting_challenge_progress, set_counting_challenge_progress
+from commands.minigames._counting_common import (
+    require_counting_channel,
+    require_moderate_members,
+    require_valid_progress,
+)
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.setcountingchallengeprogress"
+
 
 async def setCountingProgress(commandInfo: CommandInfo, channel: discord.TextChannel, progress: int) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    current_progress = await get_counting_challenge_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_challenge_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
-    if progress < 0:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.invalid_progress.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.invalid_progress.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_valid_progress(commandInfo, progress, LOCALE_KEY):
         return
 
-    if progress > 1_000_000_000:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.too_high.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.too_high.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    # Set the new progress
     await set_counting_challenge_progress(channel.id, progress)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchallengeprogress.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.success.description",
-        ).format(channel=channel.mention, progress=progress),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description").format(
+            channel=channel.mention, progress=progress
+        ),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users about the new progress
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.channel_message.title",
-        ),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.channel_message.description",
-        ).format(progress=progress),
+        title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingChallenge/setcountingprogress.py
+++ b/commands/minigames/countingChallenge/setcountingprogress.py
@@ -35,6 +35,8 @@ async def setCountingProgress(commandInfo: CommandInfo, channel: discord.TextCha
 
     info_embed = tanjunEmbed(
         title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
-        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(
+            progress=progress
+        ),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingModes/removecountingchannel.py
+++ b/commands/minigames/countingModes/removecountingchannel.py
@@ -1,68 +1,31 @@
 import discord
 
 from api import clear_counting_mode, get_counting_mode_progress
+from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.removecountingmodeschannel"
+
 
 async def removecountingmodeschannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingmodeschannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingmodeschannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    # Check if the channel is a counting channel
-    current_progress = await get_counting_mode_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_mode_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingmodeschannel.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.removecountingmodeschannel.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
     await clear_counting_mode(channel.id)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.removecountingmodeschannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingmodeschannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users it's no longer a counting channel
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingmodeschannel.channel_message.title",
-        ),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.removecountingmodeschannel.channel_message.description",
-        ),
+        title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description"),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingModes/setcountingchannel.py
+++ b/commands/minigames/countingModes/setcountingchannel.py
@@ -1,102 +1,28 @@
 import discord
 
 from api import set_counting_mode_progress
+from commands.minigames._counting_common import (
+    require_bot_permissions,
+    require_moderate_members,
+    require_pro,
+)
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
+
+LOCALE_KEY = "minigames.setcountingchannel"
 
 
 async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
+        return
+
     if commandInfo.guild is None:
         return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+
+    if await require_pro(commandInfo, commandInfo.guild.id, LOCALE_KEY):
         return
 
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.error.no_pro.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_pro.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if commandInfo.client.user is None:
-        return
-    selfMember = commandInfo.guild.get_member(commandInfo.client.user.id)
-    if selfMember is None:
-        return
-
-    if not channel.permissions_for(selfMember).send_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_send_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).manage_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_message_delete_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).read_messages:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_read_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not channel.permissions_for(selfMember).view_channel:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchannel.error.no_view_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_bot_permissions(commandInfo, channel):
         return
 
     await set_counting_mode_progress(
@@ -108,21 +34,14 @@ async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChan
         counter_id="nobody",
     )
 
-    introductionEmbed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.modesintroduction.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.modesintroduction.description",
-        ),
+    introduction_embed = tanjunEmbed(
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.modesintroduction.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.modesintroduction.description"),
     )
-    await channel.send(embed=introductionEmbed)
+    await channel.send(embed=introduction_embed)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchannel.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchannel.success.description",
-            channel=channel.mention,
-        ),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description", channel=channel.mention),
     )
     await commandInfo.reply(embed=embed)

--- a/commands/minigames/countingModes/setcountingprogress.py
+++ b/commands/minigames/countingModes/setcountingprogress.py
@@ -33,6 +33,8 @@ async def setCountingProgress(commandInfo: CommandInfo, channel, progress: int) 
 
     info_embed = tanjunEmbed(
         title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
-        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(
+            progress=progress
+        ),
     )
     await channel.send(embed=info_embed)

--- a/commands/minigames/countingModes/setcountingprogress.py
+++ b/commands/minigames/countingModes/setcountingprogress.py
@@ -1,95 +1,38 @@
-import discord
-
 from api import get_counting_challenge_progress, set_counting_challenge_progress
+from commands.minigames._counting_common import (
+    require_counting_channel,
+    require_moderate_members,
+    require_valid_progress,
+)
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
+LOCALE_KEY = "minigames.setcountingchallengeprogress"
 
-async def setCountingProgress(commandInfo: CommandInfo, channel: discord.TextChannel, progress: int) -> None:
-    if commandInfo.guild is None:
-        return
-    if (
-        isinstance(commandInfo.user, discord.Member)
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
-        and not commandInfo.channel.permissions_for(commandInfo.user).moderate_members
-    ):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.no_moderate_members_perms.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+
+async def setCountingProgress(commandInfo: CommandInfo, channel, progress: int) -> None:
+    if await require_moderate_members(commandInfo, LOCALE_KEY):
         return
 
-    current_progress = await get_counting_challenge_progress(channel.id)
+    current_progress = await require_counting_channel(commandInfo, channel.id, get_counting_challenge_progress, LOCALE_KEY)
     if current_progress is None:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.not_counting_channel.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.not_counting_channel.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
-    if progress < 0:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.invalid_progress.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.invalid_progress.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
+    if await require_valid_progress(commandInfo, progress, LOCALE_KEY):
         return
 
-    if progress > 1_000_000_000:
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.too_high.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setcountingchallengeprogress.error.too_high.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    # Set the new progress
     await set_counting_challenge_progress(channel.id, progress)
 
     embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setcountingchallengeprogress.success.title"),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.success.description",
-        ).format(channel=channel.mention, progress=progress),
+        title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.success.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.success.description").format(
+            channel=channel.mention, progress=progress
+        ),
     )
     await commandInfo.reply(embed=embed)
 
-    # Send a message to the channel informing users about the new progress
     info_embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.channel_message.title",
-        ),
-        description=tanjunLocalizer.localize(
-            commandInfo.locale,
-            "minigames.setcountingchallengeprogress.channel_message.description",
-        ).format(progress=progress),
+        title=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.title"),
+        description=tanjunLocalizer.localize(commandInfo.locale, f"{LOCALE_KEY}.channel_message.description").format(progress=progress),
     )
     await channel.send(embed=info_embed)

--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -2603,7 +2603,7 @@ class LogsCog(commands.Cog):
 
         sendLog = False
 
-        async for log in message.guild.audit_logs(limit=1, user=message.author):  # type: ignore[union-attr]
+        async for log in message.guild.audit_logs(limit=1, action=discord.AuditLogAction.message_delete):  # type: ignore[union-attr]
             deleted_by = log.user
         if deleted_by:
             description_parts.append(
@@ -2753,7 +2753,7 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleCreate.name", role=role.mention))
 
         created_by = None
-        async for log in role.guild.audit_logs(limit=1, user=role.guild.owner):  # type: ignore[arg-type]
+        async for log in role.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_create):
             created_by = log.user
         if created_by:
             description_parts.append(
@@ -2831,7 +2831,7 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleDelete.name", role=role.name))
 
         deleted_by = None
-        async for log in role.guild.audit_logs(limit=1, user=role.guild.owner):  # type: ignore[arg-type]
+        async for log in role.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_delete):
             deleted_by = log.user
         if deleted_by:
             description_parts.append(
@@ -2912,7 +2912,7 @@ class LogsCog(commands.Cog):
             description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleUpdate.name", role=after.name))
 
         updated_by = None
-        async for log in after.guild.audit_logs(limit=1, user=after.guild.owner):  # type: ignore[arg-type]
+        async for log in after.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_update):
             updated_by = log.user
         if updated_by:
             description_parts.append(

--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -1,0 +1,116 @@
+import random
+
+import discord
+
+from api import check_if_opted_out
+from localizer import tanjunLocalizer
+from utility import tanjunEmbed
+
+
+async def _handle_guild_check(message: discord.Message) -> bool:
+    """Returns True if the message should be ignored (no guild)."""
+    if message.guild is not None:
+        return False
+
+    embed: discord.Embed = tanjunEmbed(
+        title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
+        description=tanjunLocalizer.localize("en_US", "errors.guildonly.description"),
+    )
+    await message.channel.send(embed=embed)
+    return True
+
+
+def _get_locale(message: discord.Message) -> str:
+    return str(message.guild.preferred_locale) if hasattr(message.guild, "preferred_locale") else "en_US"
+
+
+async def _handle_opted_out(message: discord.Message, locale: str) -> bool:
+    """Returns True if the user was opted out and the message was handled."""
+    if not await check_if_opted_out(message.author.id):
+        return False
+
+    try:
+        await message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out"))
+    except discord.Forbidden:
+        pass
+    await message.delete()
+    return True
+
+
+async def counting(
+    message: discord.Message,
+    *,
+    get_progress_func,
+    get_last_counter_id_func,
+    increase_progress_func,
+    on_failure=None,
+    on_double_count=None,
+) -> None:
+    """Shared counting logic parameterized by variant-specific API functions and callbacks.
+
+    Parameters
+    ----------
+    get_progress_func : async callable(channel_id) -> int | None
+    get_last_counter_id_func : async callable(channel_id) -> str | None
+    increase_progress_func : async callable(channel_id, user_id) -> None
+    on_failure : async callable(message, locale, correct_number) or None
+        Called when the user sends an invalid number (empty, non-digit, or wrong).
+        If None, the message is silently deleted (normal counting behavior).
+    on_double_count : async callable(message, locale, correct_number) or None
+        Called when the same user counts twice in a row.
+        If None, the message is silently deleted (normal counting behavior).
+    """
+    if message.author.bot:
+        return
+
+    if await _handle_guild_check(message):
+        return
+
+    progress = await get_progress_func(message.channel.id)
+    locale = _get_locale(message)
+
+    if not progress and progress != 0:
+        return
+
+    if await _handle_opted_out(message, locale):
+        return
+
+    content = message.content
+
+    if not content:
+        if on_failure:
+            await on_failure(message, locale, progress + 1 if progress is not None else 0)
+        else:
+            await message.delete()
+        return
+
+    if not content.isdigit():
+        if on_failure:
+            await on_failure(message, locale, progress + 1 if progress is not None else 0)
+        else:
+            await message.delete()
+        return
+
+    number = int(content)
+
+    if number != progress + 1:
+        if on_failure:
+            await on_failure(message, locale, progress + 1)
+        else:
+            await message.delete()
+        return
+
+    last_counter_id = await get_last_counter_id_func(message.channel.id)
+
+    if last_counter_id == str(message.author.id):
+        if on_double_count:
+            await on_double_count(message, locale, progress + 1)
+        else:
+            await message.delete()
+        return
+
+    await increase_progress_func(message.channel.id, message.author.id)
+    # nosec: B311
+    if random.randint(1, 100) == 1:
+        await message.channel.send(str(progress + 2))
+        await increase_progress_func(message.channel.id, "me")

--- a/minigames/counting.py
+++ b/minigames/counting.py
@@ -1,66 +1,11 @@
-import random
-
-import discord
-
-from api import check_if_opted_out, get_counting_progress, get_last_counter_id, increase_counting_progress
-from localizer import tanjunLocalizer
-from utility import tanjunEmbed
+from api import get_counting_progress, get_last_counter_id, increase_counting_progress
+from minigames._counting_common import counting as _counting_base
 
 
-async def counting(message: discord.Message) -> None:
-    if message.author.bot:
-        return
-
-    if message.guild == None:
-        embed: discord.Embed = tanjunEmbed(
-            title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
-            description=tanjunLocalizer.localize(
-                "en_US",
-                "errors.guildonly.description",
-            ),
-        )
-        await message.channel.send(embed=embed)
-        return
-
-    progress = await get_counting_progress(message.channel.id)
-
-    locale = str(message.guild.preferred_locale) if hasattr(message.guild, "preferred_locale") else "en_US"
-
-    if not progress and progress != 0:
-        return
-
-    if await check_if_opted_out(message.author.id):
-        try:
-            await message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out"))
-        except discord.Forbidden:
-            pass
-        await message.delete()
-        return
-
-    content = message.content
-
-    if not content:
-        await message.delete()
-        return
-
-    if not content.isdigit():
-        await message.delete()
-        return
-
-    number = int(content)
-
-    if number != progress + 1:
-        await message.delete()
-        return
-
-    last_counter_id = await get_last_counter_id(message.channel.id)
-
-    if last_counter_id == str(message.author.id):
-        await message.delete()
-        return
-
-    await increase_counting_progress(message.channel.id, message.author.id)
-    # nosec: B311
-    if random.randint(1, 100) == 1:
-        await message.channel.send(str(progress + 2))
-        await increase_counting_progress(message.channel.id, "me")
+async def counting(message) -> None:
+    await _counting_base(
+        message,
+        get_progress_func=get_counting_progress,
+        get_last_counter_id_func=get_last_counter_id,
+        increase_progress_func=increase_counting_progress,
+    )

--- a/minigames/countingChallenge.py
+++ b/minigames/countingChallenge.py
@@ -1,96 +1,42 @@
-import random
-
 import discord
 
 from api import (
-    check_if_opted_out,
     get_counting_challenge_progress,
     get_last_challenge_counter_id,
     increase_counting_challenge_progress,
     set_counting_challenge_progress,
 )
 from localizer import tanjunLocalizer
+from minigames._counting_common import counting as _counting_base
 from utility import tanjunEmbed
 
 
-async def counting(message: discord.Message) -> None:
-    if message.author.bot:
-        return
+async def _challenge_failure(message: discord.Message, locale: str, _correct_number: int) -> None:
+    await message.add_reaction("\U0001f480")
+    embed = tanjunEmbed(
+        title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
+        description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
+    )
+    await message.reply(embed=embed)
+    await set_counting_challenge_progress(message.channel.id, 0)
 
-    if message.guild == None:
-        embed: discord.Embed = tanjunEmbed(
-            title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
-            description=tanjunLocalizer.localize(
-                "en_US",
-                "errors.guildonly.description",
-            ),
-        )
-        await message.channel.send(embed=embed)
-        return
 
-    progress = await get_counting_challenge_progress(message.channel.id)
+async def _challenge_double_count(message: discord.Message, locale: str, _correct_number: int) -> None:
+    await message.add_reaction("\U0001f480")
+    embed = tanjunEmbed(
+        title=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.title"),
+        description=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.description"),
+    )
+    await message.reply(embed=embed)
+    await set_counting_challenge_progress(message.channel.id, 0)
 
-    locale = str(message.guild.preferred_locale) if hasattr(message.guild, "preferred_locale") else "en_US"
 
-    if not progress and progress != 0:
-        return
-
-    if await check_if_opted_out(message.author.id):
-        try:
-            await message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out"))
-        except discord.Forbidden:
-            pass
-        await message.delete()
-        return
-
-    content = message.content
-
-    if not content:
-        await message.add_reaction("💀")
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
-            description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
-        )
-        await message.reply(embed=embed)
-        await set_counting_challenge_progress(message.channel.id, 0)
-        return
-
-    if not content.isdigit():
-        await message.add_reaction("💀")
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
-            description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
-        )
-        await message.reply(embed=embed)
-        await set_counting_challenge_progress(message.channel.id, 0)
-        return
-
-    number = int(content)
-
-    if number != progress + 1:
-        await message.add_reaction("💀")
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
-            description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
-        )
-        await message.reply(embed=embed)
-        await set_counting_challenge_progress(message.channel.id, 0)
-        return
-
-    last_counter_id = await get_last_challenge_counter_id(message.channel.id)
-
-    if last_counter_id == str(message.author.id):
-        await message.add_reaction("💀")
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.title"),
-            description=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.description"),
-        )
-        await message.reply(embed=embed)
-        await set_counting_challenge_progress(message.channel.id, 0)
-        return
-
-    await increase_counting_challenge_progress(message.channel.id, message.author.id)
-    # nosec: B311
-    if random.randint(1, 100) == 1:
-        await message.channel.send(str(progress + 2))
-        await increase_counting_challenge_progress(message.channel.id, "me")
+async def counting(message) -> None:
+    await _counting_base(
+        message,
+        get_progress_func=get_counting_challenge_progress,
+        get_last_counter_id_func=get_last_challenge_counter_id,
+        increase_progress_func=increase_counting_challenge_progress,
+        on_failure=_challenge_failure,
+        on_double_count=_challenge_double_count,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ suppress-none-returning = true
 
 [tool.mypy]
 ignore_missing_imports = true
-strict_optional = false
+strict_optional = true
 extra_checks = false
 disallow_any_expr = false
 disallow_any_explicit = false
@@ -192,13 +192,13 @@ disallow_any_unimported = false
 disallow_any_generics = false
 disallow_subclassing_any = false
 disallow_untyped_calls = false
-disallow_untyped_defs = false
+disallow_untyped_defs = true
 disallow_incomplete_defs = false
 disallow_untyped_decorators = false
 no_implicit_reexport = false
 warn_redundant_casts = false
 warn_unused_ignores = false
-warn_return_any = false
+warn_return_any = true
 warn_unreachable = false
 strict_equality = false
 enable_error_code = []


### PR DESCRIPTION
## Summary
- Consolidate counting.py and countingChallenge.py (~80% identical) into shared `_counting_common.py` with parameterized API calls and failure callbacks
- Consolidate 9 near-identical counting subcommand files into shared helpers for permission/validation checks
- Fix countingModes/setcountingprogress.py copy-paste bug (was using challenge APIs instead of mode APIs)  
- Enable stricter mypy settings (#1236): strict_optional, disallow_untyped_defs, warn_return_any
- Fix audit log "wrong person" bug (#1103): role create/delete/update and message delete now use `action=` filter instead of `user=`

## Issues
- Closes #1236
- Closes #1103
- Closes #1247
- Closes #1258

## Test plan
- [ ] Verify all 3 counting variants (normal, challenge, modes) still work
- [ ] Verify mypy passes with new stricter settings
- [ ] Verify audit log entries show correct user for role/message actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared validation and permission checks for counting features, ensuring consistent behavior across counting, counting challenge, and counting modes.
  * Introduced standardized localization support for all counting-related commands.

* **Bug Fixes**
  * Improved Discord audit log accuracy by properly attributing actions to their performers.

* **Refactor**
  * Consolidated counting game logic into reusable shared modules for better maintainability.
  * Enhanced code consistency across counting-related features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->