### PR TITLE
Migrate AI integration from OpenAI to OpenRouter

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,3 +35,4 @@ CALC_SUBTRACT = "math_substract:1254372627766837248"
 CALC_MULTIPLY = "math_multiply:1254372798319558768"
 CALC_DIVIDE = "math_divide:1254373636224323644"
 CALC_BACKSPACE = "math_backspace:1254371946695757854"
+OPENROUTER_API_KEY = os.environ.get(\"OPENROUTER_API_KEY\", \"")\nOPENROUTER_MODEL = os.environ.get(\"OPENROUTER_MODEL\", \"deepseek/deepseek-v4-flash:free\")


### PR DESCRIPTION
This PR migrates the AI integration from OpenAI to OpenRouter, making the default model `deepseek/deepseek-v4-flash:free`. It includes environment variable configurations for the OpenRouter API key and model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenRouter integration support. Users can now configure the OpenRouter API key and model selection via environment variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->