### PR TITLE
Add startup cache preload for guild-level configs to avoid cold-start latency

### DIFF
--- a/api.py
+++ b/api.py
@@ -1365,13 +1365,7 @@ async def set_xp_scaling(guild_id: str, scaling: str) -> None:
 
 async def get_xp_scaling(guild_id: str) -> str:
     """Get the XP scaling for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "scaling")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT difficulty FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else "medium"
+    return await _get_cached_config(guild_id, "scaling", "medium")
 
 
 async def set_custom_formula(guild_id: str, formula: str) -> None:
@@ -1387,13 +1381,7 @@ async def set_custom_formula(guild_id: str, formula: str) -> None:
 
 async def get_custom_formula(guild_id: str) -> str | None:
     """Get the custom XP formula for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "custom_formula")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT customFormula FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    return await _get_cached_config(guild_id, "custom_formula", None)
 
 
 async def add_level_role(guild_id: str, role_id: str, level: int) -> None:
@@ -2076,24 +2064,12 @@ async def set_voice_cooldown(guild_id: str, cooldown: int) -> None:
 
 async def get_text_cooldown(guild_id: str) -> int:
     """Get the text XP cooldown for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "text_cooldown")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT textCooldown FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else 60  # Default to 60 seconds if not set
+    return await _get_cached_config(guild_id, "text_cooldown", 60)
 
 
 async def get_voice_cooldown(guild_id: str) -> int:
     """Get the voice XP cooldown for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "voice_cooldown")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT voiceCooldown FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else 60  # Default to 60 seconds if not set
+    return await _get_cached_config(guild_id, "voice_cooldown", 60)
 
 
 async def useToken(user_id: str, amount: int) -> None:

--- a/api.py
+++ b/api.py
@@ -1364,6 +1364,10 @@ async def set_xp_scaling(guild_id: str, scaling: str) -> None:
 
 
 async def get_xp_scaling(guild_id: str) -> str:
+    """Get the XP scaling for a guild, using cached config when available."""
+    cached_value = await _get_cached_config(guild_id, "scaling")
+    if cached_value is not None:
+        return cached_value
     query = "SELECT difficulty FROM levelConfig WHERE guild_id = %s"
     params = (guild_id,)
     result = await execute_query(query, params)
@@ -1382,6 +1386,10 @@ async def set_custom_formula(guild_id: str, formula: str) -> None:
 
 
 async def get_custom_formula(guild_id: str) -> str | None:
+    """Get the custom XP formula for a guild, using cached config when available."""
+    cached_value = await _get_cached_config(guild_id, "custom_formula")
+    if cached_value is not None:
+        return cached_value
     query = "SELECT customFormula FROM levelConfig WHERE guild_id = %s"
     params = (guild_id,)
     result = await execute_query(query, params)
@@ -2067,6 +2075,10 @@ async def set_voice_cooldown(guild_id: str, cooldown: int) -> None:
 
 
 async def get_text_cooldown(guild_id: str) -> int:
+    """Get the text XP cooldown for a guild, using cached config when available."""
+    cached_value = await _get_cached_config(guild_id, "text_cooldown")
+    if cached_value is not None:
+        return cached_value
     query = "SELECT textCooldown FROM levelConfig WHERE guild_id = %s"
     params = (guild_id,)
     result = await execute_query(query, params)
@@ -2074,6 +2086,10 @@ async def get_text_cooldown(guild_id: str) -> int:
 
 
 async def get_voice_cooldown(guild_id: str) -> int:
+    """Get the voice XP cooldown for a guild, using cached config when available."""
+    cached_value = await _get_cached_config(guild_id, "voice_cooldown")
+    if cached_value is not None:
+        return cached_value
     query = "SELECT voiceCooldown FROM levelConfig WHERE guild_id = %s"
     params = (guild_id,)
     result = await execute_query(query, params)

--- a/main.py
+++ b/main.py
@@ -1048,6 +1048,12 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
     await create_tables(bot)
+
+    # Preload guild configs into cache to avoid cold-start latency
+    from api import preload_guild_configs
+
+    await preload_guild_configs(bot)
+
 nimport logging
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Description

Fixes #1377

Adds a startup cache preload that fetches all guild-level configs at once, reducing ~12 sequential DB queries per guild on first message after restart.

### Changes

- **main.py**: Call `preload_guild_configs(bot)` after database tables are created during startup
- **api.py**: Updated `get_xp_scaling`, `get_custom_formula`, `get_text_cooldown`, `get_voice_cooldown` to use the in-memory cache (`_get_cached_config`) instead of hitting the database every time
- The caching infrastructure (`_guild_config_cache`, `_get_cached_config`, `_get_cached_blacklist`, `preload_guild_configs`) was already defined in `api.py` but was never wired up during startup

### Benefits
- ~12x fewer startup DB queries per guild on first message
- Instant config access for config values already preloaded
- Warm cache on first message — eliminates cold-start latency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Configuration values are now cached to reduce load times and database queries, improving responsiveness.
  * Preloading guild configurations at startup shortens first-use latency.

* **Refactor**
  * Streamlined startup and extension/translator loading for faster, more reliable bot initialization.
  * Bot presence now shows version info and readiness is signaled more promptly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->