### PR TITLE
Add FUNDING.yml for GitHub Sponsors integration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [EntchenEric]


### PR DESCRIPTION
Closes #1403

## Summary
Adds a `.github/FUNDING.yml` file linking to the project maintainer's GitHub Sponsors profile. This enables the GitHub Sponsors button on the repository page.

## Changes
- Created `.github/FUNDING.yml` with `github: [EntchenEric]`

## Notes
No custom donation URLs were added — if a donation page exists for the project, it can be added as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated funding configuration to enable GitHub Sponsors support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->