### PR TITLE
Add async context manager for database transactions and convert multi-step operations

### DIFF
--- a/api.py
+++ b/api.py
@@ -1279,10 +1279,13 @@ async def delete_level_system_data(guild_id: str) -> None:
         "levelRole",
         "levelConfig",
     ]
-    for table in tables:
-        query = f"DELETE FROM {table} WHERE guild_id = %s"
-        params = (guild_id,)
-        await execute_action(query, params)
+    try:
+        async with transaction() as conn, conn.cursor() as cursor:
+            for table in tables:
+                await cursor.execute(f"DELETE FROM {table} WHERE guild_id = %s", (guild_id,))
+    except Exception as e:
+        print(f"Error deleting level system data for guild {guild_id}: {e}")
+        raise
     _invalidate_guild_cache(guild_id)
 
 
@@ -1798,8 +1801,33 @@ async def set_giveaway_ended(giveaway_id: int) -> None:
 
 
 async def delete_old_giveaways() -> None:
-    query = "DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
-    await execute_action(query)
+    """Delete old ended giveaways and their related data in a single transaction."""
+    try:
+        async with transaction() as conn, conn.cursor() as cursor:
+            # Find old giveaways first
+            await cursor.execute(
+                "SELECT giveawayId FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
+            )
+            old_ids = [row[0] for row in await cursor.fetchall()]
+            if not old_ids:
+                return
+
+            related_tables = [
+                "giveawayChannelRequirement",
+                "giveawayRoleRequirement",
+                "giveawayParticipant",
+                "giveawayVoiceTime",
+                "giveawayNewMessage",
+                "giveawayChannelMessages",
+            ]
+            for give_id in old_ids:
+                for table in related_tables:
+                    await cursor.execute(f"DELETE FROM {table} WHERE giveawayId = %s", (give_id,))
+            await cursor.execute(
+                "DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
+            )
+    except Exception as e:
+        print(f"Error deleting old giveaways: {e}")
 
 
 async def get_giveaway_participants(giveaway_id: int) -> list[str]:
@@ -1946,9 +1974,23 @@ async def get_giveaway_blacklisted_roles(guild_id: str) -> list[GiveawayBlacklis
 
 
 async def delete_giveaway(giveaway_id: int) -> None:
-    query = "DELETE FROM giveaway WHERE giveawayId = %s"
-    params = (giveaway_id,)
-    await execute_action(query, params)
+    """Delete a giveaway and all related data in a single transaction."""
+    related_tables = [
+        "giveawayChannelRequirement",
+        "giveawayRoleRequirement",
+        "giveawayParticipant",
+        "giveawayVoiceTime",
+        "giveawayNewMessage",
+        "giveawayChannelMessages",
+    ]
+    try:
+        async with transaction() as conn, conn.cursor() as cursor:
+            for table in related_tables:
+                await cursor.execute(f"DELETE FROM {table} WHERE giveawayId = %s", (giveaway_id,))
+            await cursor.execute("DELETE FROM giveaway WHERE giveawayId = %s", (giveaway_id,))
+    except Exception as e:
+        print(f"Error deleting giveaway {giveaway_id}: {e}")
+        raise
 
 
 async def set_giveaway_endtime(giveaway_id: int, endtime: datetime) -> None:

--- a/api.py
+++ b/api.py
@@ -1279,10 +1279,22 @@ async def delete_level_system_data(guild_id: str) -> None:
         "levelRole",
         "levelConfig",
     ]
+    # Validated mapping to avoid SQL injection from f-strings
+    table_delete_queries = {
+        "level": "DELETE FROM level WHERE guild_id = %s",
+        "blacklistedUser": "DELETE FROM blacklistedUser WHERE guild_id = %s",
+        "blacklistedRole": "DELETE FROM blacklistedRole WHERE guild_id = %s",
+        "blacklistedChannel": "DELETE FROM blacklistedChannel WHERE guild_id = %s",
+        "userXpBoost": "DELETE FROM userXpBoost WHERE guild_id = %s",
+        "roleXpBoost": "DELETE FROM roleXpBoost WHERE guild_id = %s",
+        "channelXpBoost": "DELETE FROM channelXpBoost WHERE guild_id = %s",
+        "levelRole": "DELETE FROM levelRole WHERE guild_id = %s",
+        "levelConfig": "DELETE FROM levelConfig WHERE guild_id = %s",
+    }
     try:
         async with transaction() as conn, conn.cursor() as cursor:
             for table in tables:
-                await cursor.execute(f"DELETE FROM {table} WHERE guild_id = %s", (guild_id,))
+                await cursor.execute(table_delete_queries[table], (guild_id,))
     except Exception as e:
         print(f"Error deleting level system data for guild {guild_id}: {e}")
         raise
@@ -1824,6 +1836,7 @@ async def delete_old_giveaways() -> None:
             await cursor.execute("DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK")
     except Exception as e:
         print(f"Error deleting old giveaways: {e}")
+        raise
 
 
 async def get_giveaway_participants(giveaway_id: int) -> list[str]:

--- a/api.py
+++ b/api.py
@@ -1805,9 +1805,7 @@ async def delete_old_giveaways() -> None:
     try:
         async with transaction() as conn, conn.cursor() as cursor:
             # Find old giveaways first
-            await cursor.execute(
-                "SELECT giveawayId FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
-            )
+            await cursor.execute("SELECT giveawayId FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK")
             old_ids = [row[0] for row in await cursor.fetchall()]
             if not old_ids:
                 return
@@ -1823,9 +1821,7 @@ async def delete_old_giveaways() -> None:
             for give_id in old_ids:
                 for table in related_tables:
                     await cursor.execute(f"DELETE FROM {table} WHERE giveawayId = %s", (give_id,))
-            await cursor.execute(
-                "DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
-            )
+            await cursor.execute("DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK")
     except Exception as e:
         print(f"Error deleting old giveaways: {e}")
 


### PR DESCRIPTION
Closes #1367

## Changes

The `transaction()` async context manager was already implemented with proper rollback on error. This PR ensures multi-step database operations use it for atomicity:

- **`delete_level_system_data`**: Now wraps all 9 DELETE queries in a single transaction. Partial deletion failures will roll back all changes.
- **`delete_giveaway`**: Now cleans up related tables (`giveawayChannelRequirement`, `giveawayRoleRequirement`, `giveawayParticipant`, `giveawayVoiceTime`, `giveawayNewMessage`, `giveawayChannelMessages`) in a transaction before deleting the giveaway itself.
- **`delete_old_giveaways`**: Same cleanup for related tables when purging expired giveaways.

### Previously converted (already using `transaction()`)
- `add_giveaway` - inserts giveaway + channel requirements + role requirements atomically
- `edit_giveaway` - updates giveaway + replaces channel/role requirements atomically
- `bulk_update_user_xp` - batch XP updates in a single transaction

## Benefits
- **Atomic operations**: Multi-step DB changes are all-or-nothing
- **Proper rollback**: Errors automatically revert partial changes
- **Cleaner pool state**: No uncommitted transactions returned to pool
- **Safer for complex operations**: Giveaway creation, deletion, and level system cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency of data deletion by ensuring related records are removed together and failures are logged and surfaced.
  * Prevents partial deletions so data integrity is preserved during cleanup operations.

* **Chores**
  * Enhanced automatic cleanup to remove giveaways that ended over one week ago along with all associated data.
  * Added an explicit cleanup path to delete a single giveaway and its related records in one operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->