### PR TITLE
fix: add null guard for voice.channel.id in blacklist check

### DIFF
--- a/loops/level.py
+++ b/loops/level.py
@@ -28,7 +28,12 @@ async def addXpToVoiceUsers(client):
             continue
 
         role_ids = {str(role.id) for role in user.roles}
-        if await is_entity_blacklisted(str(user.guild.id), str(user.id), str(user.voice.channel.id), role_ids):
+        if await is_entity_blacklisted(
+            str(user.guild.id),
+            str(user.id),
+            str(user.voice.channel.id) if user.voice and user.voice.channel else "0",
+            role_ids,
+        ):
             continue
 
         scaling, custom_formula, xp_to_add = await fetch_xp_details(user)


### PR DESCRIPTION
## Summary
- Add null guard for `user.voice.channel.id` in the `is_entity_blacklisted` call within `addXpToVoiceUsers`, matching the existing guard in `fetch_xp_details`
- Prevents `AttributeError` when a user in `voiceUsers` has disconnected before the blacklist check runs

## Test plan
- Verify XP loop continues without AttributeError when voice users disconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code organization for improved maintainability in the XP system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->