### PR TITLE
Pre-compute and cache level thresholds per guild to avoid O(n) XP lookups

### DIFF
--- a/loops/level.py
+++ b/loops/level.py
@@ -1,7 +1,6 @@
 import discord
 
 from api import (
-    _get_cached_config,
     get_level_system_status,
     update_user_xp_from_voice,
 )
@@ -16,17 +15,15 @@ def _get_member(client: discord.Client, user_id: int, guild_id: int) -> discord.
     return guild.get_member(user_id)
 
 
-async def fetch_xp_details(user: discord.Member):
+async def fetch_xp_details(user: discord.Member) -> int:
     guild_id = str(user.guild.id)
-    scaling = await _get_cached_config(guild_id, "scaling", "medium")
-    custom_formula = await _get_cached_config(guild_id, "custom_formula")
     xp_to_add = await calculate_xp(
         guild_id,
         str(user.id),
         str(user.voice.channel.id) if user.voice and user.voice.channel else "0",
         [str(role.id) for role in user.roles],
     )
-    return scaling, custom_formula, xp_to_add
+    return xp_to_add
 
 
 async def addXpToVoiceUsers(client):
@@ -47,5 +44,5 @@ async def addXpToVoiceUsers(client):
         ):
             continue
 
-        scaling, custom_formula, xp_to_add = await fetch_xp_details(user)
+        xp_to_add = await fetch_xp_details(user)
         await update_user_xp_from_voice(user.guild.id, user.id, xp_to_add, True)

--- a/loops/level.py
+++ b/loops/level.py
@@ -1,9 +1,8 @@
 import discord
 
 from api import (
-    get_custom_formula,
+    _get_cached_config,
     get_level_system_status,
-    get_xp_scaling,
     update_user_xp_from_voice,
 )
 from loops._voice_tracker import voice_user_ids
@@ -18,10 +17,11 @@ def _get_member(client: discord.Client, user_id: int, guild_id: int) -> discord.
 
 
 async def fetch_xp_details(user: discord.Member):
-    scaling = await get_xp_scaling(user.guild.id)
-    custom_formula = await get_custom_formula(user.guild.id)
+    guild_id = str(user.guild.id)
+    scaling = await _get_cached_config(guild_id, "scaling", "medium")
+    custom_formula = await _get_cached_config(guild_id, "custom_formula")
     xp_to_add = await calculate_xp(
-        str(user.guild.id),
+        guild_id,
         str(user.id),
         str(user.voice.channel.id) if user.voice and user.voice.channel else "0",
         [str(role.id) for role in user.roles],

--- a/minigames/addLevelXp.py
+++ b/minigames/addLevelXp.py
@@ -1,15 +1,14 @@
 import discord
 
 from api import (
+    _get_cached_config,
     check_if_opted_out,
-    get_custom_formula,
     get_level_roles,
     get_level_system_status,
     get_levelup_channel,
     get_levelup_message,
     get_levelup_message_status,
     get_user_xp,
-    get_xp_scaling,
     update_user_xp,
 )
 from localizer import tanjunLocalizer
@@ -49,8 +48,8 @@ async def addLevelXp(message: discord.Message) -> None:
 
 
 async def fetch_xp_details(message: discord.Message, guild_id: str) -> tuple[str, str | None, int]:
-    scaling = await get_xp_scaling(guild_id)
-    custom_formula = await get_custom_formula(guild_id)
+    scaling = await _get_cached_config(guild_id, "scaling", "medium")
+    custom_formula = await _get_cached_config(guild_id, "custom_formula")
     xp_to_add = await calculate_xp(
         guild_id,
         str(message.author.id),

--- a/utility.py
+++ b/utility.py
@@ -1,5 +1,6 @@
 import ast
 import bisect
+import collections
 import datetime
 import gzip
 import logging
@@ -1002,18 +1003,28 @@ class LevelThresholdCache:
     per-call overhead to just the bisect.
     """
 
-    _thresholds: dict[tuple[str, str | None], tuple[list[int], int]] = {}
+    _thresholds: collections.OrderedDict[tuple[str, str | None], tuple[list[int], int]] = collections.OrderedDict()
     _MAX_LEVEL = 10000
+    _MAX_ENTRIES = 50  # Prevent unbounded growth: ~50 scaling/formula combos max
 
     @classmethod
     def get_level_for_xp(cls, xp: int, scaling: str, custom_formula: str | None = None) -> int:
         key = (scaling, custom_formula)
-        thresholds, max_level = cls._thresholds.get(key, (None, 0))  # type: ignore
+        entry = cls._thresholds.get(key)
+        thresholds: list[int] | None
+        max_level: int
+        if entry is not None:
+            thresholds, max_level = entry
+        else:
+            thresholds = None
+            max_level = cls._MAX_LEVEL
+
         if thresholds is None or thresholds[-1] < xp:
             # Build or extend thresholds if needed
             if thresholds is None:
                 start_level = 1
                 thresholds = []
+                max_level = cls._MAX_LEVEL
             else:
                 # Extend from current; don't rebuild from scratch
                 if max_level >= cls._MAX_LEVEL and thresholds[-1] >= xp:
@@ -1026,6 +1037,9 @@ class LevelThresholdCache:
                     max_level = level
                     break
             cls._thresholds[key] = (thresholds, max_level)
+            # Evict oldest entries if cache exceeds limit
+            while len(cls._thresholds) > cls._MAX_ENTRIES:
+                cls._thresholds.popitem(last=False)
         return bisect.bisect_right(thresholds, xp)
 
 

--- a/utility.py
+++ b/utility.py
@@ -1009,7 +1009,10 @@ class LevelThresholdCache:
 
     @classmethod
     def get_level_for_xp(cls, xp: int, scaling: str, custom_formula: str | None = None) -> int:
-        key = (scaling, custom_formula)
+        # Normalize key: only store custom_formula when scaling is "custom"
+        # to avoid duplicate cache entries for built-in scalings
+        effective_formula = custom_formula if scaling == "custom" else None
+        key = (scaling, effective_formula)
         entry = cls._thresholds.get(key)
         thresholds: list[int] | None
         max_level: int
@@ -1032,7 +1035,7 @@ class LevelThresholdCache:
                 start_level = len(thresholds) + 1
                 max_level = cls._MAX_LEVEL
             for level in range(start_level, max_level + 1):
-                thresholds.append(get_xp_for_level(level, scaling, custom_formula))
+                thresholds.append(get_xp_for_level(level, scaling, effective_formula))
                 if thresholds[-1] > xp and level >= start_level + 10:
                     max_level = level
                     break
@@ -1149,7 +1152,7 @@ def get_xp_for_level(level: int, scaling: str, custom_formula: str | None = None
     return math.floor(result)
 
 
-def get_level_for_xp(xp: int, scaling: str, custom_formula: str = None) -> int:
+def get_level_for_xp(xp: int, scaling: str, custom_formula: str | None = None) -> int:
     """Get the level for a given XP value using pre-computed thresholds."""
     return LevelThresholdCache.get_level_for_xp(xp, scaling, custom_formula)
 

--- a/utility.py
+++ b/utility.py
@@ -1,4 +1,5 @@
 import ast
+import bisect
 import datetime
 import gzip
 import logging
@@ -991,6 +992,43 @@ LEVEL_SCALINGS = {
     "extreme": lambda level: 100 * (level**2.5),
 }
 
+
+class LevelThresholdCache:
+    """Pre-compute and cache level XP thresholds per (scaling, custom_formula) pair.
+
+    Instead of binary-searching get_xp_for_level on every call (O(log n) per call
+    with O(1) per iteration), this pre-computes all thresholds once and uses
+    bisect_right for O(log n) lookup on the pre-computed list — reducing
+    per-call overhead to just the bisect.
+    """
+
+    _thresholds: dict[tuple[str, str | None], tuple[list[int], int]] = {}
+    _MAX_LEVEL = 10000
+
+    @classmethod
+    def get_level_for_xp(cls, xp: int, scaling: str, custom_formula: str | None = None) -> int:
+        key = (scaling, custom_formula)
+        thresholds, max_level = cls._thresholds.get(key, (None, 0))  # type: ignore
+        if thresholds is None or thresholds[-1] < xp:
+            # Build or extend thresholds if needed
+            if thresholds is None:
+                start_level = 1
+                thresholds = []
+            else:
+                # Extend from current; don't rebuild from scratch
+                if max_level >= cls._MAX_LEVEL and thresholds[-1] >= xp:
+                    return bisect.bisect_right(thresholds, xp)
+                start_level = len(thresholds) + 1
+                max_level = cls._MAX_LEVEL
+            for level in range(start_level, max_level + 1):
+                thresholds.append(get_xp_for_level(level, scaling, custom_formula))
+                if thresholds[-1] > xp and level >= start_level + 10:
+                    max_level = level
+                    break
+            cls._thresholds[key] = (thresholds, max_level)
+        return bisect.bisect_right(thresholds, xp)
+
+
 operators = {
     ast.Add: op.add,
     ast.Sub: op.sub,
@@ -1098,14 +1136,8 @@ def get_xp_for_level(level: int, scaling: str, custom_formula: str = None) -> in
 
 
 def get_level_for_xp(xp: int, scaling: str, custom_formula: str = None) -> int:
-    low, high = 1, 10000  # Assuming a high range cap for levels
-    while low < high:
-        mid = (low + high) // 2
-        if get_xp_for_level(mid, scaling, custom_formula) > xp:
-            high = mid
-        else:
-            low = mid + 1
-    return low
+    """Get the level for a given XP value using pre-computed thresholds."""
+    return LevelThresholdCache.get_level_for_xp(xp, scaling, custom_formula)
 
 
 def relativeTimeStrToDate(time_string: str) -> datetime.datetime:

--- a/utility.py
+++ b/utility.py
@@ -1134,7 +1134,7 @@ def eval_(node, variables):
         raise TypeError(f"Unsupported operation: {node}")
 
 
-def get_xp_for_level(level: int, scaling: str, custom_formula: str = None) -> int:
+def get_xp_for_level(level: int, scaling: str, custom_formula: str | None = None) -> int:
     if level <= 0:
         return 0
     if scaling == "custom" and custom_formula:


### PR DESCRIPTION
## Description

Implements per-(scaling, custom_formula) level threshold caching to avoid
binary-searching `get_xp_for_level` on every message and voice XP tick.

### Changes

1. **utility.py** — Added `LevelThresholdCache` class that pre-computes XP
   thresholds for each (scaling, custom_formula) combination and uses
   `bisect_right` for O(log n) lookup on the pre-computed list. The cache
   builds thresholds lazily, only computing up to the needed level + buffer,
   and extends incrementally as higher XP values are queried.

2. **minigames/addLevelXp.py** — Updated `fetch_xp_details` to use
   `_get_cached_config` directly instead of separate `get_xp_scaling` and
   `get_custom_formula` async function calls, reducing per-message config
   fetch overhead to a cache lookup.

3. **loops/level.py** — Same update for voice XP tracking: `fetch_xp_details`
   now uses `_get_cached_config` for scaling and custom formula.

### Benefits

- **Pre-computed thresholds**: `get_level_for_xp` becomes a dict lookup +
  bisect on pre-computed array instead of O(log n) binary search calling
  `get_xp_for_level` (which evaluates a lambda or custom formula) each
  iteration.
- **Reduced per-call overhead**: Custom formula evaluation only happens
  during cache construction, not on every message.
- **Fewer function calls**: Config values fetched from the already-existing
  `_get_cached_config` TTL cache instead of separate DB-backed functions.

Fixes #1345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster XP config retrieval via improved caching.
  * More efficient XP→level calculations using precomputed thresholds, reducing lag for level lookups and checks.

* **Stability**
  * Simplified XP awarding flow reduces overhead when granting XP.
  * More reliable level-up detection, notifications, and role updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->