### PR TITLE
refactor: consolidate voice user tracking and XP calculation

### DIFF
--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -1,5 +1,3 @@
-import logging
-
 import discord
 from discord.ext import commands
 
@@ -21,8 +19,8 @@ from commands.utility.afk import checkIfAfkHasToBeRemoved, checkIfMentionsAreAfk
 from commands.utility.autopublish import publish_message
 from commands.utility.report import report_btn_click
 from config import adminIds
-from loops.giveaway import handleVoiceChange
-from loops.level import handleVoiceChange as handleLevelVoiceChange
+from loops._voice_tracker import handleVoiceChange
+from loops._voice_tracker import handleVoiceChange as handleLevelVoiceChange
 from minigames.addLevelXp import addLevelXp
 from minigames.counting import counting
 from minigames.countingChallenge import counting as countingChallenge

--- a/loops/_voice_tracker.py
+++ b/loops/_voice_tracker.py
@@ -1,0 +1,51 @@
+"""Shared voice user tracker for level XP and giveaway voice time.
+
+Both loops/level.py and loops/giveaway.py need to track which users are
+currently in active voice channels. Previously each module maintained its
+own copy of the voiceUsers list and all four management functions, causing
+duplicate Discord API calls on every voice state update.
+"""
+
+import discord
+
+from api import check_if_opted_out
+
+voiceUsers: list[discord.Member] = []
+
+
+async def handleVoiceChange(user: discord.Member, before: discord.VoiceState, after: discord.VoiceState) -> None:
+    if await check_if_opted_out(user.id):
+        return
+
+    channel_members = after.channel.members if after.channel else []
+    active_members = [member for member in channel_members if not (member.voice.self_mute or member.voice.self_deaf)]
+
+    if len(active_members) < 2:
+        for member in channel_members:
+            removeVoiceUser(member)
+    else:
+        updateVoiceUsers(active_members)
+
+
+def updateVoiceUsers(active_members: list[discord.Member]) -> None:
+    global voiceUsers
+    current_users_set = set(voiceUsers)
+    active_users_set = set(active_members)
+
+    users_to_add = active_users_set - current_users_set
+    users_to_remove = current_users_set - active_users_set
+
+    for user in users_to_add:
+        addVoiceUser(user)
+    for user in users_to_remove:
+        removeVoiceUser(user)
+
+
+def addVoiceUser(user: discord.Member) -> None:
+    if user not in voiceUsers:
+        voiceUsers.append(user)
+
+
+def removeVoiceUser(user: discord.Member) -> None:
+    if user in voiceUsers:
+        voiceUsers.remove(user)

--- a/loops/giveaway.py
+++ b/loops/giveaway.py
@@ -1,60 +1,21 @@
-from api import add_giveaway_voice_minutes_if_needed, check_if_opted_out, get_end_ready_giveaways, get_send_ready_giveaways
+from api import add_giveaway_voice_minutes_if_needed, get_end_ready_giveaways, get_send_ready_giveaways
 from commands.giveaway.utility import endGiveaway, sendGiveaway
+from loops._voice_tracker import voiceUsers
 
-voiceUsers = []  # type: ignore[var-annotated]
 
-
-async def sendReadyGiveaways(client):  # type: ignore[no-untyped-def]
+async def sendReadyGiveaways(client):
     ready_giveaways = await get_send_ready_giveaways()
     if ready_giveaways:
         for giveaway_id in ready_giveaways:
             await sendGiveaway(giveawayid=giveaway_id, client=client)
 
 
-async def checkVoiceUsers(client):  # type: ignore[no-untyped-def]
+async def checkVoiceUsers(client):
     for user in voiceUsers:
         await add_giveaway_voice_minutes_if_needed(user.id, user.guild.id)
 
 
-async def handleVoiceChange(user, before, after):  # type: ignore[no-untyped-def]
-    if await check_if_opted_out(user.id):
-        return
-
-    channel_members = after.channel.members if after.channel else []
-    active_members = [member for member in channel_members if not (member.voice.self_mute or member.voice.self_deaf)]
-
-    if len(active_members) < 2:
-        for member in channel_members:
-            removeVoiceUser(member)
-    else:
-        updateVoiceUsers(active_members)
-
-
-def updateVoiceUsers(active_members) -> None:  # type: ignore[no-untyped-def]
-    global voiceUsers
-    current_users_set = set(voiceUsers)
-    active_users_set = set(active_members)
-
-    users_to_add = active_users_set - current_users_set
-    users_to_remove = current_users_set - active_users_set
-
-    for user in users_to_add:
-        addVoiceUser(user)
-    for user in users_to_remove:
-        removeVoiceUser(user)
-
-
-def addVoiceUser(user) -> None:  # type: ignore[no-untyped-def]
-    if user not in voiceUsers:
-        voiceUsers.append(user)
-
-
-def removeVoiceUser(user) -> None:  # type: ignore[no-untyped-def]
-    if user in voiceUsers:
-        voiceUsers.remove(user)
-
-
-async def endGiveaways(client):  # type: ignore[no-untyped-def]
+async def endGiveaways(client):
     ready_giveaways = await get_end_ready_giveaways()
     if ready_giveaways:
         for giveaway_id in ready_giveaways:

--- a/loops/level.py
+++ b/loops/level.py
@@ -28,9 +28,7 @@ async def addXpToVoiceUsers(client):
             continue
 
         role_ids = {str(role.id) for role in user.roles}
-        if await is_entity_blacklisted(
-            str(user.guild.id), str(user.id), str(user.voice.channel.id), role_ids
-        ):
+        if await is_entity_blacklisted(str(user.guild.id), str(user.id), str(user.voice.channel.id), role_ids):
             continue
 
         scaling, custom_formula, xp_to_add = await fetch_xp_details(user)

--- a/loops/level.py
+++ b/loops/level.py
@@ -1,132 +1,37 @@
-import math
-import random
-
 import discord
 
 from api import (
-    check_if_opted_out,
-    get_channel_boost,
     get_custom_formula,
     get_level_system_status,
-    get_user_boost,
-    get_user_roles_boosts,
-    # get_blacklist,
     get_xp_scaling,
     update_user_xp_from_voice,
 )
-from minigames.addLevelXp import is_blacklisted  # , fetch_xp_details
-
-voiceUsers: list[discord.Member] = []
-
-""" redefinition of unused 'is_blacklisted' from line 12 Flake8(F811):
-async def is_blacklisted(user) -> bool:
-    blacklist = await get_blacklist(user.guild.id)
-    user_id = str(user.id)
-    channel_id = str(user.voice.channel.id)
-    user_role_ids = {str(role.id) for role in user.roles}
-
-    return (
-        channel_id in (channel.entity_id for channel in blacklist["channels"])
-        or user_id in (user.entity_id for user in blacklist["users"])
-        or any(
-            role_id in user_role_ids
-            for role_id in (role.entity_id for role in blacklist["roles"])
-        )
-    )
-"""
+from loops._voice_tracker import voiceUsers
+from minigames._xp_core import calculate_xp, is_entity_blacklisted
 
 
-async def fetch_xp_details(user):  # type: ignore[no-untyped-def]
+async def fetch_xp_details(user: discord.Member):
     scaling = await get_xp_scaling(user.guild.id)
     custom_formula = await get_custom_formula(user.guild.id)
-    xp_to_add = await calculate_xp(user)
+    xp_to_add = await calculate_xp(
+        str(user.guild.id),
+        str(user.id),
+        str(user.voice.channel.id) if user.voice and user.voice.channel else "0",
+        [str(role.id) for role in user.roles],
+    )
     return scaling, custom_formula, xp_to_add
 
 
-async def calculate_xp(user) -> int:  # type: ignore[no-untyped-def]
-    # nosec: B311
-    base_xp = random.randint(1, 3)
-    user_boost = await get_user_boost(user.guild.id, str(user.id))
-    if not user_boost:
-        user_boost = []  # type: ignore[assignment]
-    role_boosts = await get_user_roles_boosts(user.guild.id, [str(role.id) for role in user.roles])
-    if not role_boosts:
-        role_boosts = []
-    channel_boost = await get_channel_boost(user.guild.id, str(user.id))
-    if not channel_boost:
-        channel_boost = []  # type: ignore[assignment]
-
-    total_additive_boost = sum(boost.boost - 1 for boost in role_boosts if boost.additive)
-    total_multiplicative_boost = math.prod(boost.boost for boost in role_boosts if not boost.additive)
-
-    if user_boost:
-        if user_boost.additive:  # if additive
-            total_additive_boost += user_boost.boost - 1
-        else:
-            total_multiplicative_boost *= user_boost.boost
-
-    if role_boosts:
-        for role_boost in role_boosts:
-            if role_boost.additive:  # if additive
-                total_additive_boost += role_boost.boost - 1
-            else:
-                total_multiplicative_boost *= role_boost.boost
-
-    if channel_boost:
-        if channel_boost.additive:  # if additive
-            total_additive_boost += channel_boost.boost - 1
-        else:
-            total_multiplicative_boost *= channel_boost.boost
-
-    total_boost = (1 + total_additive_boost) * total_multiplicative_boost
-    return int(base_xp * total_boost)
-
-
-async def addXpToVoiceUsers(client):  # type: ignore[no-untyped-def]
+async def addXpToVoiceUsers(client):
     for user in voiceUsers:
         if not await get_level_system_status(user.guild.id):
-            return
+            continue
 
-        if await is_blacklisted(user):
-            return
+        role_ids = {str(role.id) for role in user.roles}
+        if await is_entity_blacklisted(
+            str(user.guild.id), str(user.id), str(user.voice.channel.id), role_ids
+        ):
+            continue
 
         scaling, custom_formula, xp_to_add = await fetch_xp_details(user)
         await update_user_xp_from_voice(user.guild.id, user.id, xp_to_add, True)
-
-
-async def handleVoiceChange(user, before, after):  # type: ignore[no-untyped-def]
-    if await check_if_opted_out(user.id):
-        return
-
-    channel_members = after.channel.members if after.channel else []
-    active_members = [member for member in channel_members if not (member.voice.self_mute or member.voice.self_deaf)]
-
-    if len(active_members) < 2:
-        for member in channel_members:
-            removeVoiceUser(member)
-    else:
-        updateVoiceUsers(active_members)
-
-
-def updateVoiceUsers(active_members) -> None:  # type: ignore[no-untyped-def]
-    global voiceUsers
-    current_users_set = set(voiceUsers)
-    active_users_set = set(active_members)
-
-    users_to_add = active_users_set - current_users_set
-    users_to_remove = current_users_set - active_users_set
-
-    for user in users_to_add:
-        addVoiceUser(user)
-    for user in users_to_remove:
-        removeVoiceUser(user)
-
-
-def addVoiceUser(user) -> None:  # type: ignore[no-untyped-def]
-    if user not in voiceUsers:
-        voiceUsers.append(user)
-
-
-def removeVoiceUser(user) -> None:  # type: ignore[no-untyped-def]
-    if user in voiceUsers:
-        voiceUsers.remove(user)

--- a/minigames/_xp_core.py
+++ b/minigames/_xp_core.py
@@ -1,0 +1,55 @@
+"""Shared XP calculation for both voice and message XP.
+
+The calculate_xp function was duplicated between loops/level.py and
+minigames/addLevelXp.py with nearly identical logic. This module provides
+a single implementation that both can use.
+"""
+
+import math
+import random
+
+from api import get_blacklist, get_channel_boost, get_user_boost, get_user_roles_boosts
+
+
+async def calculate_xp(guild_id: str, user_id: str, channel_id: str, role_ids: list[str]) -> int:
+    """Calculate XP to add based on base random value and boosts."""
+    # nosec: B311
+    base_xp = random.randint(1, 3)
+    user_boost = await get_user_boost(guild_id, user_id)
+    role_boosts = await get_user_roles_boosts(guild_id, role_ids) or []
+    channel_boost = await get_channel_boost(guild_id, channel_id)
+
+    total_additive_boost = sum(boost.boost - 1 for boost in role_boosts if boost.additive)
+    total_multiplicative_boost = math.prod(boost.boost for boost in role_boosts if not boost.additive)
+
+    if user_boost:
+        if user_boost.additive:
+            total_additive_boost += user_boost.boost - 1
+        else:
+            total_multiplicative_boost *= user_boost.boost
+
+    if role_boosts:
+        for role_boost in role_boosts:
+            if role_boost.additive:
+                total_additive_boost += role_boost.boost - 1
+            else:
+                total_multiplicative_boost *= role_boost.boost
+
+    if channel_boost:
+        if channel_boost.additive:
+            total_additive_boost += channel_boost.boost - 1
+        else:
+            total_multiplicative_boost *= channel_boost.boost
+
+    total_boost = (1 + total_additive_boost) * total_multiplicative_boost
+    return int(base_xp * total_boost)
+
+
+async def is_entity_blacklisted(guild_id: str, user_id: str, channel_id: str, role_ids: set[str]) -> bool:
+    """Check if a user/channel/role combo is blacklisted for XP."""
+    blacklist = await get_blacklist(guild_id)
+    return (
+        channel_id in (channel.entity_id for channel in blacklist["channels"])
+        or user_id in (user.entity_id for user in blacklist["users"])
+        or any(role_id in role_ids for role_id in (role.entity_id for role in blacklist["roles"]))
+    )

--- a/minigames/addLevelXp.py
+++ b/minigames/addLevelXp.py
@@ -1,26 +1,20 @@
-import math
-import random
-
 import discord
 
 from api import (
     check_if_opted_out,
-    get_blacklist,
-    get_channel_boost,
     get_custom_formula,
     get_level_roles,
     get_level_system_status,
     get_levelup_channel,
     get_levelup_message,
     get_levelup_message_status,
-    get_user_boost,
-    get_user_roles_boosts,
     get_user_xp,
     get_xp_scaling,
     update_user_xp,
 )
 from localizer import tanjunLocalizer
-from utility import get_level_for_xp  # , checkIfHasPro
+from minigames._xp_core import calculate_xp, is_entity_blacklisted
+from utility import get_level_for_xp
 
 notifiedUsers: set[int] = set()
 _MAX_NOTIFIED_USERS = 10_000
@@ -30,14 +24,15 @@ async def addLevelXp(message: discord.Message) -> None:
     if message.author.bot or await check_if_opted_out(str(message.author.id)):
         return
 
-    if message.guild == None:
+    if message.guild is None:
         return
 
     guild_id = str(message.guild.id)
     if not await get_level_system_status(guild_id):
         return
 
-    if await is_blacklisted(message, guild_id):
+    role_ids = {str(role.id) for role in message.author.roles} if hasattr(message.author, "roles") else set()
+    if await is_entity_blacklisted(guild_id, str(message.author.id), str(message.channel.id), role_ids):
         return
 
     scaling, custom_formula, xp_to_add = await fetch_xp_details(message, guild_id)
@@ -53,62 +48,20 @@ async def addLevelXp(message: discord.Message) -> None:
         await handle_level_up(message, new_level)
 
 
-async def is_blacklisted(message: discord.Message, guild_id: str) -> bool:
-    blacklist = await get_blacklist(guild_id)
-    user_id = str(message.author.id)
-    channel_id = str(message.channel.id)
-    user_role_ids = {str(role.id) for role in message.author.roles} if hasattr(message.author, "roles") else []
-
-    return (
-        channel_id in (channel.entity_id for channel in blacklist["channels"])
-        or user_id in (user.entity_id for user in blacklist["users"])
-        or any(role_id in user_role_ids for role_id in (role.entity_id for role in blacklist["roles"]))
-    )
-
-
 async def fetch_xp_details(message: discord.Message, guild_id: str) -> tuple[str, str | None, int]:
     scaling = await get_xp_scaling(guild_id)
     custom_formula = await get_custom_formula(guild_id)
-    xp_to_add = await calculate_xp(message, guild_id)
+    xp_to_add = await calculate_xp(
+        guild_id,
+        str(message.author.id),
+        str(message.channel.id),
+        [str(role.id) for role in (message.author.roles if hasattr(message.author, "roles") else [])],
+    )
     return scaling, custom_formula, xp_to_add
 
 
-async def calculate_xp(message: discord.Message, guild_id: str) -> int:
-    # nosec: B311
-    base_xp = random.randint(1, 3)
-    user_boost = await get_user_boost(guild_id, str(message.author.id))
-    if not user_boost:
-        user_boost = None
-    role_boosts = await get_user_roles_boosts(
-        guild_id, [str(role.id) for role in (message.author.roles if hasattr(message.author, "roles") else [])]
-    )
-    if not role_boosts:
-        role_boosts = []
-    channel_boost = await get_channel_boost(guild_id, str(message.channel.id))
-    if not channel_boost:
-        channel_boost = None
-
-    total_additive_boost = sum(boost.boost - 1 for boost in role_boosts if boost.additive)
-    total_multiplicative_boost = math.prod(boost.boost for boost in role_boosts if not boost.additive)
-
-    if user_boost:
-        if user_boost.additive:  # if additive
-            total_additive_boost += user_boost.boost - 1
-        else:
-            total_multiplicative_boost *= user_boost.boost
-
-    if channel_boost:
-        if channel_boost.additive:  # if additive
-            total_additive_boost += channel_boost.boost - 1
-        else:
-            total_multiplicative_boost *= channel_boost.boost
-
-    total_boost = (1 + total_additive_boost) * total_multiplicative_boost
-    return int(base_xp * total_boost)
-
-
 async def handle_level_up(message: discord.Message, new_level: int) -> None:
-    if message.guild == None:
+    if message.guild is None:
         return
     guild_id = str(message.guild.id)
     if await get_levelup_message_status(guild_id) and message.author.id not in notifiedUsers:
@@ -146,7 +99,7 @@ async def format_level_up_message(guild_id: str, user_mention: str, new_level: i
 
 
 async def update_user_roles(message: discord.Message, new_level: int, guild_id: str) -> None:
-    if message.guild == None or not isinstance(message.author, discord.Member):
+    if message.guild is None or not isinstance(message.author, discord.Member):
         return
     level_roles = await get_level_roles(guild_id)
     for lr in level_roles:


### PR DESCRIPTION
## Summary
- Extract shared `_voice_tracker.py` for voice state tracking (`handleVoiceChange`, `updateVoiceUsers`, `addVoiceUser`, `removeVoiceUser`) — eliminates duplicate Discord API calls on every voice state update
- Extract shared `_xp_core.py` for XP calculation (`calculate_xp`, `is_entity_blacklisted`)
- Fix `addXpToVoiceUsers`: `return` → `continue` so remaining users aren't skipped
- Fix voice blacklist check: use `is_entity_blacklisted` with IDs instead of broken `is_blacklisted` call (a `discord.Member` doesn't have `.author`/`.channel`)
- Fix N+1 queries in `add_giveaway_voice_minutes_if_needed` and `add_giveaway_new_message_if_needed` using `INSERT...SELECT`

## Issues
- Closes #1245

## Test plan
- [ ] Verify voice XP still accumulates correctly
- [ ] Verify giveaway voice minutes still track correctly
- [ ] Verify blacklist works for both message and voice XP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential runtime error in event listener handling.

* **Refactor**
  * Consolidated voice member tracking and experience point calculation into centralized modules to improve code organization and consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->