### PR TITLE
fix: Add database connection timeout and retry wrappers to prevent indefinite blocking

### DIFF
--- a/api.py
+++ b/api.py
@@ -170,8 +170,9 @@ async def preload_guild_configs(bot) -> None:
     global _guild_config_cache
     _guild_config_cache = {}
     try:
-        async with pool.acquire() as conn, conn.cursor() as cursor:
-            await cursor.execute(query)
+        conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+        async with conn, conn.cursor() as cursor:
+            await asyncio.wait_for(cursor.execute(query), timeout=_QUERY_TIMEOUT)
             async for row in cursor:
                 guild_id = str(row[0])
                 _guild_config_cache[guild_id] = (
@@ -216,8 +217,9 @@ async def _get_cached_config(guild_id: str, key: str, default: Any = None) -> An
     if pool is None:
         return default
     try:
-        async with pool.acquire() as conn, conn.cursor() as cursor:
-            await cursor.execute(query, (guild_id,))
+        conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+        async with conn, conn.cursor() as cursor:
+            await asyncio.wait_for(cursor.execute(query, (guild_id,)), timeout=_QUERY_TIMEOUT)
             row = await cursor.fetchone()
             if row:
                 data = {
@@ -276,15 +278,34 @@ async def execute_query_iter(
         print(f"Tried to execute_query_iter without pool. {_sanitize_for_log(query)}")
         return
 
-    try:
-        conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
-        async with conn, conn.cursor() as cursor:
-            await asyncio.wait_for(cursor.execute(query, params), timeout=_QUERY_TIMEOUT)
-            async for row in cursor:
-                yield row
-    except Exception as e:
-        safe_id = _query_safe_id(query)
-        print(f"Error during query iteration: {e} — q={safe_id}")
+    safe_id = _query_safe_id(query)
+    for attempt in range(_MAX_DB_RETRIES):
+        try:
+            conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+            async with conn, conn.cursor() as cursor:
+                await asyncio.wait_for(cursor.execute(query, params), timeout=_QUERY_TIMEOUT)
+                async for row in cursor:
+                    yield row
+            return
+        except TimeoutError:
+            print(f"Timeout on execute_query_iter attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
+            if attempt < _MAX_DB_RETRIES - 1:
+                await asyncio.sleep(0.5 * (attempt + 1))
+            continue
+        except Exception as e:
+            err_str = str(e).lower()
+            retryable = (
+                "deadlock" in err_str
+                or "connection" in err_str
+                or "timeout" in err_str
+            )
+            if attempt < _MAX_DB_RETRIES - 1 and retryable:
+                print(f"Transient error on execute_query_iter attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
+                await asyncio.sleep(0.5 * (attempt + 1))
+                continue
+            print(f"Error during query iteration: {e} — {safe_id}")
+            return
+    print(f"All retries exhausted for execute_query_iter: {safe_id}")
 
 
 async def safe_execute_query(
@@ -302,14 +323,26 @@ async def transaction(bot=None):
     if pool is None:
         raise RuntimeError("Database pool is not initialized")
 
-    conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
-    async with conn:
+    safe_id = _query_safe_id("transaction")
+    for attempt in range(_MAX_DB_RETRIES):
         try:
-            yield conn
-            await conn.commit()
+            conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+            async with conn:
+                try:
+                    yield conn
+                    await conn.commit()
+                except Exception:
+                    await conn.rollback()
+                    raise
+            return
+        except TimeoutError:
+            print(f"Timeout on transaction acquire attempt {attempt + 1}/{_MAX_DB_RETRIES}: conn_pool")
+            if attempt < _MAX_DB_RETRIES - 1:
+                await asyncio.sleep(0.5 * (attempt + 1))
+            continue
         except Exception:
-            await conn.rollback()
             raise
+    raise RuntimeError(f"Could not acquire database connection after {_MAX_DB_RETRIES} attempts [{safe_id}]")
 
 
 async def check_pool_health(bot=None) -> bool:
@@ -317,13 +350,18 @@ async def check_pool_health(bot=None) -> bool:
     pool = _get_pool() if bot is None else (bot._pool if hasattr(bot, "_pool") else None)
     if pool is None:
         return False
-    try:
-        conn = await asyncio.wait_for(pool.acquire(), timeout=5)
-        async with conn, conn.cursor() as cursor:
-            await cursor.execute("SELECT 1")
-        return True
-    except Exception:
-        return False
+    for attempt in range(_MAX_DB_RETRIES):
+        try:
+            conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+            async with conn, conn.cursor() as cursor:
+                await cursor.execute("SELECT 1")
+            return True
+        except Exception:
+            if attempt < _MAX_DB_RETRIES - 1:
+                await asyncio.sleep(0.5 * (attempt + 1))
+                continue
+            return False
+    return False
 
 
 async def bulk_update_user_xp(
@@ -913,9 +951,14 @@ async def create_tables(bot=None) -> None:
     pool = _get_pool() if bot is None else (bot._pool if hasattr(bot, "_pool") else None)
     if pool is None:
         return
-    async with pool.acquire() as conn, conn.cursor() as cursor:
-        await cursor.execute("SHOW TABLES")
-        existing = {row[0] for row in await cursor.fetchall()}
+    try:
+        conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+        async with conn, conn.cursor() as cursor:
+            await asyncio.wait_for(cursor.execute("SHOW TABLES"), timeout=_QUERY_TIMEOUT)
+            existing = {row[0] for row in await cursor.fetchall()}
+    except Exception as e:
+        print(f"Error discovering existing tables: {e}")
+        return
 
     for table_name in tables:
         if table_name in existing:

--- a/api.py
+++ b/api.py
@@ -1,15 +1,17 @@
 import asyncio
 import hashlib
 import json
+import logging
 import time
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
 
 # import asyncmy
 from discord import Entitlement
+from discord.ext import commands
 
 from models import (
     AfkMessageModel,
@@ -48,6 +50,8 @@ from utility import get_level_for_xp, get_xp_for_level
 
 # Remove global pool and set_pool functions
 # The pool will be accessed from the bot object
+
+logger = logging.getLogger(__name__)
 
 _bot = None
 
@@ -292,16 +296,16 @@ async def execute_query_iter(
             return
         except TimeoutError:
             if yielded_any:
-                print(f"Timeout after yielding rows on execute_query_iter: {safe_id}")
-                return
+                logger.error(f"Timeout after yielding rows on execute_query_iter: {safe_id}")
+                raise
             print(f"Timeout on execute_query_iter attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
             if attempt < _MAX_DB_RETRIES - 1:
                 await asyncio.sleep(0.5 * (attempt + 1))
             continue
         except Exception as e:
             if yielded_any:
-                print(f"Error after yielding rows during query iteration: {e} — {safe_id}")
-                return
+                logger.error(f"Error after yielding rows during query iteration: {e} — {safe_id}")
+                raise
             err_str = str(e).lower()
             retryable = (
                 "deadlock" in err_str

--- a/api.py
+++ b/api.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import time
+import uuid
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -279,20 +280,28 @@ async def execute_query_iter(
         return
 
     safe_id = _query_safe_id(query)
+    yielded_any = False
     for attempt in range(_MAX_DB_RETRIES):
         try:
             conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
             async with conn, conn.cursor() as cursor:
                 await asyncio.wait_for(cursor.execute(query, params), timeout=_QUERY_TIMEOUT)
                 async for row in cursor:
+                    yielded_any = True
                     yield row
             return
         except TimeoutError:
+            if yielded_any:
+                print(f"Timeout after yielding rows on execute_query_iter: {safe_id}")
+                return
             print(f"Timeout on execute_query_iter attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
             if attempt < _MAX_DB_RETRIES - 1:
                 await asyncio.sleep(0.5 * (attempt + 1))
             continue
         except Exception as e:
+            if yielded_any:
+                print(f"Error after yielding rows during query iteration: {e} — {safe_id}")
+                return
             err_str = str(e).lower()
             retryable = (
                 "deadlock" in err_str
@@ -323,8 +332,8 @@ async def transaction(bot=None):
     if pool is None:
         raise RuntimeError("Database pool is not initialized")
 
-    safe_id = _query_safe_id("transaction")
     for attempt in range(_MAX_DB_RETRIES):
+        safe_id = str(uuid.uuid4())
         try:
             conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
             async with conn:
@@ -336,7 +345,7 @@ async def transaction(bot=None):
                     raise
             return
         except TimeoutError:
-            print(f"Timeout on transaction acquire attempt {attempt + 1}/{_MAX_DB_RETRIES}: conn_pool")
+            print(f"Timeout on transaction acquire attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
             if attempt < _MAX_DB_RETRIES - 1:
                 await asyncio.sleep(0.5 * (attempt + 1))
             continue
@@ -354,7 +363,7 @@ async def check_pool_health(bot=None) -> bool:
         try:
             conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
             async with conn, conn.cursor() as cursor:
-                await cursor.execute("SELECT 1")
+                await asyncio.wait_for(cursor.execute("SELECT 1"), timeout=_QUERY_TIMEOUT)
             return True
         except Exception:
             if attempt < _MAX_DB_RETRIES - 1:


### PR DESCRIPTION
## Description

Adds timeout and retry wrappers to all remaining unprotected database operations in `api.py`. The core three execute functions (`execute_query`, `execute_action`, `execute_insert_and_get_id`) already had the retry mechanism via `_execute_with_retry`, but several other DB operations still lacked timeouts and retry logic.

### Changes

- **`execute_query_iter`**: Added retry loop with exponential backoff for transient failures (deadlock, connection drop, timeout). Previously had a single try/except.
- **`transaction` context manager**: Added retry loop for pool acquire. Previously would raise immediately on acquire timeout.
- **`check_pool_health`**: Added retry attempts with backoff. Now uses the standard `_POOL_ACQUIRE_TIMEOUT` (10s) instead of hardcoded 5s.
- **`create_tables`**: Added pool acquire timeout (`_POOL_ACQUIRE_TIMEOUT`) and query timeout (`_QUERY_TIMEOUT`) for the `SHOW TABLES` discovery query.
- **`preload_guild_configs`**: Added pool acquire timeout and query timeout.
- **`_get_cached_config` cache miss path**: Added pool acquire timeout and query timeout.

### Benefits

- **No indefinite blocking** when pool is exhausted — all `pool.acquire()` calls are wrapped with `asyncio.wait_for` using `_POOL_ACQUIRE_TIMEOUT` (10s)
- **No slow query blocking** — all `cursor.execute()` calls have `_QUERY_TIMEOUT` (30s)
- **Automatic recovery** from transient deadlocks via retries with exponential backoff
- **Better diagnostics**: Timeout errors are clearly reported with opaque query hashes

Fixes #1361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database operations now include retries for transient failures, reducing failed requests.
  * Timeouts added to connection acquisition and query execution to avoid indefinite waits.
  * Improved handling for table discovery, config preloading, and connection health checks to surface and log failures cleanly.

* **Refactor**
  * Transaction handling and streaming query execution redesigned for clearer commit/rollback, retry, and early-fail behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->