### PR TITLE
Enhance healthcheck.py to verify database connectivity (#1399)

### DIFF
--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,9 +1,11 @@
 """Docker health check for Tanjun bot.
 
-Verifies the bot process is alive and has connected to Discord
-by checking for the ready flag file written by on_ready().
+Verifies the bot process is alive, has connected to Discord
+by checking for the ready flag file written by on_ready(),
+and that the database connection pool is responsive.
 """
 
+import asyncio
 import os
 import sys
 import tempfile
@@ -12,10 +14,32 @@ from pathlib import Path
 READY_FILE = Path(os.path.join(tempfile.gettempdir(), "bot_ready"))
 
 
+async def check_health() -> bool:
+    """Run all health checks and return True only if all pass."""
+    # Check 1: Bot has fired on_ready
+    if not READY_FILE.exists():
+        return False
+
+    # Check 2: Database pool is responsive
+    try:
+        from api import _get_pool
+
+        pool = _get_pool()
+        if pool:
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute("SELECT 1")
+                    result = await cursor.fetchone()
+                    if result and result[0] == 1:
+                        return True
+        return False
+    except Exception:
+        return False
+
+
 def main() -> None:
-    if READY_FILE.exists():
-        sys.exit(0)
-    sys.exit(1)
+    result = asyncio.run(check_health())
+    sys.exit(0 if result else 1)
 
 
 if __name__ == "__main__":

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -22,16 +22,9 @@ async def check_health() -> bool:
 
     # Check 2: Database pool is responsive
     try:
-        from api import _get_pool
+        from api import check_pool_health
 
-        pool = _get_pool()
-        if pool:
-            async with pool.acquire() as conn, conn.cursor() as cursor:
-                await cursor.execute("SELECT 1")
-                result = await cursor.fetchone()
-                if result and result[0] == 1:
-                    return True
-        return False
+        return await check_pool_health()
     except Exception:
         return False
 

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -26,12 +26,11 @@ async def check_health() -> bool:
 
         pool = _get_pool()
         if pool:
-            async with pool.acquire() as conn:
-                async with conn.cursor() as cursor:
-                    await cursor.execute("SELECT 1")
-                    result = await cursor.fetchone()
-                    if result and result[0] == 1:
-                        return True
+            async with pool.acquire() as conn, conn.cursor() as cursor:
+                await cursor.execute("SELECT 1")
+                result = await cursor.fetchone()
+                if result and result[0] == 1:
+                    return True
         return False
     except Exception:
         return False


### PR DESCRIPTION
## Summary

Enhances the Docker health check to verify not just the bot's Discord connection (via the `bot_ready` flag file), but also that the database connection pool is responsive.

## Changes

- Converted `healthcheck.py` from synchronous to asynchronous
- Added database connectivity check using `SELECT 1` via the existing pool from `api._get_pool()`
- Health check now passes only if **both** the ready flag exists **and** the database responds

## Testing

- `/tmp/bot_ready` exists + DB responsive → exit 0 (healthy)
- `/tmp/bot_ready` missing → exit 1 (unhealthy)  
- `/tmp/bot_ready` exists + DB down → exit 1 (unhealthy)

Closes #1399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health check enhanced to verify database connectivity in addition to the readiness flag.
  * Container entrypoint now exits with success only when full health validation passes; failures cause a non-zero exit to signal unhealthy startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->