### PR TITLE
Optimize Twitch API polling: reduce interval to 60s and batch notifications

### DIFF
--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -110,7 +110,7 @@ class LoopCog(commands.Cog):
         except Exception:
             logging.exception("Error in loop")
 
-    @tasks.loop(seconds=10)
+    @tasks.loop(seconds=60)  # Reduced from 10s to 60s to respect Twitch API rate limits
     async def pollTwitchStreams(self) -> None:
         try:
             twitch_api = getTwitchApi()
@@ -132,16 +132,23 @@ class LoopCog(commands.Cog):
             streams = await twitch_api.get_streams(user_ids)
             live_streams = {stream["user_id"]: stream for stream in streams}
 
-            # Check for newly live streams
+            # Batch notification for streams going live simultaneously
+            newly_live = [
+                uuid for uuid in user_ids
+                if not twitch_api.stream_status.get(uuid, False)
+                and uuid in live_streams
+            ]
+
+            if newly_live:
+                await asyncio.gather(
+                    *(notify_twitch_online(self.bot, uuid, live_streams[uuid])
+                      for uuid in newly_live),
+                    return_exceptions=True,
+                )
+
+            # Update status for all tracked uuids
             for uuid in user_ids:
-                was_live = twitch_api.stream_status.get(uuid, False)
-                is_live = uuid in live_streams
-
-                if not was_live and is_live:
-                    # Stream just went live
-                    await notify_twitch_online(self.bot, uuid, live_streams[uuid])
-
-                twitch_api.stream_status[uuid] = is_live
+                twitch_api.stream_status[uuid] = uuid in live_streams
 
         except Exception:
             logging.exception("Error in loop")

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -133,16 +133,11 @@ class LoopCog(commands.Cog):
             live_streams = {stream["user_id"]: stream for stream in streams}
 
             # Batch notification for streams going live simultaneously
-            newly_live = [
-                uuid for uuid in user_ids
-                if not twitch_api.stream_status.get(uuid, False)
-                and uuid in live_streams
-            ]
+            newly_live = [uuid for uuid in user_ids if not twitch_api.stream_status.get(uuid, False) and uuid in live_streams]
 
             if newly_live:
                 await asyncio.gather(
-                    *(notify_twitch_online(self.bot, uuid, live_streams[uuid])
-                      for uuid in newly_live),
+                    *(notify_twitch_online(self.bot, uuid, live_streams[uuid]) for uuid in newly_live),
                     return_exceptions=True,
                 )
 


### PR DESCRIPTION
## Changes

1. Reduced Twitch stream polling interval from **10s to 60s** (~83% fewer API calls)
2. Batch notifications using **asyncio.gather** for streams going live simultaneously (parallel instead of sequential)
3. Simplified stream status tracking to use a boolean expression

## Benefits

- Respects Twitch API rate limits comfortably (~1 req/min instead of 6 req/min)
- Multiple streams going live at once notify concurrently
- Reduced database load from fewer UUID lookups

Closes #1366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Adjusted Twitch stream polling interval from 10 to 60 seconds
  * Optimized newly live stream notifications using concurrent processing instead of sequential checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->