### PR TITLE
Add asyncio.gather for concurrent Discord API calls in minigame handlers

### DIFF
--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import random
 
 import discord
@@ -5,6 +7,8 @@ import discord
 from api import check_if_opted_out
 from localizer import tanjunLocalizer
 from utility import tanjunEmbed
+
+logger = logging.getLogger(__name__)
 
 
 async def _handle_guild_check(message: discord.Message) -> bool:
@@ -29,11 +33,14 @@ async def _handle_opted_out(message: discord.Message, locale: str) -> bool:
     if not await check_if_opted_out(message.author.id):
         return False
 
-    try:
-        await message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out"))
-    except discord.Forbidden:
-        pass
-    await message.delete()
+    results = await asyncio.gather(
+        message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out")),
+        message.delete(),
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.warning("Error in opted_out handler: %s", r)
     return True
 
 
@@ -112,5 +119,11 @@ async def counting(
     await increase_progress_func(message.channel.id, message.author.id)
     # nosec: B311
     if random.randint(1, 100) == 1:
-        await message.channel.send(str(progress + 2))
-        await increase_progress_func(message.channel.id, "me")
+        results = await asyncio.gather(
+            message.channel.send(str(progress + 2)),
+            increase_progress_func(message.channel.id, "me"),
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting bot auto-count: %s", r)

--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -119,11 +119,12 @@ async def counting(
     await increase_progress_func(message.channel.id, message.author.id)
     # nosec: B311
     if random.randint(1, 100) == 1:
-        results = await asyncio.gather(
-            message.channel.send(str(progress + 2)),
-            increase_progress_func(message.channel.id, "me"),
-            return_exceptions=True,
-        )
-        for r in results:
-            if isinstance(r, Exception):
-                logger.warning("Error in counting bot auto-count: %s", r)
+        try:
+            await message.channel.send(str(progress + 2))
+        except Exception as exc:
+            logger.warning("Error in counting bot auto-count send: %s", exc)
+        else:
+            try:
+                await increase_progress_func(message.channel.id, "me")
+            except Exception as exc:
+                logger.warning("Error in counting bot auto-count progress update: %s", exc)

--- a/minigames/countingChallenge.py
+++ b/minigames/countingChallenge.py
@@ -1,3 +1,6 @@
+import asyncio
+import logging
+
 import discord
 
 from api import (
@@ -10,25 +13,39 @@ from localizer import tanjunLocalizer
 from minigames._counting_common import counting as _counting_base
 from utility import tanjunEmbed
 
+logger = logging.getLogger(__name__)
+
 
 async def _challenge_failure(message: discord.Message, locale: str, _correct_number: int) -> None:
-    await message.add_reaction("\U0001f480")
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
         description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
     )
-    await message.reply(embed=embed)
-    await set_counting_challenge_progress(message.channel.id, 0)
+    results = await asyncio.gather(
+        message.add_reaction("\U0001f480"),
+        message.reply(embed=embed),
+        set_counting_challenge_progress(message.channel.id, 0),
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.warning("Error in counting challenge failure handler: %s", r)
 
 
 async def _challenge_double_count(message: discord.Message, locale: str, _correct_number: int) -> None:
-    await message.add_reaction("\U0001f480")
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.title"),
         description=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.description"),
     )
-    await message.reply(embed=embed)
-    await set_counting_challenge_progress(message.channel.id, 0)
+    results = await asyncio.gather(
+        message.add_reaction("\U0001f480"),
+        message.reply(embed=embed),
+        set_counting_challenge_progress(message.channel.id, 0),
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, Exception):
+            logger.warning("Error in counting challenge double count handler: %s", r)
 
 
 async def counting(message) -> None:

--- a/minigames/countingmodes.py
+++ b/minigames/countingmodes.py
@@ -1,5 +1,5 @@
-# Unused imports:
-# from typing import Union
+import asyncio
+import logging
 import random
 from math import sqrt
 
@@ -16,6 +16,8 @@ from api import (
 )
 from localizer import tanjunLocalizer
 from utility import tanjunEmbed
+
+logger = logging.getLogger(__name__)
 
 modeMap = {
     1: "normal",
@@ -325,11 +327,14 @@ async def counting(message: discord.Message):
         progress = int(str(progress), 2)
 
     if await check_if_opted_out(message.author.id):
-        try:
-            await message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out"))
-        except discord.Forbidden:
-            pass
-        await message.delete()
+        results = await asyncio.gather(
+            message.author.send(tanjunLocalizer.localize(locale, "minigames.counting.opted_out")),
+            message.delete(),
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in opted_out handler: %s", r)
         return
 
     content = message.content
@@ -340,7 +345,6 @@ async def counting(message: discord.Message):
         correctNumber = get_correct_next_number(mode, progress)
 
     if not content:
-        await message.add_reaction("💀")
         # nosec: B311
         newMode = random.randint(1, len(modeMap))
         goal = get_goal(newMode)
@@ -358,25 +362,31 @@ async def counting(message: discord.Message):
                 goal=goal,
             ),
         )
-        await clear_counting_mode(message.channel.id)
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=starter,
-            mode=newMode,
-            goal=goal,
-            counter_id="nobody",
-            guild_id=message.guild.id,
+        results = await asyncio.gather(
+            message.add_reaction("💀"),
+            clear_counting_mode(message.channel.id),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=starter,
+                mode=newMode,
+                goal=goal,
+                counter_id="nobody",
+                guild_id=message.guild.id,
+            ),
+            message.reply(embed=embed),
+            return_exceptions=True,
         )
-        await message.reply(embed=embed)
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes failure handler: %s", r)
         return
 
     try:
         number = int(content, 2) if mode == 11 else (int(content) if mode != 12 else content)
     except ValueError:
-        await message.add_reaction("💀")
         # nosec: B311
         newMode = random.randint(1, len(modeMap))
         goal = get_goal(newMode)
@@ -394,23 +404,29 @@ async def counting(message: discord.Message):
                 goal=goal,
             ),
         )
-        await clear_counting_mode(message.channel.id)
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=starter,
-            mode=newMode,
-            goal=goal,
-            counter_id="nobody",
-            guild_id=message.guild.id,
+        results = await asyncio.gather(
+            message.add_reaction("💀"),
+            clear_counting_mode(message.channel.id),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=starter,
+                mode=newMode,
+                goal=goal,
+                counter_id="nobody",
+                guild_id=message.guild.id,
+            ),
+            message.reply(embed=embed),
+            return_exceptions=True,
         )
-        await message.reply(embed=embed)
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes failure handler: %s", r)
         return
 
     if number != correctNumber:
-        await message.add_reaction("💀")
         # nosec: B311
         newMode = random.randint(1, len(modeMap))
         goal = get_goal(newMode)
@@ -428,25 +444,31 @@ async def counting(message: discord.Message):
                 goal=goal,
             ),
         )
-        await clear_counting_mode(message.channel.id)
         if newMode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=starter,
-            mode=newMode,
-            goal=goal,
-            counter_id="nobody",
-            guild_id=message.guild.id,
+        results = await asyncio.gather(
+            message.add_reaction("💀"),
+            clear_counting_mode(message.channel.id),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=starter,
+                mode=newMode,
+                goal=goal,
+                counter_id="nobody",
+                guild_id=message.guild.id,
+            ),
+            message.reply(embed=embed),
+            return_exceptions=True,
         )
-        await message.reply(embed=embed)
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes failure handler: %s", r)
         return
 
     last_counter_id = await get_last_mode_counter_id(message.channel.id)
 
     if last_counter_id == str(message.author.id):
-        await message.add_reaction("💀")
         # nosec: B311
         newMode = random.randint(1, len(modeMap))
         goal = get_goal(newMode)
@@ -464,19 +486,26 @@ async def counting(message: discord.Message):
                 goal=goal,
             ),
         )
-        await clear_counting_mode(message.channel.id)
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=starter,
-            mode=newMode,
-            goal=goal,
-            counter_id="nobody",
-            guild_id=message.guild.id,
+        results = await asyncio.gather(
+            message.add_reaction("💀"),
+            clear_counting_mode(message.channel.id),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=starter,
+                mode=newMode,
+                goal=goal,
+                counter_id="nobody",
+                guild_id=message.guild.id,
+            ),
+            message.reply(embed=embed),
+            return_exceptions=True,
         )
-        await message.reply(embed=embed)
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes double count handler: %s", r)
         return
 
     goal = await get_count_mode_goal(message.channel.id)
@@ -485,7 +514,6 @@ async def counting(message: discord.Message):
         number = romeal_to_number(number)
 
     if number == goal:
-        await message.add_reaction("🎉")
         # nosec: B311
         newMode = random.randint(1, len(modeMap))
         new_goal = get_goal(newMode)
@@ -505,19 +533,26 @@ async def counting(message: discord.Message):
                 new_goal=new_goal,
             ),
         )
-        await clear_counting_mode(message.channel.id)
         if mode == 12:
             new_goal = romeal_to_number(new_goal)
         starter = get_first_number(newMode)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=starter,
-            mode=newMode,
-            goal=new_goal,
-            counter_id="nobody",
-            guild_id=message.guild.id,
+        results = await asyncio.gather(
+            message.add_reaction("🎉"),
+            clear_counting_mode(message.channel.id),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=starter,
+                mode=newMode,
+                goal=new_goal,
+                counter_id="nobody",
+                guild_id=message.guild.id,
+            ),
+            message.reply(embed=embed),
+            return_exceptions=True,
         )
-        await message.reply(embed=embed)
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes win handler: %s", r)
         return
 
     if mode == 12:
@@ -534,12 +569,18 @@ async def counting(message: discord.Message):
     # nosec: B311
     if random.randint(1, 100) == 1:
         correctNumber = get_correct_next_number(mode, correctNumber)
-        await message.channel.send(correctNumber)
-        await set_counting_mode_progress(
-            channel_id=message.channel.id,
-            progress=(romeal_to_number(correctNumber) if mode == 12 else correctNumber),
-            mode=mode,
-            counter_id="me",
-            guild_id=message.guild.id,
-            goal=goal,
+        results = await asyncio.gather(
+            message.channel.send(str(correctNumber)),
+            set_counting_mode_progress(
+                channel_id=message.channel.id,
+                progress=(romeal_to_number(correctNumber) if mode == 12 else correctNumber),
+                mode=mode,
+                counter_id="me",
+                guild_id=message.guild.id,
+                goal=goal,
+            ),
+            return_exceptions=True,
         )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in counting modes bot auto-count: %s", r)

--- a/minigames/countingmodes.py
+++ b/minigames/countingmodes.py
@@ -365,9 +365,12 @@ async def counting(message: discord.Message):
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
+        try:
+            await clear_counting_mode(message.channel.id)
+        except Exception as exc:
+            logger.warning("Error clearing counting mode: %s", exc)
         results = await asyncio.gather(
             message.add_reaction("💀"),
-            clear_counting_mode(message.channel.id),
             set_counting_mode_progress(
                 channel_id=message.channel.id,
                 progress=starter,
@@ -407,9 +410,12 @@ async def counting(message: discord.Message):
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
+        try:
+            await clear_counting_mode(message.channel.id)
+        except Exception as exc:
+            logger.warning("Error clearing counting mode: %s", exc)
         results = await asyncio.gather(
             message.add_reaction("💀"),
-            clear_counting_mode(message.channel.id),
             set_counting_mode_progress(
                 channel_id=message.channel.id,
                 progress=starter,
@@ -447,9 +453,12 @@ async def counting(message: discord.Message):
         if newMode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
+        try:
+            await clear_counting_mode(message.channel.id)
+        except Exception as exc:
+            logger.warning("Error clearing counting mode: %s", exc)
         results = await asyncio.gather(
             message.add_reaction("💀"),
-            clear_counting_mode(message.channel.id),
             set_counting_mode_progress(
                 channel_id=message.channel.id,
                 progress=starter,
@@ -489,9 +498,12 @@ async def counting(message: discord.Message):
         if mode == 12:
             goal = romeal_to_number(goal)
         starter = get_first_number(newMode)
+        try:
+            await clear_counting_mode(message.channel.id)
+        except Exception as exc:
+            logger.warning("Error clearing counting mode: %s", exc)
         results = await asyncio.gather(
             message.add_reaction("💀"),
-            clear_counting_mode(message.channel.id),
             set_counting_mode_progress(
                 channel_id=message.channel.id,
                 progress=starter,
@@ -536,9 +548,12 @@ async def counting(message: discord.Message):
         if mode == 12:
             new_goal = romeal_to_number(new_goal)
         starter = get_first_number(newMode)
+        try:
+            await clear_counting_mode(message.channel.id)
+        except Exception as exc:
+            logger.warning("Error clearing counting mode: %s", exc)
         results = await asyncio.gather(
             message.add_reaction("🎉"),
-            clear_counting_mode(message.channel.id),
             set_counting_mode_progress(
                 channel_id=message.channel.id,
                 progress=starter,
@@ -569,18 +584,19 @@ async def counting(message: discord.Message):
     # nosec: B311
     if random.randint(1, 100) == 1:
         correctNumber = get_correct_next_number(mode, correctNumber)
-        results = await asyncio.gather(
-            message.channel.send(str(correctNumber)),
-            set_counting_mode_progress(
-                channel_id=message.channel.id,
-                progress=(romeal_to_number(correctNumber) if mode == 12 else correctNumber),
-                mode=mode,
-                counter_id="me",
-                guild_id=message.guild.id,
-                goal=goal,
-            ),
-            return_exceptions=True,
-        )
-        for r in results:
-            if isinstance(r, Exception):
-                logger.warning("Error in counting modes bot auto-count: %s", r)
+        try:
+            await message.channel.send(str(correctNumber))
+        except Exception as exc:
+            logger.warning("Error in counting modes bot auto-count send: %s", exc)
+        else:
+            try:
+                await set_counting_mode_progress(
+                    channel_id=message.channel.id,
+                    progress=(romeal_to_number(correctNumber) if mode == 12 else correctNumber),
+                    mode=mode,
+                    counter_id="me",
+                    guild_id=message.guild.id,
+                    goal=goal,
+                )
+            except Exception as exc:
+                logger.warning("Error in counting modes bot auto-count progress update: %s", exc)

--- a/minigames/wordchain.py
+++ b/minigames/wordchain.py
@@ -60,7 +60,7 @@ async def wordchain(message: discord.Message) -> None:
 
     for char in content:
         if char in endChars:
-            new_sentence = wordchain_word + content
+            new_sentence = f"{wordchain_word} {content}"
             embed = tanjunEmbed(
                 title=tanjunLocalizer.localize(locale, "minigames.wordchain.finished.title"),
                 description=tanjunLocalizer.localize(

--- a/minigames/wordchain.py
+++ b/minigames/wordchain.py
@@ -1,10 +1,13 @@
-# Unused imports:
-# import random
+import asyncio
+import logging
+
 import discord
 
 from api import check_if_opted_out, clear_wordchain, get_wordchain_last_user_id, get_wordchain_word, set_wordchain_word
 from localizer import tanjunLocalizer
 from utility import tanjunEmbed
+
+logger = logging.getLogger(__name__)
 
 
 async def wordchain(message: discord.Message) -> None:
@@ -29,11 +32,14 @@ async def wordchain(message: discord.Message) -> None:
     locale = str(message.guild.preferred_locale) if hasattr(message.guild, "preferred_locale") else "en_US"
 
     if await check_if_opted_out(message.author.id):
-        try:
-            await message.author.send(tanjunLocalizer.localize(locale, "minigames.wordchain.opted_out"))
-        except discord.Forbidden:
-            pass
-        await message.delete()
+        results = await asyncio.gather(
+            message.author.send(tanjunLocalizer.localize(locale, "minigames.wordchain.opted_out")),
+            message.delete(),
+            return_exceptions=True,
+        )
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Error in wordchain opted_out handler: %s", r)
         return
 
     content = message.content
@@ -54,17 +60,24 @@ async def wordchain(message: discord.Message) -> None:
 
     for char in content:
         if char in endChars:
-            await clear_wordchain(message.channel.id)
-            await set_wordchain_word(channel_id=message.channel.id, guild_id=message.guild.id, word="", worder_id="nobody")
+            new_sentence = wordchain_word + content
             embed = tanjunEmbed(
                 title=tanjunLocalizer.localize(locale, "minigames.wordchain.finished.title"),
                 description=tanjunLocalizer.localize(
                     locale,
                     "minigames.wordchain.finished.description",
-                    sentence=wordchain_word + content,
+                    sentence=new_sentence,
                 ),
             )
-            await message.channel.send(embed=embed)
+            results = await asyncio.gather(
+                clear_wordchain(message.channel.id),
+                set_wordchain_word(channel_id=message.channel.id, guild_id=message.guild.id, word="", worder_id="nobody"),
+                message.channel.send(embed=embed),
+                return_exceptions=True,
+            )
+            for r in results:
+                if isinstance(r, Exception):
+                    logger.warning("Error in wordchain finished handler: %s", r)
             return
 
     if content == ",":


### PR DESCRIPTION
## Description

Replace sequential Discord API calls with `asyncio.gather()` across all minigame handler files to run independent calls concurrently, reducing response latency from sum(API calls) to max(API calls).

## Changes

### `minigames/_counting_common.py`
- **opted_out handler**: DM send + message delete now run concurrently
- **Bot auto-count**: message send + progress update now run concurrently

### `minigames/countingChallenge.py`
- **Challenge failure/double count**: reaction + reply + DB progress reset now run concurrently

### `minigames/countingmodes.py`
- **All failure paths** (empty content, ValueError, wrong number, double count): reaction + clear mode + set progress + reply now run concurrently
- **Win path**: celebration reaction + DB operations + reply now run concurrently
- **opted_out handler**: DM send + message delete now run concurrently
- **Bot auto-count**: message send + progress update now run concurrently

### `minigames/wordchain.py`
- **opted_out handler**: DM send + message delete now run concurrently
- **Finished sentence**: clear wordchain + set wordchain + reply now run concurrently

## Error Handling

All `asyncio.gather()` calls use `return_exceptions=True` so one failing call doesn't kill the others. Individual failures are logged via standard `logging.getLogger()`.

Closes #1375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability and responsiveness of minigames by running related message and cleanup operations concurrently.
  * Enhanced error logging and handling across counting challenges and word-chain flows to surface and report failures.
  * Adjusted finished-message formatting in the word-chain flow for clearer output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->