### PR TITLE
Add Twitch API health check: Validate credentials, token acquisition, and API reachability

### DIFF
--- a/TwitchAPIHealthCheck.py
+++ b/TwitchAPIHealthCheck.py
@@ -4,7 +4,6 @@ Validates:
 1. twitchId and twitchSecret are configured
 2. App access token can be obtained
 3. API is reachable
-4. Token is not expired
 """
 
 from __future__ import annotations
@@ -28,7 +27,7 @@ class TwitchAPIHealthCheck(HealthCheck):
     async def run(self) -> HealthCheckResult:
         from config import twitchId, twitchSecret
 
-        if not twitchId or twitchSecret is None:
+        if not twitchId or not twitchSecret:
             return HealthCheckResult(
                 check_name=self.name,
                 status=HealthStatus.CRITICAL,
@@ -57,6 +56,13 @@ class TwitchAPIHealthCheck(HealthCheck):
                         )
                     data = await response.json()
                     token = data.get("access_token")
+
+                    if not token:
+                        return HealthCheckResult(
+                            check_name=self.name,
+                            status=HealthStatus.CRITICAL,
+                            message="Twitch auth failed: No access token returned in response",
+                        )
 
                 # Test API call with token
                 headers = {"Client-ID": twitchId, "Authorization": f"Bearer {token}"}

--- a/TwitchAPIHealthCheck.py
+++ b/TwitchAPIHealthCheck.py
@@ -1,0 +1,92 @@
+"""Twitch API health check for Tanjun bot.
+
+Validates:
+1. twitchId and twitchSecret are configured
+2. App access token can be obtained
+3. API is reachable
+4. Token is not expired
+"""
+
+from __future__ import annotations
+
+from aiohttp import ClientError, ClientSession
+
+from health.checks import HealthCheck, HealthCheckResult, HealthStatus
+
+
+class TwitchAPIHealthCheck(HealthCheck):
+    """Health check for the Twitch API."""
+
+    @property
+    def name(self) -> str:
+        return "Twitch API"
+
+    @property
+    def critical(self) -> bool:
+        return True  # Should refuse to start if misconfigured
+
+    async def run(self) -> HealthCheckResult:
+        from config import twitchId, twitchSecret
+
+        if not twitchId or twitchSecret is None:
+            return HealthCheckResult(
+                check_name=self.name,
+                status=HealthStatus.CRITICAL,
+                message="Twitch client ID or secret not configured. Set twitchId and twitchSecret in .env",
+            )
+
+        try:
+            async with ClientSession() as session:
+                # Test token acquisition
+                auth_params: dict[str, str] = {
+                    "client_id": twitchId,
+                    "client_secret": twitchSecret,
+                    "grant_type": "client_credentials",
+                }
+                async with session.post(
+                    "https://id.twitch.tv/oauth2/token",
+                    params=auth_params,
+                    timeout=10,
+                ) as response:
+                    if response.status != 200:
+                        data = await response.json()
+                        return HealthCheckResult(
+                            check_name=self.name,
+                            status=HealthStatus.CRITICAL,
+                            message=f"Twitch auth failed (HTTP {response.status}): {data.get('message', 'Unknown error')}",
+                        )
+                    data = await response.json()
+                    token = data.get("access_token")
+
+                # Test API call with token
+                headers = {"Client-ID": twitchId, "Authorization": f"Bearer {token}"}
+                async with session.get(
+                    "https://api.twitch.tv/helix/streams",
+                    headers=headers,
+                    timeout=10,
+                ) as response:
+                    if response.status != 200:
+                        return HealthCheckResult(
+                            check_name=self.name,
+                            status=HealthStatus.DEGRADED,
+                            message=f"Twitch API call failed (HTTP {response.status})",
+                        )
+
+        except TimeoutError:
+            return HealthCheckResult(
+                check_name=self.name,
+                status=HealthStatus.DEGRADED,
+                message="Twitch API request timed out after 10s",
+            )
+        except ClientError as e:
+            return HealthCheckResult(
+                check_name=self.name,
+                status=HealthStatus.DEGRADED,
+                message=f"Twitch API connection error: {e}",
+            )
+
+        return HealthCheckResult(
+            check_name=self.name,
+            status=HealthStatus.HEALTHY,
+            message="Twitch API is authenticated and reachable.",
+        )

--- a/health_check.py
+++ b/health_check.py
@@ -12,10 +12,12 @@ New code should import from the ``health`` package directly.
 
 from health.checks import HealthCheck, HealthCheckResult, HealthStatus
 from OpenAIHealthCheck import OpenAIHealthCheck
+from TwitchAPIHealthCheck import TwitchAPIHealthCheck
 
 __all__ = [
     "HealthCheck",
     "HealthCheckResult",
     "HealthStatus",
     "OpenAIHealthCheck",
+    "TwitchAPIHealthCheck",
 ]

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ from config import (
 )
 from health.manager import HealthCheckManager
 from OpenAIHealthCheck import OpenAIHealthCheck
+from TwitchAPIHealthCheck import TwitchAPIHealthCheck
 from translator import TanjunTranslator
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
@@ -124,6 +125,7 @@ async def main():
     # Run startup health checks
     health_manager = HealthCheckManager(bot)
     health_manager.register(OpenAIHealthCheck())
+    health_manager.register(TwitchAPIHealthCheck())
     ok, critical_failures = await health_manager.run_startup_checks()
     if not ok:
         # Can't send Discord notification before login; log prominently instead.

--- a/main.py
+++ b/main.py
@@ -31,8 +31,8 @@ from config import (
 )
 from health.manager import HealthCheckManager
 from OpenAIHealthCheck import OpenAIHealthCheck
-from TwitchAPIHealthCheck import TwitchAPIHealthCheck
 from translator import TanjunTranslator
+from TwitchAPIHealthCheck import TwitchAPIHealthCheck
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 


### PR DESCRIPTION
Closes #1412

## Summary
Adds a new `TwitchAPIHealthCheck` class that validates:
1. **Credentials are configured**: `twitchId` and `twitchSecret` are set
2. **App access token can be obtained**: POST to `https://id.twitch.tv/oauth2/token`
3. **API is reachable**: GET to `https://api.twitch.tv/helix/streams`

This is a **critical** health check — the bot will refuse to start if Twitch credentials are missing or invalid, since the Twitch polling feature is a core feature.

Also registers the check in `main.py` and adds the re-export in the legacy `health_check.py` module for backwards compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Twitch connectivity check during startup to verify credentials and API reachability.
  * Startup will abort on missing credentials or unrecoverable Twitch API failures.
  * Transient network/timeouts are treated as degraded (do not block startup); successful checks report healthy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->