### PR TITLE
fix: add success_locale_key for edge_enhance and find_edges image filters

### DIFF
--- a/extensions/image.py
+++ b/extensions/image.py
@@ -92,7 +92,7 @@ class ImageCommands(discord.app_commands.Group):
     @app_commands.describe(image=app_commands.locale_str("image_edgeenhance_params_image_description"))
     async def edgeenhance(self, interaction: discord.Interaction, image: discord.Attachment) -> None:
         await interaction.response.defer()
-        await apply_filter(_make_command_info(interaction), image, "edge_enhance")
+        await apply_filter(_make_command_info(interaction), image, "edge_enhance", success_locale_key="image.edgeenhance")
 
     @app_commands.command(
         name=app_commands.locale_str("image_emboss_name"),
@@ -110,7 +110,7 @@ class ImageCommands(discord.app_commands.Group):
     @app_commands.describe(image=app_commands.locale_str("image_findedges_params_image_description"))
     async def findedges(self, interaction: discord.Interaction, image: discord.Attachment) -> None:
         await interaction.response.defer()
-        await apply_filter(_make_command_info(interaction), image, "find_edges")
+        await apply_filter(_make_command_info(interaction), image, "find_edges", success_locale_key="image.findedges")
 
     @app_commands.command(
         name=app_commands.locale_str("image_sharpen_name"),


### PR DESCRIPTION
## Summary
- Fix broken success embeds for `edge_enhance` and `find_edges` image filters
- The locale identifiers use `commands.image.edgeenhance` and `commands.image.findedges` (no underscores)
- But `apply_filter` defaulted to `commands.image.edge_enhance` and `commands.image.find_edges` (with underscores)
- Also fixed `boxblur` → `box_blur` in image.py (already resolved in development via #1277)

## Test plan
- Verify success embeds show correct localized messages for edge_enhance and find_edges filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localization support for success messages in image edge enhancement and edge finding filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->