### PR TITLE
Migrate AI integration from OpenAI to OpenRouter with deepseek-v4-flash:free as default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "new_tanjun",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ backcall==0.2.0
 beautifulsoup4==4.13.4
 bleach==6.2.0
 certifi==2025.4.26
-cffi==1.17.1
+cffi
 charset-normalizer==3.4.2
 colorama==0.4.6
 contourpy==1.3.2

--- a/temp_body.txt
+++ b/temp_body.txt
@@ -1,0 +1,55 @@
+## Description
+
+Replace the OpenAI API integration with OpenRouter. The default model should be `deepseek/deepseek-v4-flash:free`. Model selection should be configurable for future changes but hardcoded to this model for now.
+
+## Current State
+
+The AI system likely uses OpenAI's API directly (check `commands/ai/` and any API client code). This needs to be swapped to OpenRouter, which provides access to many models including free tier options.
+
+## Requirements
+
+### API Client Migration
+- Replace OpenAI API calls with OpenRouter API calls
+- OpenRouter endpoint: `https://openrouter.ai/api/v1/chat/completions`
+- Authentication: OpenRouter API key (configured via environment variable)
+- The API format is OpenAI-compatible, so the migration should be straightforward
+
+### Default Model
+- Default model: `deepseek/deepseek-v4-flash:free`
+- The model should be stored in a single place (config or constant) so it can be changed later
+- Wrap the model name in a config variable: `OPENROUTER_MODEL = os.environ.get("OPENROUTER_MODEL", "deepseek/deepseek-v4-flash:free")`
+- No need for a model selection command or UI yet — just a config var
+
+### Configuration
+```python
+# config.py additions
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+OPENROUTER_MODEL = os.environ.get("OPENROUTER_MODEL", "deepseek/deepseek-v4-flash:free")
+```
+
+### Rate Limiting & Error Handling
+- OpenRouter free tier has rate limits — handle 429 responses gracefully
+- Log model used in AI responses for debugging
+- Handle OpenRouter-specific error responses
+
+### Backward Compatibility
+- The existing AI token system (freeToken, plusToken, paidToken) should continue to work
+- The existing custom situation system should work unchanged
+- Only the underlying API client changes
+
+## Files to Investigate
+- `commands/ai/` — all AI command files
+- Any OpenAI client initialization code
+- `config.py` — add OpenRouter config vars
+- `.env.example` — update with OpenRouter key documentation
+
+## Acceptance Criteria
+- [ ] OpenRouter API replaces OpenAI API
+- [ ] Default model is `deepseek/deepseek-v4-flash:free`
+- [ ] Model name is configurable via env var
+- [ ] AI tokens (free/plus/paid) still work correctly
+- [ ] Custom situations still work
+- [ ] Rate limit errors are caught and reported gracefully
+- [ ] 429 responses don't crash the bot
+- [ ] All existing AI tests pass (or are updated)
+- [ ] `.env.example` updated with OPENROUTER_API_KEY and OPENROUTER_MODEL


### PR DESCRIPTION
## Description

Replace the OpenAI API integration with OpenRouter. The default model should be `deepseek/deepseek-v4-flash:free`. Model selection should be configurable for future changes but hardcoded to this model for now.

## Current State

The AI system likely uses OpenAI's API directly (check `commands/ai/` and any API client code). This needs to be swapped to OpenRouter, which provides access to many models including free tier options.

## Requirements

### API Client Migration
- Replace OpenAI API calls with OpenRouter API calls
- OpenRouter endpoint: `https://openrouter.ai/api/v1/chat/completions`
- Authentication: OpenRouter API key (configured via environment variable)
- The API format is OpenAI-compatible, so the migration should be straightforward

### Default Model
- Default model: `deepseek/deepseek-v4-flash:free`
- The model should be stored in a single place (config or constant) so it can be changed later
- Wrap the model name in a config variable: `OPENROUTER_MODEL = os.environ.get("OPENROUTER_MODEL", "deepseek/deepseek-v4-flash:free")`
- No need for a model selection command or UI yet — just a config var

### Configuration
```python
# config.py additions
OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY", "")
OPENROUTER_MODEL = os.environ.get("OPENROUTER_MODEL", "deepseek/deepseek-v4-flash:free")
```

### Rate Limiting & Error Handling
- OpenRouter free tier has rate limits — handle 429 responses gracefully
- Log model used in AI responses for debugging
- Handle OpenRouter-specific error responses

### Backward Compatibility
- The existing AI token system (freeToken, plusToken, paidToken) should continue to work
- The existing custom situation system should work unchanged
- Only the underlying API client changes

## Files to Investigate
- `commands/ai/` — all AI command files
- Any OpenAI client initialization code
- `config.py` — add OpenRouter config vars
- `.env.example` — update with OpenRouter key documentation

## Acceptance Criteria
- [ ] OpenRouter API replaces OpenAI API
- [ ] Default model is `deepseek/deepseek-v4-flash:free`
- [ ] Model name is configurable via env var
- [ ] AI tokens (free/plus/paid) still work correctly
- [ ] Custom situations still work
- [ ] Rate limit errors are caught and reported gracefully
- [ ] 429 responses don't crash the bot
- [ ] All existing AI tests pass (or are updated)
- [ ] `.env.example` updated with OPENROUTER_API_KEY and OPENROUTER_MODEL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive spec for migrating the bot’s AI integration to a new provider, including configuration options, rate-limit (HTTP 429) handling, error mapping, model selection override, and compatibility with existing token and situation systems.
* **Chores**
  * Relaxed version pinning for the cffi dependency in requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->