### PR TITLE
Add pagination to leaderboard command to avoid loading all rows at once

### DIFF
--- a/api.py
+++ b/api.py
@@ -2204,10 +2204,14 @@ async def get_level_leaderboard_paginated(
     Uses SQL-level LIMIT/OFFSET so only the requested page of rows
     is loaded from the database.
     """
+    if limit < 1:
+        limit = 10
+    if offset < 0:
+        offset = 0
     query = """
         SELECT user_id, xp FROM level
         WHERE guild_id = %s
-        ORDER BY xp DESC
+        ORDER BY xp DESC, user_id ASC
         LIMIT %s OFFSET %s
     """
     params = (guild_id, limit, offset)

--- a/api.py
+++ b/api.py
@@ -2194,6 +2194,35 @@ async def getLevelLeaderboard(guild_id: str) -> list[LevelLeaderboardEntryModel]
     return [LevelLeaderboardEntryModel.from_row(row) for row in result] if result else []
 
 
+async def get_level_leaderboard_paginated(
+    guild_id: str,
+    limit: int = 10,
+    offset: int = 0,
+) -> list[LevelLeaderboardEntryModel]:
+    """Fetch a paginated slice of the level leaderboard.
+
+    Uses SQL-level LIMIT/OFFSET so only the requested page of rows
+    is loaded from the database.
+    """
+    query = """
+        SELECT user_id, xp FROM level
+        WHERE guild_id = %s
+        ORDER BY xp DESC
+        LIMIT %s OFFSET %s
+    """
+    params = (guild_id, limit, offset)
+    result = await execute_query(query, params)
+    return [LevelLeaderboardEntryModel.from_row(row) for row in result] if result else []
+
+
+async def get_level_leaderboard_count(guild_id: str) -> int:
+    """Return the total number of members on the leaderboard for a guild."""
+    query = "SELECT COUNT(*) FROM level WHERE guild_id = %s"
+    params = (guild_id,)
+    result = await execute_query(query, params)
+    return result[0][0] if result else 0
+
+
 async def addCustomSituation(
     user_id: str,
     situation: str,

--- a/commands/level/leaderboard.py
+++ b/commands/level/leaderboard.py
@@ -1,50 +1,65 @@
 import discord
 
 import utility
-from api import get_custom_formula, get_xp_scaling, getLevelLeaderboard
+from api import (
+    get_custom_formula,
+    get_level_leaderboard_count,
+    get_level_leaderboard_paginated,
+    get_xp_scaling,
+)
 from localizer import tanjunLocalizer
+
+ITEMS_PER_PAGE = 10
 
 
 async def leaderboard(commandInfo: utility.commandInfo, page: int = 1):
     if page < 1:
         page = 1
-    leaderboard = await getLevelLeaderboard(commandInfo.guild.id)
+
+    total_entries = await get_level_leaderboard_count(commandInfo.guild.id)
+    if total_entries == 0:
+        await commandInfo.message.channel.send(
+            tanjunLocalizer.localize(commandInfo.locale, "commands.level.leaderboard.no_data")
+        )
+        return
+
+    total_pages = max(1, (total_entries + ITEMS_PER_PAGE - 1) // ITEMS_PER_PAGE)
+    if page > total_pages:
+        page = total_pages
+
     scaling = await get_xp_scaling(commandInfo.guild.id)
     custom_formula = await get_custom_formula(commandInfo.guild.id)
-    if not leaderboard:
-        await commandInfo.message.channel.send(
-            tanjunLocalizer.localize(commandInfo.locale, "commands.level.leaderboard.no_data")
+
+    async def load_page(page_number: int) -> list:
+        offset = (page_number - 1) * ITEMS_PER_PAGE
+        return await get_level_leaderboard_paginated(
+            commandInfo.guild.id,
+            limit=ITEMS_PER_PAGE,
+            offset=offset,
         )
-        return
-    if len(leaderboard) == 0:
-        await commandInfo.message.channel.send(
-            tanjunLocalizer.localize(commandInfo.locale, "commands.level.leaderboard.no_data")
-        )
-        return
-    if page > len(leaderboard) / 10 + 1:
-        page = int(len(leaderboard) / 10 + 1)
 
     async def generate_page(page_number: int) -> discord.Embed:
+        entries = await load_page(page_number)
         description = ""
-        for i in range(10):
-            try:
-                placeData = leaderboard[i + (page_number - 1) * 10]
-                user = placeData.user_id
-                xp = placeData.xp
-                level = utility.get_level_for_xp(xp, scaling, custom_formula)
-                xp_from_last_level = xp - utility.get_xp_for_level(level - 1, scaling, custom_formula)
-                xp_till_next_level = utility.get_xp_for_level(level, scaling, custom_formula)
-                description += f"\n{i + 1 + (page_number - 1) * 10}. <@{user}> - {tanjunLocalizer.localize(commandInfo.locale, 'commands.level.leaderboard.data', level=level, xp_from_last_level=xp_from_last_level, xp_till_next_level=xp_till_next_level)}"
-            except Exception:
-                break
+        base_rank = (page_number - 1) * ITEMS_PER_PAGE + 1
+        for i, entry in enumerate(entries):
+            user = entry.user_id
+            xp = entry.xp
+            level = utility.get_level_for_xp(xp, scaling, custom_formula)
+            xp_from_last_level = xp - utility.get_xp_for_level(level - 1, scaling, custom_formula)
+            xp_till_next_level = utility.get_xp_for_level(level, scaling, custom_formula)
+            description += (
+                f"\n{base_rank + i}. <@{user}> - "
+                f"{tanjunLocalizer.localize(commandInfo.locale, 'commands.level.leaderboard.data', level=level, xp_from_last_level=xp_from_last_level, xp_till_next_level=xp_till_next_level)}"
+            )
 
-        if int(len(leaderboard) / 10 + 1) > 1:
+        if total_pages > 1:
             embed = utility.tanjunEmbed(
                 title=tanjunLocalizer.localize(
                     commandInfo.locale,
                     "commands.level.leaderboard.title",
                     current_page=page_number,
-                    total_pages=int(len(leaderboard) / 10 + 1),
+                    total_pages=total_pages,
                 ),
                 description=description,
             )
@@ -59,7 +74,7 @@ async def leaderboard(commandInfo: utility.commandInfo, page: int = 1):
         def __init__(self, current_page=1):
             super().__init__(timeout=3600)
             self.current_page = current_page
-            self.total_pages = int(len(leaderboard) / 10 + 1)
+            self.total_pages = total_pages
 
         @discord.ui.button(label="⬅️", style=discord.ButtonStyle.secondary)
         async def previous(self, interaction: discord.Interaction, button: discord.ui.Button):


### PR DESCRIPTION
## Summary

The level leaderboard command previously loaded ALL user XP rows from the database and processed them in memory. For large guilds with thousands of members, this meant sorting and holding thousands of rows for every leaderboard request.

## Changes

### api.py
- Added **`get_level_leaderboard_paginated(guild_id, limit, offset)`** — fetches only the requested page using SQL-level `LIMIT/OFFSET` instead of loading everything
- Added **`get_level_leaderboard_count(guild_id)`** — returns the total number of entries so the UI can show `total_pages`

### commands/level/leaderboard.py
- Rewrote to fetch only the current page from the database via the paginated API
- Total page count is now determined by a lightweight `COUNT` query instead of `len(all_rows)`
- Each page navigation fires a fresh paginated DB query instead of slicing a pre-loaded list

## Benefits

- **Constant memory usage**: Only loads the requested page of data
- **Faster queries**: Database only sorts and returns 10 rows instead of thousands
- **Better UX**: Navigation still works via buttons, but each page is fetched on demand

Closes #1348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side paginated leaderboard endpoint and a total-count endpoint to fetch leaderboard pages and overall size.

* **Refactor**
  * Client now requests only the needed leaderboard page from the server, clamps pages within bounds, preserves correct rank numbering across pages, and updates the UI header to show current/total pages when applicable, improving responsiveness and reducing memory use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->