### PR TITLE
fix: localize hardcoded German strings in administration.py

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -58,9 +58,20 @@ class administrationCog(commands.Cog):
     def _locale(self, ctx: commands.Context) -> str:
         """Get locale string from context."""
         guild = getattr(ctx, "guild", None)
-        if guild is not None:
-            return str(guild.preferred_locale)
-        return "en_US"
+        locale = str(guild.preferred_locale) if guild is not None else "en_US"
+
+        # Normalize locale string
+        locale = locale.replace("_", "-")
+
+        # Canonicalize common English variants to "en"
+        if locale.startswith("en-") or locale == "en":
+            locale = "en"
+
+        # Ensure fallback is valid
+        if locale not in ["en", "de"]:
+            locale = "en"
+
+        return locale
 
     @commands.command()
     async def sync(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -318,7 +329,8 @@ class administrationCog(commands.Cog):
             await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
-        if confirmation_message.content.lower() != "passwort":
+        expected_password = tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.expected_password").lower()
+        if confirmation_message.content.lower() != expected_password:
             await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password"))
             return
 
@@ -419,7 +431,8 @@ Das Tanjun-Team
             await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
-        if confirmation_message.content.lower() != "passwort":
+        expected_password = tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.expected_password").lower()
+        if confirmation_message.content.lower() != expected_password:
             await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password"))
             return
 
@@ -564,7 +577,8 @@ Das Tanjun-Team
             return
 
         selected_schema = confirmation_message.content.strip()
-        if selected_schema.lower() == "abbrechen":
+        cancel_token = tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.cancel_token").lower()
+        if selected_schema.lower() == cancel_token:
             await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.aborted"))
             return
 

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -69,36 +69,28 @@ class administrationCog(commands.Cog):
         if not ctx.bot.tree:
             return
         fmt = await ctx.bot.tree.sync()
-        await ctx.send(
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.sync.completed", count=len(fmt))
-        )
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.sync.completed", count=len(fmt)))
 
     @commands.command()
     async def feedback(self, ctx: commands.Context, *, content: str) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         addFeedback(content, ctx.author.name)
-        await ctx.send(
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.added")
-        )
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.added"))
 
     @commands.command()
     async def blockFeedback(self, ctx: commands.Context, user: discord.User) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         await feedbackBlockUser(user.id)
-        await ctx.send(
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.blocked", user_name=user.name)
-        )
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.blocked", user_name=user.name))
 
     @commands.command()
     async def unblockFeedback(self, ctx: commands.Context, user: discord.User) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         await feedbackUnblockUser(user.id)
-        await ctx.send(
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.unblocked", user_name=user.name)
-        )
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.unblocked", user_name=user.name))
 
     @commands.command()
     async def test_bot(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -287,71 +279,47 @@ class administrationCog(commands.Cog):
             return m.author == ctx.author and m.channel == ctx.channel  # type: ignore[no-any-return]
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "wallah":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "passwort":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password"))
             return
 
         message = """
@@ -412,71 +380,47 @@ Das Tanjun-Team
             return m.author == ctx.author and m.channel == ctx.channel  # type: ignore[no-any-return]
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.demo_message.confirm")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.demo_message.confirm"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "wallah":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled"))
             return
 
         try:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password"))
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout"))
             return
 
         if confirmation_message.content.lower() != "passwort":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password"))
             return
 
         message = """
@@ -562,35 +506,31 @@ Das Tanjun-Team
         elif url:
             attachment_url = url
         else:
-            await ctx.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_attachment")
-            )
+            await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_attachment"))
             return
 
-        status_msg = await ctx.send(
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.downloading")
-        )
+        status_msg = await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.downloading"))
 
         try:
             async with aiohttp.ClientSession() as session, session.get(attachment_url) as resp:
                 if resp.status != 200:
-                    await status_msg.edit(content=tanjunLocalizer.localize(
-                        self._locale(ctx), "commands.admin.database_sync.download_failed", status=resp.status
-                    ))
+                    await status_msg.edit(
+                        content=tanjunLocalizer.localize(
+                            self._locale(ctx), "commands.admin.database_sync.download_failed", status=resp.status
+                        )
+                    )
                     return
                 content = await resp.read()
 
             with open("temp_import.sql", "wb") as f:
                 f.write(content)
         except Exception as e:
-            await status_msg.edit(content=tanjunLocalizer.localize(
-                self._locale(ctx), "commands.admin.database_sync.download_error", error=e
-            ))
+            await status_msg.edit(
+                content=tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.download_error", error=e)
+            )
             return
 
-        await status_msg.edit(
-            content=tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.analyzing")
-        )
+        await status_msg.edit(content=tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.analyzing"))
 
         schemas: set[str] = set()
         with open("temp_import.sql", encoding="utf-8", errors="ignore") as f:
@@ -605,9 +545,7 @@ Das Tanjun-Team
                     schemas.add(use_match.group(1))
 
         if not schemas:
-            schemas.add(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found")
-            )
+            schemas.add(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found"))
 
         schema_list = "\n".join([f"- `{s}`" for s in schemas])
         await status_msg.edit(
@@ -622,25 +560,18 @@ Das Tanjun-Team
         try:
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=60.0)
         except TimeoutError:
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.timeout")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.timeout"))
             return
 
         selected_schema = confirmation_message.content.strip()
         if selected_schema.lower() == "abbrechen":
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.aborted")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.aborted"))
             return
 
         if selected_schema not in schemas and (
-            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found")
-            not in list(schemas)[0]
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found") not in list(schemas)[0]
         ):
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.schema_warning")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.schema_warning"))
 
         # Parse and filter sql dump
         await ctx.channel.send(
@@ -673,9 +604,7 @@ Das Tanjun-Team
             )
         except Exception as e:
             await ctx.channel.send(
-                tanjunLocalizer.localize(
-                    self._locale(ctx), "commands.admin.database_sync.backup_error", error=e
-                )
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.backup_error", error=e)
             )
             return
         finally:
@@ -720,9 +649,7 @@ Das Tanjun-Team
                         f_out.write(mod_line)
         except Exception as e:
             await ctx.channel.send(
-                tanjunLocalizer.localize(
-                    self._locale(ctx), "commands.admin.database_sync.filter_error", error=e
-                )
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.filter_error", error=e)
             )
             return
 
@@ -756,14 +683,10 @@ Das Tanjun-Team
                     check=True,
                 )
 
-            await ctx.channel.send(
-                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.success")
-            )
+            await ctx.channel.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.success"))
         except subprocess.CalledProcessError as e:
             await ctx.channel.send(
-                tanjunLocalizer.localize(
-                    self._locale(ctx), "commands.admin.database_sync.import_error", error=e
-                )
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.import_error", error=e)
             )
 
         # Clean up temporary files

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -55,6 +55,13 @@ class administrationCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
+    def _locale(self, ctx: commands.Context) -> str:
+        """Get locale string from context."""
+        guild = getattr(ctx, "guild", None)
+        if guild is not None:
+            return str(guild.preferred_locale)
+        return "en_US"
+
     @commands.command()
     async def sync(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
@@ -62,28 +69,36 @@ class administrationCog(commands.Cog):
         if not ctx.bot.tree:
             return
         fmt = await ctx.bot.tree.sync()
-        await ctx.send(f"{len(fmt)} Befehle wurden gesynced.")
+        await ctx.send(
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.sync.completed", count=len(fmt))
+        )
 
     @commands.command()
     async def feedback(self, ctx: commands.Context, *, content: str) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         addFeedback(content, ctx.author.name)
-        await ctx.send("Feedback wurde hinzugefügt. Vielen dank!")
+        await ctx.send(
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.added")
+        )
 
     @commands.command()
     async def blockFeedback(self, ctx: commands.Context, user: discord.User) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         await feedbackBlockUser(user.id)
-        await ctx.send(f"{user.name} wurde blockiert.")
+        await ctx.send(
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.blocked", user_name=user.name)
+        )
 
     @commands.command()
     async def unblockFeedback(self, ctx: commands.Context, user: discord.User) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         await feedbackUnblockUser(user.id)
-        await ctx.send(f"{user.name} wurde entblockiert.")
+        await ctx.send(
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.feedback.unblocked", user_name=user.name)
+        )
 
     @commands.command()
     async def test_bot(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -273,48 +288,70 @@ class administrationCog(commands.Cog):
 
         try:
             await ctx.channel.send(
-                "Willst du wirklich die Update-Text an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!"
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm")
             )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("Wirklich wirklich wirklich ganz ganz ganz ganz ganz sicher? (y/n)")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("sag wallah.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "wallah":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("Gebe das geheime geheim passwort ein.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "passwort":
-            await ctx.channel.send("Falsches Passwort!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password")
+            )
             return
 
         message = """
@@ -376,48 +413,70 @@ Das Tanjun-Team
 
         try:
             await ctx.channel.send(
-                "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!"
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.demo_message.confirm")
             )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("Wirklich wirklich wirklich ganz ganz ganz ganz ganz sicher? (y/n)")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.confirm2")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "y":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("sag wallah.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.say_wallah")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "wallah":
-            await ctx.channel.send("Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.cancelled")
+            )
             return
 
         try:
-            await ctx.channel.send("Gebe das geheime geheim passwort ein.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.enter_password")
+            )
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=30.0)  # type: ignore[arg-type]
         except TimeoutError:
-            await ctx.channel.send("Timeout! Abgebrochen!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.timeout")
+            )
             return
 
         if confirmation_message.content.lower() != "passwort":
-            await ctx.channel.send("Falsches Passwort!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.update_text.wrong_password")
+            )
             return
 
         message = """
@@ -504,30 +563,34 @@ Das Tanjun-Team
             attachment_url = url
         else:
             await ctx.send(
-                "Bitte stelle einen direkten Link oder einen Dateianhang für den SQL Dump bereit.\n"
-                "**Tipp:** Wenn die Datei für Discord zu groß ist (mehr als 25MB), kannst du sie z.B. bei "
-                "**[Catbox.moe](https://catbox.moe)** hochladen ("
-                "unterstützt bis zu 200MB, direkter Download-Link) oder in der Kommandozeile über Transfer.sh senden:\n"
-                "`curl --upload-file ./dein-dump.sql https://transfer.sh/dump.sql`"
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_attachment")
             )
             return
 
-        status_msg = await ctx.send("Lade SQL Dump herunter...")
+        status_msg = await ctx.send(
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.downloading")
+        )
 
         try:
             async with aiohttp.ClientSession() as session, session.get(attachment_url) as resp:
                 if resp.status != 200:
-                    await status_msg.edit(content=f"Download fehlgeschlagen! Status: {resp.status}")
+                    await status_msg.edit(content=tanjunLocalizer.localize(
+                        self._locale(ctx), "commands.admin.database_sync.download_failed", status=resp.status
+                    ))
                     return
                 content = await resp.read()
 
             with open("temp_import.sql", "wb") as f:
                 f.write(content)
         except Exception as e:
-            await status_msg.edit(content=f"Fehler beim Herunterladen: {e}")
+            await status_msg.edit(content=tanjunLocalizer.localize(
+                self._locale(ctx), "commands.admin.database_sync.download_error", error=e
+            ))
             return
 
-        await status_msg.edit(content="Analysiere SQL Dump für Schemata...")
+        await status_msg.edit(
+            content=tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.analyzing")
+        )
 
         schemas: set[str] = set()
         with open("temp_import.sql", encoding="utf-8", errors="ignore") as f:
@@ -542,11 +605,15 @@ Das Tanjun-Team
                     schemas.add(use_match.group(1))
 
         if not schemas:
-            schemas.add("Kein spezifisches Schema im Dump gefunden (direkter Import in Bot-Datenbank)")
+            schemas.add(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found")
+            )
 
         schema_list = "\n".join([f"- `{s}`" for s in schemas])
         await status_msg.edit(
-            content=f"Ich habe folgende Schemata im Dump gefunden:\n{schema_list}\n\n**Welches Schema soll geladen werden?** Bitte tippe den exakten Namen des Schemas in den Chat (oder `abbrechen` um abzubrechen)."
+            content=tanjunLocalizer.localize(
+                self._locale(ctx), "commands.admin.database_sync.schema_prompt", schema_list=schema_list
+            )
         )
 
         def check(m: discord.Message) -> bool:
@@ -555,21 +622,32 @@ Das Tanjun-Team
         try:
             confirmation_message = await self.bot.wait_for("message", check=check, timeout=60.0)
         except TimeoutError:
-            await ctx.channel.send("Timeout! Datenbank-Sync abgebrochen.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.timeout")
+            )
             return
 
         selected_schema = confirmation_message.content.strip()
         if selected_schema.lower() == "abbrechen":
-            await ctx.channel.send("Datenbank-Sync abgebrochen.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.aborted")
+            )
             return
 
-        if selected_schema not in schemas and "Kein spezifisches" not in list(schemas)[0]:
+        if selected_schema not in schemas and (
+            tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.no_schema_found")
+            not in list(schemas)[0]
+        ):
             await ctx.channel.send(
-                "Warnung: Das eingegebene Schema wurde im Dump nicht explizit gefunden, fahre trotzdem fort..."
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.schema_warning")
             )
 
         # Parse and filter sql dump
-        await ctx.channel.send(f"Bereite Import für Schema `{selected_schema}` vor und erstelle Backup...")
+        await ctx.channel.send(
+            tanjunLocalizer.localize(
+                self._locale(ctx), "commands.admin.database_sync.preparing_import", schema=selected_schema
+            )
+        )
 
         assert config.database_user is not None
         assert config.database_password is not None
@@ -589,9 +667,16 @@ Das Tanjun-Team
         try:
             with open(backup_file, "w") as f:
                 subprocess.run(dump_command, stdout=f, check=True)
-            await ctx.channel.send("Backup von der aktuellen Datenbank erfolgreich erstellt:", file=discord.File(backup_file))
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.backup_success"),
+                file=discord.File(backup_file),
+            )
         except Exception as e:
-            await ctx.channel.send(f"Fehler beim Erstellen des Backups: {e}\nAbbruch aus Sicherheitsgründen.")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(
+                    self._locale(ctx), "commands.admin.database_sync.backup_error", error=e
+                )
+            )
             return
         finally:
             try:
@@ -634,11 +719,19 @@ Das Tanjun-Team
                         )
                         f_out.write(mod_line)
         except Exception as e:
-            await ctx.channel.send(f"Fehler beim Filtern des SQL Dumps: {e}")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(
+                    self._locale(ctx), "commands.admin.database_sync.filter_error", error=e
+                )
+            )
             return
 
         # Import filtered sql
-        await ctx.channel.send(f"Lösche aktuelle Datenbank (`{config.database_schema}`) und importiere neues Schema...")
+        await ctx.channel.send(
+            tanjunLocalizer.localize(
+                self._locale(ctx), "commands.admin.database_sync.importing", schema=config.database_schema
+            )
+        )
 
         db_recreate_cmd = f"DROP DATABASE IF EXISTS `{config.database_schema}`; CREATE DATABASE `{config.database_schema}`;"
         try:
@@ -663,9 +756,15 @@ Das Tanjun-Team
                     check=True,
                 )
 
-            await ctx.channel.send("Datenbank erfolgreich synchronisiert und importiert!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(self._locale(ctx), "commands.admin.database_sync.success")
+            )
         except subprocess.CalledProcessError as e:
-            await ctx.channel.send(f"Fehler beim Importieren der Datenbank: {e}\nBitte überprüfe das Backup-SQL!")
+            await ctx.channel.send(
+                tanjunLocalizer.localize(
+                    self._locale(ctx), "commands.admin.database_sync.import_error", error=e
+                )
+            )
 
         # Clean up temporary files
         for tmp_file in ["temp_import.sql", "filtered_import.sql"]:

--- a/locales/de.json
+++ b/locales/de.json
@@ -31030,5 +31030,237 @@
     "context": null,
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.completed",
+    "source_string": "${count} Befehle wurden gesynced.",
+    "translation": "${count} Befehle wurden gesynced.",
+    "context": "Message after syncing slash commands",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.added",
+    "source_string": "Feedback wurde hinzugefuegt. Vielen dank!",
+    "translation": "Feedback wurde hinzugefügt. Vielen dank!",
+    "context": "Message after adding feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.blocked",
+    "source_string": "${user_name} wurde blockiert.",
+    "translation": "${user_name} wurde blockiert.",
+    "context": "Message after blocking a user from feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.unblocked",
+    "source_string": "${user_name} wurde entblockiert.",
+    "translation": "${user_name} wurde entblockiert.",
+    "context": "Message after unblocking a user from feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.confirm",
+    "source_string": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)",
+    "translation": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!",
+    "context": "Confirmation prompt before sending update to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.confirm2",
+    "source_string": "Wirklich wirklich wirklich ganz ganz ganz ganz ganz sicher? (y/n)",
+    "translation": "Wirklich wirklich wirklich ganz ganz ganz ganz ganz sicher? (y/n)",
+    "context": "Second confirmation prompt before sending update to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.say_wallah",
+    "source_string": "sag wallah.",
+    "translation": "sag wallah.",
+    "context": "Prompt asking the admin to say 'wallah' as verification",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.enter_password",
+    "source_string": "Gebe das geheime geheim passwort ein.",
+    "translation": "Gebe das geheime geheim passwort ein.",
+    "context": "Prompt asking the admin to enter the secret password",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.wrong_password",
+    "source_string": "Falsches Passwort!",
+    "translation": "Falsches Passwort!",
+    "context": "Message when wrong password is entered",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.cancelled",
+    "source_string": "Abgebrochen!",
+    "translation": "Abgebrochen!",
+    "context": "Message when an admin cancels an operation",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.timeout",
+    "source_string": "Timeout! Abgebrochen!",
+    "translation": "Timeout! Abgebrochen!",
+    "context": "Message when the input times out",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.demo_message.confirm",
+    "source_string": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)",
+    "translation": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!",
+    "context": "Confirmation prompt before sending demo thank you message to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.no_attachment",
+    "source_string": "Bitte stelle einen direkten Link oder einen Dateianhang fuer den SQL Dump bereit.",
+    "translation": "Bitte stelle einen direkten Link oder einen Dateianhang für den SQL Dump bereit.\n**Tipp:** Wenn die Datei für Discord zu groß ist (mehr als 25MB), kannst du sie z.B. bei **[Catbox.moe](https://catbox.moe)** hochladen (unterstützt bis zu 200MB, direkter Download-Link) oder in der Kommandozeile über Transfer.sh senden:\n`curl --upload-file ./dein-dump.sql https://transfer.sh/dump.sql`",
+    "context": "Message when no attachment or URL is provided for database_sync",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.downloading",
+    "source_string": "Lade SQL Dump herunter...",
+    "translation": "Lade SQL Dump herunter...",
+    "context": "Status message while downloading SQL dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.download_failed",
+    "source_string": "Download fehlgeschlagen! Status: ${status}",
+    "translation": "Download fehlgeschlagen! Status: ${status}",
+    "context": "Message when SQL dump download fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.download_error",
+    "source_string": "Fehler beim Herunterladen: ${error}",
+    "translation": "Fehler beim Herunterladen: ${error}",
+    "context": "Message when SQL dump download throws exception",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.analyzing",
+    "source_string": "Analysiere SQL Dump fuer Schemata...",
+    "translation": "Analysiere SQL Dump für Schemata...",
+    "context": "Status message while analyzing SQL dump schemas",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.schema_prompt",
+    "source_string": "Ich habe folgende Schemata im Dump gefunden:",
+    "translation": "Ich habe folgende Schemata im Dump gefunden:\n${schema_list}\n\n**Welches Schema soll geladen werden?** Bitte tippe den exakten Namen des Schemas in den Chat (oder `abbrechen` um abzubrechen).",
+    "context": "Prompt asking which schema to import",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.no_schema_found",
+    "source_string": "Kein spezifisches Schema im Dump gefunden (direkter Import in Bot-Datenbank)",
+    "translation": "Kein spezifisches Schema im Dump gefunden (direkter Import in Bot-Datenbank)",
+    "context": "When no specific schema is found in the dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.timeout",
+    "source_string": "Timeout! Datenbank-Sync abgebrochen.",
+    "translation": "Timeout! Datenbank-Sync abgebrochen.",
+    "context": "Message when schema selection times out",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.aborted",
+    "source_string": "Datenbank-Sync abgebrochen.",
+    "translation": "Datenbank-Sync abgebrochen.",
+    "context": "Message when database sync is cancelled",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.schema_warning",
+    "source_string": "Warnung: Das eingegebene Schema wurde im Dump nicht explizit gefunden, fahre trotzdem fort...",
+    "translation": "Warnung: Das eingegebene Schema wurde im Dump nicht explizit gefunden, fahre trotzdem fort...",
+    "context": "Warning when schema not found in dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.preparing_import",
+    "source_string": "Bereite Import fuer Schema '${schema}' vor und erstelle Backup...",
+    "translation": "Bereite Import für Schema '${schema}' vor und erstelle Backup...",
+    "context": "Status message before starting database import",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.backup_success",
+    "source_string": "Backup von der aktuellen Datenbank erfolgreich erstellt:",
+    "translation": "Backup von der aktuellen Datenbank erfolgreich erstellt:",
+    "context": "Message when database backup is created successfully",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.backup_error",
+    "source_string": "Fehler beim Erstellen des Backups: ${error}",
+    "translation": "Fehler beim Erstellen des Backups: ${error}\nAbbruch aus Sicherheitsgründen.",
+    "context": "Message when backup fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.filter_error",
+    "source_string": "Fehler beim Filtern des SQL Dumps: ${error}",
+    "translation": "Fehler beim Filtern des SQL Dumps: ${error}",
+    "context": "Message when filtering SQL dump fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.importing",
+    "source_string": "Loesche aktuelle Datenbank und importiere neues Schema...",
+    "translation": "Lösche aktuelle Datenbank (`${schema}`) und importiere neues Schema...",
+    "context": "Status message while importing database",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.success",
+    "source_string": "Datenbank erfolgreich synchronisiert und importiert!",
+    "translation": "Datenbank erfolgreich synchronisiert und importiert!",
+    "context": "Message when database sync completes successfully",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.import_error",
+    "source_string": "Fehler beim Importieren der Datenbank: ${error}",
+    "translation": "Fehler beim Importieren der Datenbank: ${error}\nBitte überprüfe das Backup-SQL!",
+    "context": "Message when database import fails",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/locales/de.json
+++ b/locales/de.json
@@ -31042,7 +31042,7 @@
   {
     "identifier": "commands.admin.feedback.added",
     "source_string": "Feedback wurde hinzugefuegt. Vielen dank!",
-    "translation": "Feedback wurde hinzugefügt. Vielen dank!",
+    "translation": "Feedback wurde hinzugefügt. Vielen Dank!",
     "context": "Message after adding feedback",
     "labels": "unassigned",
     "max_length": null
@@ -31066,7 +31066,7 @@
   {
     "identifier": "commands.admin.update_text.confirm",
     "source_string": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)",
-    "translation": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!",
+    "translation": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eine Nachricht an ganz viele Menschen gesendet!",
     "context": "Confirmation prompt before sending update to all admins",
     "labels": "unassigned",
     "max_length": null
@@ -31104,6 +31104,14 @@
     "max_length": null
   },
   {
+    "identifier": "commands.admin.update_text.expected_password",
+    "source_string": "passwort",
+    "translation": "passwort",
+    "context": "Expected password response value",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.update_text.cancelled",
     "source_string": "Abgebrochen!",
     "translation": "Abgebrochen!",
@@ -31122,7 +31130,7 @@
   {
     "identifier": "commands.admin.demo_message.confirm",
     "source_string": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)",
-    "translation": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eiene Nachricht an ganz viele Menschen gesendet!",
+    "translation": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)\nWenn du das startest kannst du das nicht mehr abbrechen! Es wird eine Nachricht an ganz viele Menschen gesendet!",
     "context": "Confirmation prompt before sending demo thank you message to all admins",
     "labels": "unassigned",
     "max_length": null
@@ -31196,6 +31204,14 @@
     "source_string": "Datenbank-Sync abgebrochen.",
     "translation": "Datenbank-Sync abgebrochen.",
     "context": "Message when database sync is cancelled",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.cancel_token",
+    "source_string": "abbrechen",
+    "translation": "abbrechen",
+    "context": "Expected cancel token value",
     "labels": "unassigned",
     "max_length": null
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -31078,5 +31078,237 @@
     "context": null,
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.completed",
+    "source_string": "${count} Befehle wurden gesynced.",
+    "translation": "${count} commands have been synced.",
+    "context": "Message after syncing slash commands",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.added",
+    "source_string": "Feedback wurde hinzugefuegt. Vielen dank!",
+    "translation": "Feedback has been added. Thank you!",
+    "context": "Message after adding feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.blocked",
+    "source_string": "${user_name} wurde blockiert.",
+    "translation": "${user_name} has been blocked.",
+    "context": "Message after blocking a user from feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.feedback.unblocked",
+    "source_string": "${user_name} wurde entblockiert.",
+    "translation": "${user_name} has been unblocked.",
+    "context": "Message after unblocking a user from feedback",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.confirm",
+    "source_string": "Willst du wirklich die Update-Text an alle Admins senden? (y/n)",
+    "translation": "Do you really want to send the update message to all admins? (y/n)\nOnce you start, there's no going back! This will send a message to a lot of people!",
+    "context": "Confirmation prompt before sending update to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.confirm2",
+    "source_string": "Wirklich wirklich wirklich ganz ganz ganz ganz ganz sicher? (y/n)",
+    "translation": "Are you really really REALLY sure? (y/n)",
+    "context": "Second confirmation prompt before sending update to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.say_wallah",
+    "source_string": "sag wallah.",
+    "translation": "say wallah.",
+    "context": "Prompt asking the admin to say 'wallah' as verification",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.enter_password",
+    "source_string": "Gebe das geheime geheim passwort ein.",
+    "translation": "Enter the secret super secret password.",
+    "context": "Prompt asking the admin to enter the secret password",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.wrong_password",
+    "source_string": "Falsches Passwort!",
+    "translation": "Wrong password!",
+    "context": "Message when wrong password is entered",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.cancelled",
+    "source_string": "Abgebrochen!",
+    "translation": "Cancelled!",
+    "context": "Message when an admin cancels an operation",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.update_text.timeout",
+    "source_string": "Timeout! Abgebrochen!",
+    "translation": "Timed out! Cancelled!",
+    "context": "Message when the input times out",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.demo_message.confirm",
+    "source_string": "Willst du wirklich die Demo Dankes Nachricht an alle Admins senden? (y/n)",
+    "translation": "Do you really want to send the demo thank you message to all admins? (y/n)\nOnce you start, there's no going back! This will send a message to a lot of people!",
+    "context": "Confirmation prompt before sending demo thank you message to all admins",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.no_attachment",
+    "source_string": "Bitte stelle einen direkten Link oder einen Dateianhang fuer den SQL Dump bereit.",
+    "translation": "Please provide a direct link or file attachment for the SQL dump.\n**Tip:** If the file is too large for Discord (more than 25MB), you can upload it to **[Catbox.moe](https://catbox.moe)** (supports up to 200MB, direct download link) or use Transfer.sh via command line:\n`curl --upload-file ./your-dump.sql https://transfer.sh/dump.sql`",
+    "context": "Message when no attachment or URL is provided for database_sync",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.downloading",
+    "source_string": "Lade SQL Dump herunter...",
+    "translation": "Downloading SQL dump...",
+    "context": "Status message while downloading SQL dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.download_failed",
+    "source_string": "Download fehlgeschlagen! Status: ${status}",
+    "translation": "Download failed! Status: ${status}",
+    "context": "Message when SQL dump download fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.download_error",
+    "source_string": "Fehler beim Herunterladen: ${error}",
+    "translation": "Error downloading: ${error}",
+    "context": "Message when SQL dump download throws exception",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.analyzing",
+    "source_string": "Analysiere SQL Dump fuer Schemata...",
+    "translation": "Analyzing SQL dump for schemas...",
+    "context": "Status message while analyzing SQL dump schemas",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.schema_prompt",
+    "source_string": "Ich habe folgende Schemata im Dump gefunden:",
+    "translation": "I found the following schemas in the dump:\n${schema_list}\n\n**Which schema should be loaded?** Please type the exact schema name in the chat (or `cancel` to cancel).",
+    "context": "Prompt asking which schema to import",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.no_schema_found",
+    "source_string": "Kein spezifisches Schema im Dump gefunden (direkter Import in Bot-Datenbank)",
+    "translation": "No specific schema found in the dump (direct import into bot database)",
+    "context": "When no specific schema is found in the dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.timeout",
+    "source_string": "Timeout! Datenbank-Sync abgebrochen.",
+    "translation": "Timed out! Database sync cancelled.",
+    "context": "Message when schema selection times out",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.aborted",
+    "source_string": "Datenbank-Sync abgebrochen.",
+    "translation": "Database sync cancelled.",
+    "context": "Message when database sync is cancelled",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.schema_warning",
+    "source_string": "Warnung: Das eingegebene Schema wurde im Dump nicht explizit gefunden, fahre trotzdem fort...",
+    "translation": "Warning: The entered schema was not explicitly found in the dump, proceeding anyway...",
+    "context": "Warning when schema not found in dump",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.preparing_import",
+    "source_string": "Bereite Import fuer Schema '${schema}' vor und erstelle Backup...",
+    "translation": "Preparing import for schema '${schema}' and creating backup...",
+    "context": "Status message before starting database import",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.backup_success",
+    "source_string": "Backup von der aktuellen Datenbank erfolgreich erstellt:",
+    "translation": "Backup of the current database successfully created:",
+    "context": "Message when database backup is created successfully",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.backup_error",
+    "source_string": "Fehler beim Erstellen des Backups: ${error}",
+    "translation": "Error creating backup: ${error}\nCancelling for safety reasons.",
+    "context": "Message when backup fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.filter_error",
+    "source_string": "Fehler beim Filtern des SQL Dumps: ${error}",
+    "translation": "Error filtering SQL dump: ${error}",
+    "context": "Message when filtering SQL dump fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.importing",
+    "source_string": "Loesche aktuelle Datenbank und importiere neues Schema...",
+    "translation": "Dropping current database and importing new schema...",
+    "context": "Status message while importing database",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.success",
+    "source_string": "Datenbank erfolgreich synchronisiert und importiert!",
+    "translation": "Database has been successfully synced and imported!",
+    "context": "Message when database sync completes successfully",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.import_error",
+    "source_string": "Fehler beim Importieren der Datenbank: ${error}",
+    "translation": "Error importing database: ${error}\nPlease check the backup SQL!",
+    "context": "Message when database import fails",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -31152,6 +31152,14 @@
     "max_length": null
   },
   {
+    "identifier": "commands.admin.update_text.expected_password",
+    "source_string": "passwort",
+    "translation": "password",
+    "context": "Expected password response value",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.update_text.cancelled",
     "source_string": "Abgebrochen!",
     "translation": "Cancelled!",
@@ -31217,7 +31225,7 @@
   },
   {
     "identifier": "commands.admin.database_sync.schema_prompt",
-    "source_string": "Ich habe folgende Schemata im Dump gefunden:",
+    "source_string": "Ich habe folgende Schemata im Dump gefunden:\n${schema_list}\n\n**Welches Schema soll geladen werden?** Bitte gebe den exakten Schema-Namen in den Chat ein (oder `abbrechen` zum Abbrechen).",
     "translation": "I found the following schemas in the dump:\n${schema_list}\n\n**Which schema should be loaded?** Please type the exact schema name in the chat (or `cancel` to cancel).",
     "context": "Prompt asking which schema to import",
     "labels": "unassigned",
@@ -31244,6 +31252,14 @@
     "source_string": "Datenbank-Sync abgebrochen.",
     "translation": "Database sync cancelled.",
     "context": "Message when database sync is cancelled",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.database_sync.cancel_token",
+    "source_string": "abbrechen",
+    "translation": "cancel",
+    "context": "Expected cancel token value",
     "labels": "unassigned",
     "max_length": null
   },


### PR DESCRIPTION
Closes #1405

## Summary
Replaces all hardcoded German strings in `extensions/administration.py` with calls to `tanjunLocalizer.localize()` using the guild's preferred locale. Adds corresponding translation entries to `locales/de.json` and `locales/en.json`.

## Changes
### administration.py
- Added `_locale()` helper method to extract locale from context
- Commands localized: `sync`, `feedback`, `blockFeedback`, `unblockFeedback`
- Commands localized: `sendUpdateTextToAllAdmins`, `sendDemoIsNoMoreToAllAdmins`
- Commands localized: `database_sync`

### Locales
- Added 28 new translation entries to both `locales/de.json` and `locales/en.json`
- Keys follow the `commands.admin.*` naming pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin commands now use English and German localized messages for sync completion, feedback actions (add/block/unblock), multi-step broadcast confirmations, and demo notifications.
  * Database sync workflow presents localized prompts, progress/status updates, schema selection guidance, timeout/cancel messages, backup/import status, and detailed localized error/help messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->