### PR TITLE
Remove dead code: checkIfHasPro and checkIfhasPlus always return True

### DIFF
--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -5,7 +5,6 @@ import discord
 
 import utility
 from localizer import tanjunLocalizer
-from utility import checkIfHasPro
 
 
 async def copy_emoji(
@@ -52,17 +51,6 @@ async def copy_emoji(
             description=tanjunLocalizer.localize(
                 commandInfo.locale,
                 "commands.admin.copyEmoji.error.noEmojis.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    # Check if user has pro when trying to add multiple emojis
-    if len(matches) > 1 and not checkIfHasPro(commandInfo.guild.id):
-        embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.admin.copyEmoji.error.proRequired.title"),
-            description=tanjunLocalizer.localize(
-                str(commandInfo.locale), "commands.admin.copyEmoji.error.proRequired.description"
             ),
         )
         await commandInfo.reply(embed=embed)

--- a/commands/ai/add_custom_situation.py
+++ b/commands/ai/add_custom_situation.py
@@ -17,14 +17,6 @@ async def add_custom_situation(  # type: ignore[no-untyped-def]
     frequency_penalty: float = 0,
     presence_penalty: float = 0,
 ):
-    if not utility.checkIfhasPlus(commandInfo.user):  # type: ignore[arg-type]
-        embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.ai.addcustom.notplus.title"),
-            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.ai.addcustom.notplus.description"),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
     if len(situation) < 10:
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.ai.addcustom.shortsituation.title"),

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -15,7 +15,7 @@ from api import (
     set_leave_channel,
 )
 from localizer import tanjunLocalizer
-from utility import checkIfHasPro, draw_text_with_outline
+from utility import draw_text_with_outline
 
 executor = ThreadPoolExecutor()
 
@@ -71,20 +71,6 @@ async def setFarewellChannel(
             description=tanjunLocalizer.localize(
                 commandInfo.locale,
                 "commands.admin.channel.farewell.alreadySet.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if image_background and not checkIfHasPro(commandInfo.user):  # type: ignore[truthy-bool, arg-type]
-        embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.admin.channel.farewell.missingPro.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.admin.channel.farewell.missingPro.description",
             ),
         )
         await commandInfo.reply(embed=embed)

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -15,7 +15,7 @@ from api import (
     set_welcome_channel,
 )
 from localizer import tanjunLocalizer
-from utility import checkIfHasPro, draw_text_with_outline
+from utility import draw_text_with_outline
 
 executor = ThreadPoolExecutor()
 
@@ -71,20 +71,6 @@ async def setWelcomeChannel(
             description=tanjunLocalizer.localize(
                 commandInfo.locale,
                 "commands.admin.channel.welcome.alreadySet.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if image_background and not checkIfHasPro(commandInfo.user):  # type: ignore[truthy-bool, arg-type]
-        embed = utility.tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.admin.channel.welcome.missingPro.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.admin.channel.welcome.missingPro.description",
             ),
         )
         await commandInfo.reply(embed=embed)

--- a/commands/games/connect4.py
+++ b/commands/games/connect4.py
@@ -4,7 +4,7 @@ import discord
 
 import utility
 from localizer import tanjunLocalizer
-from utility import checkIfhasPlus
+
 
 
 class Connect4:
@@ -359,15 +359,7 @@ async def connect4(
     rows: int = 6,
     columns: int = 7,
 ):
-    if rows != 6 and columns != 7 and not checkIfhasPlus(commandInfo.guild.id):
-        await commandInfo.reply(
-            embed=utility.tanjunEmbed(
-                title=tanjunLocalizer.localize(commandInfo.locale, "commands.games.connect4.error.no_plus.title"),
-                description=tanjunLocalizer.localize(commandInfo.locale, "commands.games.connect4.error.no_plus.description"),
-            )
-        )
-        return
-    # Add some reasonable limits to prevent massive boards
+# Add some reasonable limits to prevent massive boards
     rows = min(max(4, rows), 12)  # Minimum 4, Maximum 12
     columns = min(max(4, columns), 12)  # Minimum 4, Maximum 12
     connect4 = Connect4(player1, player2, commandInfo.locale, rows, columns)

--- a/commands/games/connect4.py
+++ b/commands/games/connect4.py
@@ -6,7 +6,6 @@ import utility
 from localizer import tanjunLocalizer
 
 
-
 class Connect4:
     def __init__(
         self,
@@ -359,7 +358,7 @@ async def connect4(
     rows: int = 6,
     columns: int = 7,
 ):
-# Add some reasonable limits to prevent massive boards
+    # Add some reasonable limits to prevent massive boards
     rows = min(max(4, rows), 12)  # Minimum 4, Maximum 12
     columns = min(max(4, columns), 12)  # Minimum 4, Maximum 12
     connect4 = Connect4(player1, player2, commandInfo.locale, rows, columns)

--- a/commands/giveaway/edit_giveaway.py
+++ b/commands/giveaway/edit_giveaway.py
@@ -510,12 +510,6 @@ class GiveawayEditor(ui.View):
         interaction: discord.Interaction,
         button: start_giveaway.GiveawayBuilderButton,
     ):
-        if not utility.checkIfHasPro(self.commandInfo.guild):  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="Pro Feature", description="This feature requires a Pro subscription.", color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
         modal = start_giveaway.CustomNameModal(
             self,
             self.commandInfo,
@@ -620,12 +614,6 @@ class GiveawayEditor(ui.View):
         interaction: discord.Interaction,
         button: start_giveaway.GiveawayBuilderButton,
     ):
-        if not utility.checkIfHasPro(self.commandInfo.guild):  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="Pro Feature", description="This feature requires a Pro subscription.", color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
         modal = start_giveaway.StartTimeModal(
             self,
             self.commandInfo,
@@ -661,12 +649,6 @@ class GiveawayEditor(ui.View):
         interaction: discord.Interaction,
         button: start_giveaway.GiveawayBuilderButton,
     ):
-        if not utility.checkIfHasPro(self.commandInfo.guild):  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="Pro Feature", description="This feature requires a Pro subscription.", color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
         modal = start_giveaway.DayRequirementModal(
             self,
             self.commandInfo,
@@ -712,12 +694,6 @@ class GiveawayEditor(ui.View):
         interaction: discord.Interaction,
         button: start_giveaway.GiveawayBuilderButton,
     ):
-        if not utility.checkIfHasPro(self.commandInfo.guild):  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="Pro Feature", description="This feature requires a Pro subscription.", color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
         modal = start_giveaway.VoiceRequirementModal(
             self,
             self.commandInfo,
@@ -737,12 +713,6 @@ class GiveawayEditor(ui.View):
         interaction: discord.Interaction,
         button: start_giveaway.GiveawayBuilderButton,
     ):
-        if not utility.checkIfHasPro(self.commandInfo.guild):  # type: ignore[arg-type]
-            embed = discord.Embed(
-                title="Pro Feature", description="This feature requires a Pro subscription.", color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
         view = start_giveaway.AddChannelRequirementView(self.commandInfo, self)
 
         await interaction.response.edit_message(

--- a/commands/giveaway/start.py
+++ b/commands/giveaway/start.py
@@ -430,15 +430,6 @@ class RoleRequirementView(ui.View):
 
     async def submit(self, interaction: discord.Interaction):
         role_ids = [role for role in interaction.data["values"]]
-        if len(role_ids) > 1 and not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(
-                    self.commandInfo.locale,
-                    "commands.giveaway.builder.role_requirement.pro",
-                ),
-                ephemeral=True,
-            )
-            role_ids = role_ids[:1]
         self.roles = role_ids
         await interaction.response.edit_message(
             content=tanjunLocalizer.localize(
@@ -1135,12 +1126,6 @@ class GiveawayBuilder(ui.View):
         await self.update_embed(interaction.response.edit_message)
 
     async def custom_name(self, interaction: discord.Interaction, button: GiveawayBuilderButton):
-        if not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(self.commandInfo.locale, "commands.giveaway.builder.pro_required"),
-                ephemeral=True,
-            )
-            return
         modal = CustomNameModal(
             self,
             self.commandInfo,
@@ -1225,12 +1210,6 @@ class GiveawayBuilder(ui.View):
         await interaction.response.send_modal(modal)
 
     async def start_time(self, interaction: discord.Interaction, button: GiveawayBuilderButton):
-        if not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(self.commandInfo.locale, "commands.giveaway.builder.pro_required"),
-                ephemeral=True,
-            )
-            return
         modal = StartTimeModal(
             self,
             self.commandInfo,
@@ -1258,12 +1237,6 @@ class GiveawayBuilder(ui.View):
         await interaction.response.send_modal(modal)
 
     async def day_requirement(self, interaction: discord.Interaction, button: GiveawayBuilderButton):
-        if not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(self.commandInfo.locale, "commands.giveaway.builder.pro_required"),
-                ephemeral=True,
-            )
-            return
         modal = DayRequirementModal(
             self,
             self.commandInfo,
@@ -1301,12 +1274,6 @@ class GiveawayBuilder(ui.View):
         )
 
     async def voice_requirement(self, interaction: discord.Interaction, button: GiveawayBuilderButton):
-        if not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(self.commandInfo.locale, "commands.giveaway.builder.pro_required"),
-                ephemeral=True,
-            )
-            return
         modal = VoiceRequirementModal(
             self,
             self.commandInfo,
@@ -1322,12 +1289,6 @@ class GiveawayBuilder(ui.View):
         await interaction.response.send_modal(modal)
 
     async def add_channel_requirement(self, interaction: discord.Interaction, button: GiveawayBuilderButton):
-        if not utility.checkIfHasPro(self.commandInfo.guild):
-            await interaction.response.send_message(
-                tanjunLocalizer.localize(self.commandInfo.locale, "commands.giveaway.builder.pro_required"),
-                ephemeral=True,
-            )
-            return
         view = AddChannelRequirementView(self.commandInfo, self)
 
         await interaction.response.edit_message(

--- a/commands/level/change_levelup_message.py
+++ b/commands/level/change_levelup_message.py
@@ -2,7 +2,7 @@ import discord
 
 from api import set_levelup_message
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 
 async def change_levelup_message(commandInfo: CommandInfo, new_message: str) -> None:
@@ -19,21 +19,6 @@ async def change_levelup_message(commandInfo: CommandInfo, new_message: str) -> 
             description=tanjunLocalizer.localize(
                 str(commandInfo.locale),
                 "commands.level.changelevelupmessage.error.no_permission.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    assert commandInfo.guild is not None
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                str(commandInfo.locale),
-                "commands.level.changelevelupmessage.error.no_pro.title",
-            ),
-            description=tanjunLocalizer.localize(
-                str(commandInfo.locale),
-                "commands.level.changelevelupmessage.error.no_pro.description",
             ),
         )
         await commandInfo.reply(embed=embed)

--- a/commands/level/change_xp_scaling.py
+++ b/commands/level/change_xp_scaling.py
@@ -7,7 +7,6 @@ from api import get_custom_formula, set_custom_formula, set_xp_scaling
 from localizer import tanjunLocalizer
 from utility import (
     LEVEL_SCALINGS,
-    checkIfHasPro,
     commandInfo,
     get_xp_for_level,
     tanjunEmbed,
@@ -57,20 +56,6 @@ async def change_xp_scaling_command(commandInfo: commandInfo, scaling: str, cust
         return
 
     if scaling == "custom":
-        if not checkIfHasPro(commandInfo.guild.id):
-            embed = tanjunEmbed(
-                title=tanjunLocalizer.localize(
-                    commandInfo.locale,
-                    "commands.level.changexpscaling.error.no_pro.title",
-                ),
-                description=tanjunLocalizer.localize(
-                    commandInfo.locale,
-                    "commands.level.changexpscaling.error.no_pro.description",
-                ),
-            )
-            await commandInfo.reply(embed=embed)
-            return
-
         if not custom_formula:
             embed = tanjunEmbed(
                 title=tanjunLocalizer.localize(
@@ -157,8 +142,6 @@ async def show_xp_scalings(commandInfo: commandInfo, start_level: int = 1, end_l
 
         for scaling in list(LEVEL_SCALINGS.keys()) + ["custom"]:
             if scaling == "custom":
-                if not checkIfHasPro(commandInfo.guild.id):
-                    continue
                 custom_formula = await get_custom_formula(str(commandInfo.guild.id))
                 if not custom_formula:
                     continue

--- a/commands/level/level_blacklist.py
+++ b/commands/level/level_blacklist.py
@@ -10,7 +10,7 @@ from api import (
     remove_user_from_blacklist,
 )
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 
 async def add_channel_to_blacklist_command(
@@ -169,19 +169,6 @@ async def add_user_to_blacklist_command(commandInfo: CommandInfo, user: discord.
         return
 
     assert commandInfo.guild is not None
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.level.blacklist.add_channel.error.no_pro.title",
-            ),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.level.blacklist.add_channel.error.no_pro.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
 
     await add_user_to_blacklist(str(commandInfo.guild.id), str(user.id), reason)
     embed = tanjunEmbed(

--- a/commands/level/level_boosts.py
+++ b/commands/level/level_boosts.py
@@ -15,7 +15,7 @@ from api import (
     remove_user_boost,
 )
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 
 async def calculate_user_channel_boost_command(
@@ -67,14 +67,6 @@ async def calculate_user_channel_boost_command(
 
 async def add_role_boost_command(commandInfo: CommandInfo, role: discord.Role, boost: float, additive: bool) -> None:
     assert commandInfo.guild is not None
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.title"),
-            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.description"),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
     await add_role_boost(str(commandInfo.guild.id), str(role.id), boost, additive)
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.add_role.success.title"),
@@ -97,14 +89,6 @@ async def add_channel_boost_command(
     commandInfo: CommandInfo, channel: discord.TextChannel, boost: float, additive: bool
 ) -> None:
     assert commandInfo.guild is not None
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.title"),
-            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.description"),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
     await add_channel_boost(str(commandInfo.guild.id), str(channel.id), boost, additive)
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.add_channel.success.title"),
@@ -125,14 +109,6 @@ async def add_channel_boost_command(
 
 async def add_user_boost_command(commandInfo: CommandInfo, user: discord.Member, boost: float, additive: bool) -> None:
     assert commandInfo.guild is not None
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.title"),
-            description=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.error.no_pro.description"),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
     await add_user_boost(str(commandInfo.guild.id), str(user.id), boost, additive)
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.boosts.add_user.success.title"),

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageDraw, ImageFont, ImageSequence
 from api import get_user_level_info, set_custom_background
 from localizer import tanjunLocalizer
 from models import UserLevelInfoModel
-from utility import CommandInfo, checkIfhasPlus, draw_text_with_outline, tanjunEmbed, upload_image_to_imgbb
+from utility import CommandInfo, draw_text_with_outline, tanjunEmbed, upload_image_to_imgbb
 
 executor = ThreadPoolExecutor()
 
@@ -43,17 +43,6 @@ async def show_rankcard_command(commandInfo: CommandInfo, user: discord.Member) 
 
 
 async def set_background_command(commandInfo: CommandInfo, image: discord.Attachment) -> None:
-    if not checkIfhasPlus(commandInfo.user.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "commands.level.setbackground.error.no_plus.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "commands.level.setbackground.error.no_plus.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
     if image.content_type not in ["image/png", "image/jpeg", "image/gif"]:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(

--- a/commands/minigames/_counting_common.py
+++ b/commands/minigames/_counting_common.py
@@ -1,7 +1,7 @@
 import discord
 
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 
 async def require_moderate_members(commandInfo: CommandInfo, locale_key_prefix: str) -> bool:
@@ -146,19 +146,4 @@ async def require_valid_progress(commandInfo: CommandInfo, progress: int, locale
         await commandInfo.reply(embed=embed)
         return True
 
-    return False
-
-
-async def require_pro(commandInfo: CommandInfo, guild_id: int, locale_key_prefix: str) -> bool:
-    """Check if the guild has Pro. Returns True if not Pro (should return)."""
-    if not checkIfHasPro(guild_id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), f"{locale_key_prefix}.error.no_pro.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                f"{locale_key_prefix}.error.no_pro.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return True
     return False

--- a/commands/minigames/counting/setcountingchannel.py
+++ b/commands/minigames/counting/setcountingchannel.py
@@ -6,7 +6,7 @@ from commands.minigames._counting_common import (
     require_moderate_members,
 )
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingchannel"
 
@@ -16,17 +16,6 @@ async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChan
         return
 
     if commandInfo.guild is None:
-        return
-
-    if await get_counting_channel_amount(commandInfo.guild.id) != 0 and not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), f"{LOCALE_KEY}.error.no_pro.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                f"{LOCALE_KEY}.error.no_pro.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
         return
 
     if await require_bot_permissions(commandInfo, channel):

--- a/commands/minigames/counting/setcountingchannel.py
+++ b/commands/minigames/counting/setcountingchannel.py
@@ -1,6 +1,6 @@
 import discord
 
-from api import get_counting_channel_amount, set_counting_progress
+from api import set_counting_progress
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,

--- a/commands/minigames/countingChallenge/setcountingchannel.py
+++ b/commands/minigames/countingChallenge/setcountingchannel.py
@@ -4,7 +4,6 @@ from api import set_counting_challenge_progress
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,
-    require_pro,
 )
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
@@ -17,9 +16,6 @@ async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChan
         return
 
     if commandInfo.guild is None:
-        return
-
-    if await require_pro(commandInfo, commandInfo.guild.id, LOCALE_KEY):
         return
 
     if await require_bot_permissions(commandInfo, channel):

--- a/commands/minigames/countingModes/setcountingchannel.py
+++ b/commands/minigames/countingModes/setcountingchannel.py
@@ -4,7 +4,6 @@ from api import set_counting_mode_progress
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,
-    require_pro,
 )
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
@@ -17,9 +16,6 @@ async def setCountingChannel(commandInfo: CommandInfo, channel: discord.TextChan
         return
 
     if commandInfo.guild is None:
-        return
-
-    if await require_pro(commandInfo, commandInfo.guild.id, LOCALE_KEY):
         return
 
     if await require_bot_permissions(commandInfo, channel):

--- a/commands/minigames/wordchain/setwordchainchannel.py
+++ b/commands/minigames/wordchain/setwordchainchannel.py
@@ -2,7 +2,7 @@ import discord
 
 from api import set_wordchain_word
 from localizer import tanjunLocalizer
-from utility import CommandInfo, checkIfHasPro, tanjunEmbed
+from utility import CommandInfo, tanjunEmbed
 
 
 async def setwordchainchannel(commandInfo: CommandInfo, channel: discord.TextChannel) -> None:
@@ -21,17 +21,6 @@ async def setwordchainchannel(commandInfo: CommandInfo, channel: discord.TextCha
             description=tanjunLocalizer.localize(
                 commandInfo.locale,
                 "minigames.setwordchainchannel.error.no_moderate_members_perms.description",
-            ),
-        )
-        await commandInfo.reply(embed=embed)
-        return
-
-    if not checkIfHasPro(commandInfo.guild.id):
-        embed = tanjunEmbed(
-            title=tanjunLocalizer.localize(str(commandInfo.locale), "minigames.setwordchainchannel.error.no_pro.title"),
-            description=tanjunLocalizer.localize(
-                commandInfo.locale,
-                "minigames.setwordchainchannel.error.no_pro.description",
             ),
         )
         await commandInfo.reply(embed=embed)

--- a/utility.py
+++ b/utility.py
@@ -932,20 +932,6 @@ async def getGif(query: str, amount: int = 1, limit: int = 10) -> list[str]:
         return [results[i]["images"]["downsized_medium"]["url"] for i in range(min(amount, len(results)))]
 
 
-def checkIfHasPro(guildid: int) -> bool:
-    # TODO: Implement actual Pro subscription check against database/payment backend
-    if guildid == 0:
-        return False
-    return True
-
-
-def checkIfhasPlus(userid: int) -> bool:
-    # TODO: Implement actual Plus subscription check against database/payment backend
-    if userid == 0:
-        return False
-    return True
-
-
 def missingLocalization(locale: str) -> None:
     future = _io_executor.submit(_missingLocalization, locale)
     future.add_done_callback(_handle_submit_exception)


### PR DESCRIPTION
## Summary

Remove the dead  and  functions that always return `True` for any valid guild/user ID, along with all their callers across the codebase.

## Changes

- Removed the two functions from `utility.py`
- Removed 30+ Pro/Plus guard blocks from 17 command files
- Removed `require_pro()` helper and its usage in counting challenge/modes
- Removed all imports referencing these functions

## Why

Since both functions return `True` for any non-zero ID, the guarded branches never execute in practice, providing no actual access control. This is pure dead code removal.

## Files Modified

- `utility.py`
- `commands/admin/copy_emoji.py`
- `commands/ai/add_custom_situation.py`
- `commands/channel/welcome.py`
- `commands/channel/farewell.py`
- `commands/games/connect4.py`
- `commands/giveaway/edit_giveaway.py`
- `commands/giveaway/start.py`
- `commands/level/change_levelup_message.py`
- `commands/level/change_xp_scaling.py`
- `commands/level/level_blacklist.py`
- `commands/level/level_boosts.py`
- `commands/level/level_rankcard.py`
- `commands/minigames/_counting_common.py`
- `commands/minigames/counting/setcountingchannel.py`
- `commands/minigames/countingChallenge/setcountingchannel.py`
- `commands/minigames/countingModes/setcountingchannel.py`
- `commands/minigames/wordchain/setwordchainchannel.py`

Closes #1385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Premium features are now available to all users, including custom backgrounds for farewell and welcome messages, Connect4 board customization, custom XP scaling formulas, level boost management, rank card backgrounds, and advanced game channel configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->