### PR TITLE
Fix Ruff CI workflow: Remove --exit-zero flag so lint failures actually fail the build

### DIFF
--- a/.github/workflows/ruff_linter.yml
+++ b/.github/workflows/ruff_linter.yml
@@ -28,10 +28,16 @@ jobs:
         run: pip install ruff
 
       - name: Run Ruff Linter (auto-fix)
-        run: ruff check . --fix --exit-zero
+        run: ruff check . --fix
 
       - name: Run Ruff Formatter
+        continue-on-error: true
         run: ruff format .
+
+      - name: Check for remaining issues
+        run: |
+          # Fail if unfixable issues remain
+          ruff check . || exit 1
 
       - name: Commit auto-fixes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary

Removes `--exit-zero` from the Ruff linter step in `.github/workflows/ruff_linter.yml` so that lint violations actually cause the CI build to fail.

## Changes

- **Removed `--exit-zero`** from `ruff check . --fix` — unfixable issues now fail the build
- **Added explicit check step** (`ruff check . || exit 1`) to gate CI success on clean lint results
- **Added `continue-on-error: true`** to the Ruff format step to prevent formatting-only changes from blocking the build
- The auto-commit step (stefanzweifel/git-auto-commit-action) only runs if all prior steps succeed, so only auto-fixable changes are committed

Closes #1406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened continuous integration with improved code quality validation and stricter formatting enforcement to maintain consistent code standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->