### PR TITLE
fix: Consolidate voice state update handlers into single dispatcher (#1370)

### DIFF
--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -20,7 +20,6 @@ from commands.utility.autopublish import publish_message
 from commands.utility.report import report_btn_click
 from config import adminIds
 from loops._voice_tracker import handleVoiceChange
-from loops._voice_tracker import handleVoiceChange as handleLevelVoiceChange
 from minigames.addLevelXp import addLevelXp
 from minigames.counting import counting
 from minigames.countingChallenge import counting as countingChallenge
@@ -94,7 +93,6 @@ class ListenerCog(commands.Cog):
         await memberLeave(before)
         await memberJoin(after, user)
         await handleVoiceChange(user, before, after)  # type: ignore[no-untyped-call]
-        await handleLevelVoiceChange(user, before, after)  # type: ignore[no-untyped-call]
 
     @commands.Cog.listener()
     async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:


### PR DESCRIPTION
## Summary
Consolidate duplicate voice state update handling in `extensions/listeners.py` to eliminate dual processing.

## Problem
`on_voice_state_update` imported `handleVoiceChange` twice (once as `handleLevelVoiceChange` alias) and called the **same function** with identical arguments, causing:
- Two opt-out DB queries per voice state change
- Two channel member list iterations
- Two voiceUsers list modifications

## Change
- Remove duplicate import `handleVoiceChange as handleLevelVoiceChange`
- Remove duplicate call to `handleLevelVoiceChange`

## Why this is safe
`handleVoiceChange` in `loops/_voice_tracker.py` already updates a shared `voiceUsers` list consumed by both `loops/giveaway.py` and `loops/level.py`. Nothing relied on the second call having separate state — it was always the same function running twice.

Closes #1370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor code cleanup and optimization to internal voice handling logic with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->