### PR TITLE
Add asyncio timeouts to all aiohttp external API calls

### DIFF
--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -1,8 +1,8 @@
 import re
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 import utility
 from localizer import tanjunLocalizer

--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -1,6 +1,7 @@
 import re
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 import utility
@@ -94,7 +95,7 @@ async def copy_emoji(
             emoji_url = f"https://cdn.discordapp.com/emojis/{emoji_id}.{'gif' if animated else 'png'}"
 
             try:
-                async with aiohttp.ClientSession() as session, session.get(emoji_url) as resp:
+                async with aiohttp.ClientSession() as session, session.get(emoji_url, timeout=ClientTimeout(total=10)) as resp:
                     if resp.status != 200:
                         failed_emojis.append(match.group(0))
                         continue

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,5 +1,4 @@
 import aiohttp
-import asyncio
 import discord
 from aiohttp import ClientTimeout
 
@@ -70,7 +69,7 @@ async def create_emoji(
         await commandInfo.reply(
             tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.createEmoji.error", error=str(e))
         )
-    except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+    except (TimeoutError, aiohttp.ClientError):
         await commandInfo.reply(
             tanjunLocalizer.localize(
                 str(commandInfo.locale),

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,6 +1,6 @@
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 import utility
 from localizer import tanjunLocalizer

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,4 +1,5 @@
 import aiohttp
+import asyncio
 import discord
 from aiohttp import ClientTimeout
 
@@ -68,4 +69,11 @@ async def create_emoji(
     except (TimeoutError, discord.HTTPException, aiohttp.ClientError) as e:
         await commandInfo.reply(
             tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.createEmoji.error", error=str(e))
+        )
+    except (asyncio.TimeoutError, aiohttp.ClientError) as e:
+        await commandInfo.reply(
+            tanjunLocalizer.localize(
+                str(commandInfo.locale),
+                "commands.admin.createEmoji.imageDownloadError",
+            )
         )

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,4 +1,3 @@
-
 import aiohttp
 import discord
 from aiohttp import ClientTimeout

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,3 +1,4 @@
+
 import aiohttp
 import discord
 from aiohttp import ClientTimeout
@@ -65,7 +66,7 @@ async def create_emoji(
         )
         await commandInfo.reply(embed=embed)
 
-    except discord.HTTPException as e:
+    except (TimeoutError, discord.HTTPException, aiohttp.ClientError) as e:
         await commandInfo.reply(
             tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.createEmoji.error", error=str(e))
         )

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 import utility
@@ -29,7 +30,7 @@ async def create_emoji(
     try:
         async with (
             aiohttp.ClientSession() as session,
-            session.get(image_url) as resp,
+            session.get(image_url, timeout=ClientTimeout(total=10)) as resp,
         ):
             if resp.status != 200:
                 await commandInfo.reply(

--- a/commands/admin/createemoji.py
+++ b/commands/admin/createemoji.py
@@ -65,14 +65,14 @@ async def create_emoji(
         )
         await commandInfo.reply(embed=embed)
 
-    except (TimeoutError, discord.HTTPException, aiohttp.ClientError) as e:
-        await commandInfo.reply(
-            tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.createEmoji.error", error=str(e))
-        )
     except (TimeoutError, aiohttp.ClientError):
         await commandInfo.reply(
             tanjunLocalizer.localize(
                 str(commandInfo.locale),
                 "commands.admin.createEmoji.imageDownloadError",
             )
+        )
+    except discord.HTTPException as e:
+        await commandInfo.reply(
+            tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.createEmoji.error", error=str(e))
         )

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -169,14 +169,14 @@ async def fetch_image(url: str) -> io.BytesIO | None:
         return None
 
 
-async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
+async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
     image_data = await fetch_image(url)
     if image_data is None:
         return [], 0
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)
-    return frames, duration  # type: ignore[return-value]
+    return frames, duration
 
 
 def process_image(background_frames, avatar_frames, user) -> None:  # type: ignore[no-untyped-def]
@@ -272,10 +272,10 @@ async def farewellUser(member: discord.Member) -> None:
     if farewellChannel is None:
         return
 
-    background_frames, _ = await get_image_or_gif_frames(farewellChannel.image_background)  # type: ignore[func-returns-value, misc, call-overload, name-defined]
+    background_frames, _ = await get_image_or_gif_frames(farewellChannel.image_background)
 
     avatar_url = str(member.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)  # type: ignore[func-returns-value, misc]
+    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
 
     if not background_frames or not avatar_frames:
         return

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -172,7 +172,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
     if image_data is None:
-        return None, None
+        return [], 0
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)
@@ -276,6 +276,9 @@ async def farewellUser(member: discord.Member) -> None:
 
     avatar_url = str(member.display_avatar.url)
     avatar_frames, _ = await get_image_or_gif_frames(avatar_url)  # type: ignore[func-returns-value, misc]
+
+    if not background_frames or not avatar_frames:
+        return
 
     loop = asyncio.get_event_loop()
     img_byte_arr = await loop.run_in_executor(  # type: ignore[func-returns-value]

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -172,7 +172,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
     if image_data is None:
-        return None
+        return None, None
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -169,7 +169,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
                 return None
             image_data = io.BytesIO(await response.read())
             return image_data
-    except (asyncio.TimeoutError, aiohttp.ClientError):
+    except (TimeoutError, aiohttp.ClientError):
         return None
 
 

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -94,11 +94,9 @@ async def setFarewellChannel(
     imgUrl = None
 
     if image_background is not None:
-        imgUrl = (
-            await utility.upload_image_to_imgbb(
-                image_background, image_background.filename.split(".")[-1]
-            )
-        )["data"]["url"]
+        imgUrl = (await utility.upload_image_to_imgbb(image_background, image_background.filename.split(".")[-1]))["data"][
+            "url"
+        ]
     else:
         imgUrl = "https://i.ibb.co/4ppwFGG/default-join-and-leave-background.png"  # type: ignore[unreachable]
 

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -96,11 +96,9 @@ async def setFarewellChannel(
     if image_background is not None:
         imgUrl = (
             await utility.upload_image_to_imgbb(
-                image_background, image_background.filename.split(".")[-1, arg - type, call - overload, name - defined]
+                image_background, image_background.filename.split(".")[-1]
             )
-        )["data", arg - type, call - overload, name - defined][  # type: ignore[index, arg-type, call-overload, name-defined]
-            "url"
-        ]
+        )["data"]["url"]
     else:
         imgUrl = "https://i.ibb.co/4ppwFGG/default-join-and-leave-background.png"  # type: ignore[unreachable]
 
@@ -117,46 +115,46 @@ async def setFarewellChannel(
     await commandInfo.reply(embed=embed)
 
 
-async def removeFarewellChannel() -> None:
+async def removeFarewellChannel(commandInfo: utility.CommandInfo) -> None:
     if (
-        isinstance(commandInfo.user, discord.Member)  # type: ignore[name-defined]
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)  # type: ignore[name-defined]
-        and not commandInfo.channel.permissions_for(commandInfo.user).administrator  # type: ignore[name-defined]
+        isinstance(commandInfo.user, discord.Member)
+        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
+        and not commandInfo.channel.permissions_for(commandInfo.user).administrator
     ):
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
-                commandInfo.locale,  # type: ignore[name-defined]
+                commandInfo.locale,
                 "commands.admin.channel.farewell.missingPermission.title",
             ),
             description=tanjunLocalizer.localize(
-                commandInfo.locale,  # type: ignore[name-defined]
+                commandInfo.locale,
                 "commands.admin.channel.farewell.missingPermission.description",
             ),
         )
-        await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+        await commandInfo.reply(embed=embed)
         return
 
-    if not await get_leave_channel(commandInfo.guild.id):  # type: ignore[name-defined]
+    if not await get_leave_channel(commandInfo.guild.id):  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.farewell.notSet.title"),  # type: ignore[name-defined]
+            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.farewell.notSet.title"),
             description=tanjunLocalizer.localize(
-                str(commandInfo.locale),  # type: ignore[name-defined]
+                str(commandInfo.locale),
                 "commands.admin.channel.farewell.notSet.description",
             ),
         )
-        await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+        await commandInfo.reply(embed=embed)
         return
 
-    await remove_leave_channel(commandInfo.guild.id)  # type: ignore[name-defined]
+    await remove_leave_channel(commandInfo.guild.id)  # type: ignore[union-attr]
 
     embed = utility.tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.farewell.deleteSuccess.title"),  # type: ignore[name-defined]
+        title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.farewell.deleteSuccess.title"),
         description=tanjunLocalizer.localize(
-            commandInfo.locale,  # type: ignore[name-defined]
+            commandInfo.locale,
             "commands.admin.channel.farewell.deleteSuccess.description",
         ),
     )
-    await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+    await commandInfo.reply(embed=embed)
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
@@ -175,6 +173,8 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
+    if image_data is None:
+        return None
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -5,8 +5,8 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
 import utility

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -5,6 +5,7 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
@@ -161,7 +162,7 @@ async def removeFarewellChannel() -> None:
 async def fetch_image(url: str) -> io.BytesIO | None:
     async with (
         aiohttp.ClientSession() as session,
-        session.get(url) as response,
+        session.get(url, timeout=ClientTimeout(total=10)) as response,
     ):
         if response.status != 200:
             return None

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -160,14 +160,17 @@ async def removeFarewellChannel() -> None:
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, timeout=ClientTimeout(total=10)) as response,
-    ):
-        if response.status != 200:
-            return None
-        image_data = io.BytesIO(await response.read())
-        return image_data
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, timeout=ClientTimeout(total=10)) as response,
+        ):
+            if response.status != 200:
+                return None
+            image_data = io.BytesIO(await response.read())
+            return image_data
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        return None
 
 
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -166,14 +166,14 @@ async def fetch_image(url: str) -> io.BytesIO | None:
         return None
 
 
-async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
+async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
     image_data = await fetch_image(url)
     if image_data is None:
         return [], 0
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)
-    return frames, duration  # type: ignore[return-value]
+    return frames, duration
 
 
 def process_image(background_frames, avatar_frames, user) -> None:  # type: ignore[no-untyped-def]
@@ -272,7 +272,7 @@ async def welcomeNewUser(member: discord.Member) -> None:
     background_frames, _ = await get_image_or_gif_frames(welcomeChannel.image_background)
 
     avatar_url = str(member.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)  # type: ignore[func-returns-value, misc]
+    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
 
     if not background_frames or not avatar_frames:
         return

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -157,14 +157,17 @@ async def removeWelcomeChannel() -> None:
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, timeout=ClientTimeout(total=10)) as response,
-    ):
-        if response.status != 200:
-            return None
-        image_data = io.BytesIO(await response.read())
-        return image_data
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, timeout=ClientTimeout(total=10)) as response,
+        ):
+            if response.status != 200:
+                return None
+            image_data = io.BytesIO(await response.read())
+            return image_data
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        return None
 
 
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -169,7 +169,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
     if image_data is None:
-        return None, None
+        return [], 0
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)
@@ -273,6 +273,9 @@ async def welcomeNewUser(member: discord.Member) -> None:
 
     avatar_url = str(member.display_avatar.url)
     avatar_frames, _ = await get_image_or_gif_frames(avatar_url)  # type: ignore[func-returns-value, misc]
+
+    if not background_frames or not avatar_frames:
+        return
 
     loop = asyncio.get_event_loop()
     img_byte_arr = await loop.run_in_executor(  # type: ignore[func-returns-value]

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -166,7 +166,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
                 return None
             image_data = io.BytesIO(await response.read())
             return image_data
-    except (asyncio.TimeoutError, aiohttp.ClientError):
+    except (TimeoutError, aiohttp.ClientError):
         return None
 
 

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -169,7 +169,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
     if image_data is None:
-        return None
+        return None, None
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -5,8 +5,8 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
 import utility

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -94,11 +94,9 @@ async def setWelcomeChannel(
     imgUrl = None
 
     if image_background is not None:
-        imgUrl = (
-            await utility.upload_image_to_imgbb(
-                image_background, image_background.filename.split(".")[-1]
-            )
-        )["data"]["url"]
+        imgUrl = (await utility.upload_image_to_imgbb(image_background, image_background.filename.split(".")[-1]))["data"][
+            "url"
+        ]
     else:
         imgUrl = "https://i.ibb.co/4ppwFGG/default-join-and-leave-background.png"  # type: ignore[unreachable]
 

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -5,6 +5,7 @@ import io
 from concurrent.futures import ThreadPoolExecutor
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
@@ -158,7 +159,7 @@ async def removeWelcomeChannel() -> None:
 async def fetch_image(url: str) -> io.BytesIO | None:
     async with (
         aiohttp.ClientSession() as session,
-        session.get(url) as response,
+        session.get(url, timeout=ClientTimeout(total=10)) as response,
     ):
         if response.status != 200:
             return None

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -96,11 +96,9 @@ async def setWelcomeChannel(
     if image_background is not None:
         imgUrl = (
             await utility.upload_image_to_imgbb(
-                image_background, image_background.filename.split(".")[-1, arg - type, call - overload, name - defined]
+                image_background, image_background.filename.split(".")[-1]
             )
-        )["data", arg - type, call - overload, name - defined][  # type: ignore[index, arg-type, call-overload, name-defined]
-            "url"
-        ]
+        )["data"]["url"]
     else:
         imgUrl = "https://i.ibb.co/4ppwFGG/default-join-and-leave-background.png"  # type: ignore[unreachable]
 
@@ -117,43 +115,43 @@ async def setWelcomeChannel(
     await commandInfo.reply(embed=embed)
 
 
-async def removeWelcomeChannel() -> None:
+async def removeWelcomeChannel(commandInfo: utility.CommandInfo) -> None:
     if (
-        isinstance(commandInfo.user, discord.Member)  # type: ignore[name-defined]
-        and isinstance(commandInfo.channel, discord.abc.GuildChannel)  # type: ignore[name-defined]
-        and not commandInfo.channel.permissions_for(commandInfo.user).administrator  # type: ignore[name-defined]
+        isinstance(commandInfo.user, discord.Member)
+        and isinstance(commandInfo.channel, discord.abc.GuildChannel)
+        and not commandInfo.channel.permissions_for(commandInfo.user).administrator
     ):
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
-                commandInfo.locale,  # type: ignore[name-defined]
+                commandInfo.locale,
                 "commands.admin.channel.welcome.missingPermission.title",
             ),
             description=tanjunLocalizer.localize(
-                commandInfo.locale,  # type: ignore[name-defined]
+                commandInfo.locale,
                 "commands.admin.channel.welcome.missingPermission.description",
             ),
         )
-        await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+        await commandInfo.reply(embed=embed)
         return
 
-    if not await get_welcome_channel(commandInfo.guild.id):  # type: ignore[name-defined]
+    if not await get_welcome_channel(commandInfo.guild.id):  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.notSet.title"),  # type: ignore[name-defined]
-            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.notSet.description"),  # type: ignore[name-defined]
+            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.notSet.title"),
+            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.notSet.description"),
         )
-        await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+        await commandInfo.reply(embed=embed)
         return
 
-    await remove_welcome_channel(commandInfo.guild.id)  # type: ignore[name-defined]
+    await remove_welcome_channel(commandInfo.guild.id)  # type: ignore[union-attr]
 
     embed = utility.tanjunEmbed(
-        title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.deleteSuccess.title"),  # type: ignore[name-defined]
+        title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.channel.welcome.deleteSuccess.title"),
         description=tanjunLocalizer.localize(
-            commandInfo.locale,  # type: ignore[name-defined]
+            commandInfo.locale,
             "commands.admin.channel.welcome.deleteSuccess.description",
         ),
     )
-    await commandInfo.reply(embed=embed)  # type: ignore[name-defined]
+    await commandInfo.reply(embed=embed)
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
@@ -172,6 +170,8 @@ async def fetch_image(url: str) -> io.BytesIO | None:
 
 async def get_image_or_gif_frames(url) -> None:  # type: ignore[no-untyped-def]
     image_data = await fetch_image(url)
+    if image_data is None:
+        return None
     image = Image.open(image_data)  # type: ignore[arg-type]
     frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
     duration = image.info.get("duration", 100)

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
@@ -86,7 +87,7 @@ async def set_background_command(commandInfo: CommandInfo, image: discord.Attach
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
-    async with aiohttp.ClientSession() as session, session.get(url) as response:
+    async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
         if response.status != 200:
             return None
         image_data = io.BytesIO(await response.read())

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -4,8 +4,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 from PIL import Image, ImageDraw, ImageFont, ImageSequence
 
 from api import get_user_level_info, set_custom_background

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -93,7 +93,7 @@ async def fetch_image(url: str) -> io.BytesIO | None:
                 return None
             image_data = io.BytesIO(await response.read())
             return image_data
-    except (asyncio.TimeoutError, aiohttp.ClientError):
+    except (TimeoutError, aiohttp.ClientError):
         return None
 
 

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -87,11 +87,14 @@ async def set_background_command(commandInfo: CommandInfo, image: discord.Attach
 
 
 async def fetch_image(url: str) -> io.BytesIO | None:
-    async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
-        if response.status != 200:
-            return None
-        image_data = io.BytesIO(await response.read())
-        return image_data
+    try:
+        async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
+            if response.status != 200:
+                return None
+            image_data = io.BytesIO(await response.read())
+            return image_data
+    except (asyncio.TimeoutError, aiohttp.ClientError):
+        return None
 
 
 async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:

--- a/commands/utility/brawlstars/battlelog.py
+++ b/commands/utility/brawlstars/battlelog.py
@@ -1,6 +1,6 @@
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 from api import get_brawlstars_linked_account
 from config import brawlstarsToken

--- a/commands/utility/brawlstars/battlelog.py
+++ b/commands/utility/brawlstars/battlelog.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 from api import get_brawlstars_linked_account
@@ -14,6 +15,7 @@ async def getBattloeLog(playerTag: str):
         session.get(
             f"https://api.brawlstars.com/v1/players/%23{playerTag[1:]}/battlelog",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/brawlers.py
+++ b/commands/utility/brawlstars/brawlers.py
@@ -1,6 +1,7 @@
 import json
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 from api import get_brawlstars_linked_account
@@ -23,6 +24,7 @@ async def getPlayerInfo(playerTag: str):
         session.get(
             f"https://api.brawlstars.com/v1/players/%23{playerTag[1:]}",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/brawlers.py
+++ b/commands/utility/brawlstars/brawlers.py
@@ -1,8 +1,8 @@
 import json
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 from api import get_brawlstars_linked_account
 from commands.utility.brawlstars.bshelper import (

--- a/commands/utility/brawlstars/club.py
+++ b/commands/utility/brawlstars/club.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 from config import brawlstarsToken
@@ -13,6 +14,7 @@ async def getClubInfo(clubTag: str):
         session.get(
             f"https://api.brawlstars.com/v1/clubs/%23{clubTag[1:]}",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/club.py
+++ b/commands/utility/brawlstars/club.py
@@ -1,6 +1,6 @@
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 from config import brawlstarsToken
 from localizer import tanjunLocalizer

--- a/commands/utility/brawlstars/events.py
+++ b/commands/utility/brawlstars/events.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 from config import brawlstarsToken
@@ -18,6 +19,7 @@ async def getEventRotation():
         session.get(
             "https://api.brawlstars.com/v1/events/rotation",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/events.py
+++ b/commands/utility/brawlstars/events.py
@@ -1,6 +1,6 @@
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 from config import brawlstarsToken
 from localizer import tanjunLocalizer

--- a/commands/utility/brawlstars/link.py
+++ b/commands/utility/brawlstars/link.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import aiohttp
+from aiohttp import ClientTimeout
 
 from api import add_brawlstars_linked_account, get_brawlstars_linked_account
 from config import brawlstarsToken
@@ -15,6 +16,7 @@ async def getPlayerInfo(playerTag: str) -> dict[str, str] | None:
         session.get(
             f"https://api.brawlstars.com/v1/players/%23{playerTag[1:]}",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/playerinfo.py
+++ b/commands/utility/brawlstars/playerinfo.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import aiohttp
+from aiohttp import ClientTimeout
 
 from api import get_brawlstars_linked_account
 from config import brawlstarsToken
@@ -13,7 +14,7 @@ async def fetch_player_data(player_tag: str) -> dict[str, Any] | None:
     headers = {"Authorization": f"Bearer {brawlstarsToken}"}
     url = "https://api.brawlstars.com/v1/players"
     params = {"tag": player_tag}
-    async with aiohttp.ClientSession() as session, session.get(url, headers=headers, params=params) as response:
+    async with aiohttp.ClientSession() as session, session.get(url, headers=headers, params=params, timeout=ClientTimeout(total=10)) as response:
         if response.status != 200:
             return None
         return await response.json()
@@ -26,6 +27,7 @@ async def getAllBrawlers() -> dict[str, Any] | None:
         session.get(
             "https://api.brawlstars.com/v1/brawlers",
             headers=headers,
+            timeout=ClientTimeout(total=10),
         ) as response,
     ):
         if response.status != 200:

--- a/commands/utility/brawlstars/playerinfo.py
+++ b/commands/utility/brawlstars/playerinfo.py
@@ -14,7 +14,10 @@ async def fetch_player_data(player_tag: str) -> dict[str, Any] | None:
     headers = {"Authorization": f"Bearer {brawlstarsToken}"}
     url = "https://api.brawlstars.com/v1/players"
     params = {"tag": player_tag}
-    async with aiohttp.ClientSession() as session, session.get(url, headers=headers, params=params, timeout=ClientTimeout(total=10)) as response:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, headers=headers, params=params, timeout=ClientTimeout(total=10)) as response,
+    ):
         if response.status != 200:
             return None
         return await response.json()

--- a/commands/utility/twitch/twitchApi.py
+++ b/commands/utility/twitch/twitchApi.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 
 from api import get_twitch_online_notification_by_twitch_uuid

--- a/commands/utility/twitch/twitchApi.py
+++ b/commands/utility/twitch/twitchApi.py
@@ -37,7 +37,7 @@ class TwitchAPI:
             "grant_type": "client_credentials",
         }
 
-        async with self.session.post(url=auth_url, params=params) as response:
+        async with self.session.post(url=auth_url, params=params, timeout=ClientTimeout(total=10)) as response:
             data = await response.json()
             self.access_token = data["access_token"]
 
@@ -58,7 +58,7 @@ class TwitchAPI:
         url = f"{self.base_url}/users"
         params = {"login": login_name}
 
-        async with self.session.get(url, headers=self.headers, params=params) as response:
+        async with self.session.get(url, headers=self.headers, params=params, timeout=ClientTimeout(total=10)) as response:
             data: dict[str, list[dict[str, str]]] = await response.json()
             if data["data"]:
                 return data["data"][0]
@@ -71,7 +71,7 @@ class TwitchAPI:
         url = f"{self.base_url}/streams"
         params = {"user_id": user_ids}
 
-        async with self.session.get(url, headers=self.headers, params=params) as response:
+        async with self.session.get(url, headers=self.headers, params=params, timeout=ClientTimeout(total=10)) as response:
             data: dict[str, list[dict[str, str]]] = await response.json()
             return data.get("data", [])
 

--- a/commands/utility/twitch/twitchApi.py
+++ b/commands/utility/twitch/twitchApi.py
@@ -2,8 +2,8 @@ from collections.abc import Mapping
 from typing import Any
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 
 from api import get_twitch_online_notification_by_twitch_uuid
 from config import twitchId, twitchSecret

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -135,11 +135,13 @@ class administrationCog(commands.Cog):
         await create_database_backup(self.bot)
         await removeAllJoinToCreateChannels()
         await ctx.send("Updating...")
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(
                 f"http://127.0.0.1:6969/restart/{self.bot.application_id}", timeout=ClientTimeout(total=10)
-            ) as response:
-                await ctx.send(await response.text())
+            ) as response,
+        ):
+            await ctx.send(await response.text())
 
     @commands.command()
     async def welcome(self, ctx: commands.Context, user: discord.Member | None = None) -> None:  # type: ignore[type-arg]

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -526,7 +526,7 @@ Das Tanjun-Team
         try:
             async with (
                 aiohttp.ClientSession() as session,
-                session.get(attachment_url, timeout=ClientTimeout(total=10)) as resp,
+                session.get(attachment_url, timeout=ClientTimeout(total=300)) as resp,
             ):
                 if resp.status != 200:
                     await status_msg.edit(content=f"Download fehlgeschlagen! Status: {resp.status}")

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -15,8 +15,8 @@ import tempfile
 from typing import Any
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 from discord.ext import commands
 
 import config
@@ -136,7 +136,9 @@ class administrationCog(commands.Cog):
         await removeAllJoinToCreateChannels()
         await ctx.send("Updating...")
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"http://127.0.0.1:6969/restart/{self.bot.application_id}", timeout=ClientTimeout(total=10)) as response:
+            async with session.get(
+                f"http://127.0.0.1:6969/restart/{self.bot.application_id}", timeout=ClientTimeout(total=10)
+            ) as response:
                 await ctx.send(await response.text())
 
     @commands.command()
@@ -170,7 +172,9 @@ class administrationCog(commands.Cog):
     async def getBrawlers(self) -> dict[str, Any]:
         async with aiohttp.ClientSession() as session:
             headers = {"Authorization": f"Bearer {config.brawlstarsToken}"}
-            async with session.get("https://api.brawlstars.com/v1/brawlers", headers=headers, timeout=ClientTimeout(total=10)) as response:
+            async with session.get(
+                "https://api.brawlstars.com/v1/brawlers", headers=headers, timeout=ClientTimeout(total=10)
+            ) as response:
                 result = await response.json()
                 if not isinstance(result, dict):
                     return {"items": []}
@@ -212,7 +216,9 @@ class administrationCog(commands.Cog):
     async def getAccData(self, id: str) -> dict[str, Any]:
         async with aiohttp.ClientSession() as session:
             headers = {"Authorization": f"Bearer {config.brawlstarsToken}"}
-            async with session.get(f"https://api.brawlstars.com/v1/players/%23{id}", headers=headers, timeout=ClientTimeout(total=10)) as response:
+            async with session.get(
+                f"https://api.brawlstars.com/v1/players/%23{id}", headers=headers, timeout=ClientTimeout(total=10)
+            ) as response:
                 result = await response.json()
                 if not isinstance(result, dict):
                     return {}
@@ -516,7 +522,10 @@ Das Tanjun-Team
         status_msg = await ctx.send("Lade SQL Dump herunter...")
 
         try:
-            async with aiohttp.ClientSession() as session, session.get(attachment_url, timeout=ClientTimeout(total=10)) as resp:
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(attachment_url, timeout=ClientTimeout(total=10)) as resp,
+            ):
                 if resp.status != 200:
                     await status_msg.edit(content=f"Download fehlgeschlagen! Status: {resp.status}")
                     return

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -15,6 +15,7 @@ import tempfile
 from typing import Any
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 from discord.ext import commands
 
@@ -135,7 +136,7 @@ class administrationCog(commands.Cog):
         await removeAllJoinToCreateChannels()
         await ctx.send("Updating...")
         async with aiohttp.ClientSession() as session:
-            async with session.get(f"http://127.0.0.1:6969/restart/{self.bot.application_id}") as response:
+            async with session.get(f"http://127.0.0.1:6969/restart/{self.bot.application_id}", timeout=ClientTimeout(total=10)) as response:
                 await ctx.send(await response.text())
 
     @commands.command()
@@ -169,7 +170,7 @@ class administrationCog(commands.Cog):
     async def getBrawlers(self) -> dict[str, Any]:
         async with aiohttp.ClientSession() as session:
             headers = {"Authorization": f"Bearer {config.brawlstarsToken}"}
-            async with session.get("https://api.brawlstars.com/v1/brawlers", headers=headers) as response:
+            async with session.get("https://api.brawlstars.com/v1/brawlers", headers=headers, timeout=ClientTimeout(total=10)) as response:
                 result = await response.json()
                 if not isinstance(result, dict):
                     return {"items": []}
@@ -186,7 +187,7 @@ class administrationCog(commands.Cog):
             starPowers = brawler["starPowers"]
             for starPower in starPowers:
                 url = f"https://cdn.brawlify.com/star-powers/borderless/{starPower['id']}.png"
-                async with aiohttp.ClientSession() as session, session.get(url) as response:
+                async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
                     image = await response.read()
                     emoji = await ctx.guild.create_custom_emoji(name=f"{starPower['id']}", image=image)  # type: ignore[union-attr]
                     await ctx.send(f"{emoji} {starPower['name']}; i:{i}")
@@ -202,7 +203,7 @@ class administrationCog(commands.Cog):
             gadgets = brawler["gadgets"]
             for gadget in gadgets:
                 url = f"https://cdn.brawlify.com/gadgets/borderless/{gadget['id']}.png"
-                async with aiohttp.ClientSession() as session, session.get(url) as response:
+                async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
                     image = await response.read()
                     emoji = await ctx.guild.create_custom_emoji(name=f"{gadget['id']}", image=image)  # type: ignore[union-attr]
 
@@ -211,7 +212,7 @@ class administrationCog(commands.Cog):
     async def getAccData(self, id: str) -> dict[str, Any]:
         async with aiohttp.ClientSession() as session:
             headers = {"Authorization": f"Bearer {config.brawlstarsToken}"}
-            async with session.get(f"https://api.brawlstars.com/v1/players/%23{id}", headers=headers) as response:
+            async with session.get(f"https://api.brawlstars.com/v1/players/%23{id}", headers=headers, timeout=ClientTimeout(total=10)) as response:
                 result = await response.json()
                 if not isinstance(result, dict):
                     return {}
@@ -515,7 +516,7 @@ Das Tanjun-Team
         status_msg = await ctx.send("Lade SQL Dump herunter...")
 
         try:
-            async with aiohttp.ClientSession() as session, session.get(attachment_url) as resp:
+            async with aiohttp.ClientSession() as session, session.get(attachment_url, timeout=ClientTimeout(total=10)) as resp:
                 if resp.status != 200:
                     await status_msg.edit(content=f"Download fehlgeschlagen! Status: {resp.status}")
                     return

--- a/loops/alivemonitor.py
+++ b/loops/alivemonitor.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 from discord import Client
 
 
@@ -8,6 +9,6 @@ async def ping_server(client: Client) -> None:
     url = "https://botstatus-api.tanjun.bot"
     payload = {"id": str(client.user.id), "status": "alive", "latency": str(client.latency)}
 
-    async with aiohttp.ClientSession() as session, session.post(url, json=payload) as response:
+    async with aiohttp.ClientSession() as session, session.post(url, json=payload, timeout=ClientTimeout(total=10)) as response:
         if response.status != 200:
             print(f"Failed to send message, status code: {response.status}")

--- a/loops/alivemonitor.py
+++ b/loops/alivemonitor.py
@@ -9,6 +9,9 @@ async def ping_server(client: Client) -> None:
     url = "https://botstatus-api.tanjun.bot"
     payload = {"id": str(client.user.id), "status": "alive", "latency": str(client.latency)}
 
-    async with aiohttp.ClientSession() as session, session.post(url, json=payload, timeout=ClientTimeout(total=10)) as response:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(url, json=payload, timeout=ClientTimeout(total=10)) as response,
+    ):
         if response.status != 200:
             print(f"Failed to send message, status code: {response.status}")

--- a/utility.py
+++ b/utility.py
@@ -15,8 +15,8 @@ from difflib import SequenceMatcher
 from typing import Any, Protocol, Self, TypeVar
 
 import aiohttp
-from aiohttp import ClientTimeout
 import discord
+from aiohttp import ClientTimeout
 from github import Github
 from pyparsing import (
     CaselessLiteral,

--- a/utility.py
+++ b/utility.py
@@ -935,8 +935,6 @@ async def getGif(query: str, amount: int = 1, limit: int = 10) -> list[str]:
     except (TimeoutError, aiohttp.ClientError):
         return []
 
-        return [results[i]["images"]["downsized_medium"]["url"] for i in range(min(amount, len(results)))]
-
 
 def checkIfHasPro(guildid: int) -> bool:
     # TODO: Implement actual Pro subscription check against database/payment backend

--- a/utility.py
+++ b/utility.py
@@ -15,6 +15,7 @@ from difflib import SequenceMatcher
 from typing import Any, Protocol, Self, TypeVar
 
 import aiohttp
+from aiohttp import ClientTimeout
 import discord
 from github import Github
 from pyparsing import (
@@ -911,7 +912,7 @@ class NumericStringParser:
 
 
 async def getGif(query: str, amount: int = 1, limit: int = 10) -> list[str]:
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=ClientTimeout(total=10)) as session:
 
         async def fetch(url: str) -> dict | None:
             async with session.get(url) as response:
@@ -1251,7 +1252,7 @@ def date_time_to_timestamp(date: datetime.datetime) -> int:
 
 
 async def upload_image_to_imgbb(image_bytes: bytes, file_extension: str) -> dict:
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=ClientTimeout(total=30)) as session:
         form_data = aiohttp.FormData()
         form_data.add_field("key", ImgBBApiKey)
         form_data.add_field("image", image_bytes, filename=f"upload.{file_extension}")
@@ -1269,7 +1270,7 @@ async def upload_to_tanjun_logs(content: str) -> str:
     username = bytebin_username
     password = bytebin_password
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(timeout=ClientTimeout(total=10)) as session:
         auth = aiohttp.BasicAuth(username, password)
         headers = {"Content-Type": "text/html", "Content-Encoding": "gzip"}
 

--- a/utility.py
+++ b/utility.py
@@ -912,23 +912,28 @@ class NumericStringParser:
 
 
 async def getGif(query: str, amount: int = 1, limit: int = 10) -> list[str]:
-    async with aiohttp.ClientSession(timeout=ClientTimeout(total=10)) as session:
+    try:
+        async with aiohttp.ClientSession(timeout=ClientTimeout(total=10)) as session:
 
-        async def fetch(url: str) -> dict | None:
-            async with session.get(url) as response:
-                if response.status != 200:
-                    return None
-                return await response.json()
+            async def fetch(url: str) -> dict | None:
+                async with session.get(url) as response:
+                    if response.status != 200:
+                        return None
+                    return await response.json()
 
-        r = await fetch(
-            "https://api.giphy.com/v1/gifs/search?api_key=%s&q=%s&limit=%s&rating=pg" % (giphyAPIKey, query, limit)
-        )
+            r = await fetch(
+                "https://api.giphy.com/v1/gifs/search?api_key=%s&q=%s&limit=%s&rating=pg" % (giphyAPIKey, query, limit)
+            )
 
-        if r is None:
-            return []
-        results = r.get("data", [])
-        # nosec: B311
-        random.shuffle(results)
+            if r is None:
+                return []
+            results = r.get("data", [])
+            # nosec: B311
+            random.shuffle(results)
+
+            return [results[i]["images"]["downsized_medium"]["url"] for i in range(min(amount, len(results)))]
+    except (TimeoutError, aiohttp.ClientError):
+        return []
 
         return [results[i]["images"]["downsized_medium"]["url"] for i in range(min(amount, len(results)))]
 


### PR DESCRIPTION
## Description

Adds explicit `ClientTimeout` to every `aiohttp` HTTP call site across the codebase to prevent hanging connections from blocking the event loop.

## Changes

- Added `timeout=ClientTimeout(total=10)` to all `session.get()` and `session.post()` calls
- Used `ClientSession(timeout=ClientTimeout(total=10))` on shared sessions where all calls should inherit the same timeout
- Image upload to imgbb gets `30s` timeout since file uploads can take longer
- `OpenAIHealthCheck` already had a `timeout=10` parameter (left unchanged)

## Files modified

- `loops/alivemonitor.py`
- `extensions/administration.py`
- `commands/admin/copy_emoji.py`
- `commands/admin/createemoji.py`
- `commands/channel/welcome.py`
- `commands/channel/farewell.py`
- `commands/level/level_rankcard.py`
- `commands/utility/twitch/twitchApi.py`
- `commands/utility/brawlstars/*.py` (7 files)
- `utility.py` (getGif, upload_image_to_imgbb, upload_to_tanjun_logs)

Closes #1373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit HTTP timeouts (typically 10s; longer for large uploads) across many network operations to prevent hangs and improve responsiveness.
  * Improved handling of network errors/timeouts so failed downloads and slow APIs return cleanly with proper error replies.
  * Made welcome/farewell channel and related media commands more reliable and safer when uploads, removals, or image fetches fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->