### PR TITLE
chore: upgrade actions/cache from v3 to v4 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
                                  python3-pip xmlstarlet jq
 
       - name: Cache Python Build Source
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.local/python-build-cache # Caching downloaded/extracted Python source


### PR DESCRIPTION
Closes #1407

Updates `actions/cache` from v3 to v4 in the CI workflow to use the latest version with Node 20+ support.

Note: `docker/build-push-action` in `publish-ghcr.yml` was already at v6, so no change needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure to use an upgraded version of the cache action, improving build efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->