### PR TITLE
Add database integration test setup: Docker Compose for test MySQL and fixtures

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,7 +25,4 @@ services:
       retries: 10
       start_period: 30s
     volumes:
-      - test-db-data:/var/lib/mysql
-
-volumes:
-  test-db-data:
+      - /var/lib/mysql

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,31 @@
+---
+services:
+  test-db:
+    image: mariadb:11
+    container_name: tanjun-test-db
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: test
+      MARIADB_DATABASE: tanjun_test
+      MARIADB_USER: test_user
+      MARIADB_PASSWORD: test_password
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "healthcheck.sh",
+          "--su-mysql",
+          "--connect",
+          "--innodb_initialized",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    volumes:
+      - test-db-data:/var/lib/mysql
+
+volumes:
+  test-db-data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,3 +80,85 @@ def mock_bot(mock_db_pool: MagicMock) -> MagicMock:
     bot = MagicMock()
     bot._pool = mock_db_pool
     return bot
+
+
+# --- Integration test fixtures (requires test database container) ---
+
+@pytest.fixture(scope="session")
+def integration_mode() -> str:
+    """
+    Return the integration test mode.
+
+    Set TANJUN_INTEGRATION=true in environment to enable real database tests.
+    Tests default to 'skip' to avoid requiring a running test DB.
+    """
+    import os
+    return os.environ.get("TANJUN_INTEGRATION", "false").lower()
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an event loop for the session-scoped integration fixtures."""
+    import asyncio
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+async def integration_db_pool():
+    """
+    Create a real database connection pool pointing at the test database.
+
+    Requires the test database to be running (e.g. via docker-compose.test.yml):
+        docker compose -f docker-compose.test.yml up -d
+
+    Yields the pool and drops + recreates all tables on teardown so each
+    test session starts with a clean schema.
+    """
+    import os
+    import asyncmy
+
+    host = os.environ.get("TANJUN_TEST_DB_HOST", "localhost")
+    port = int(os.environ.get("TANJUN_TEST_DB_PORT", "3307"))
+    user = os.environ.get("TANJUN_TEST_DB_USER", "root")
+    password = os.environ.get("TANJUN_TEST_DB_PASSWORD", "test")
+    db = os.environ.get("TANJUN_TEST_DB_NAME", "tanjun_test")
+
+    pool = await asyncmy.create_pool(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        db=db,
+        minsize=1,
+        maxsize=2,
+    )
+
+    # Set the global pool so api._get_pool() resolves
+    from api import set_bot
+    _fake_bot = MagicMock()
+    _fake_bot._pool = pool
+    set_bot(_fake_bot)
+
+    # Create all tables
+    from api import create_tables
+    await create_tables(_fake_bot)
+
+    yield pool
+
+    # Clean up: drop all tables
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "SELECT CONCAT('DROP TABLE IF EXISTS `', table_name, '`') "
+                "FROM information_schema.tables WHERE table_schema = %s",
+                (db,),
+            )
+            drop_queries = await cursor.fetchall()
+            for (dq,) in drop_queries:
+                await cursor.execute(dq)
+
+    pool.close()
+    await pool.wait_closed()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ async def integration_db_pool():
     test session starts with a clean schema.
     """
     import os
+
     import asyncmy
 
     host = os.environ.get("TANJUN_TEST_DB_HOST", "localhost")
@@ -137,9 +138,11 @@ async def integration_db_pool():
     )
 
     # Set the global pool so api._get_pool() resolves
+    import api
     from api import set_bot
     _fake_bot = MagicMock()
     _fake_bot._pool = pool
+    original_bot = api._bot
     set_bot(_fake_bot)
 
     # Create all tables
@@ -149,16 +152,18 @@ async def integration_db_pool():
     yield pool
 
     # Clean up: drop all tables
-    async with pool.acquire() as conn:
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                "SELECT CONCAT('DROP TABLE IF EXISTS `', table_name, '`') "
-                "FROM information_schema.tables WHERE table_schema = %s",
-                (db,),
-            )
-            drop_queries = await cursor.fetchall()
-            for (dq,) in drop_queries:
-                await cursor.execute(dq)
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT CONCAT('DROP TABLE IF EXISTS `', table_name, '`') "
+            "FROM information_schema.tables WHERE table_schema = %s",
+            (db,),
+        )
+        drop_queries = await cursor.fetchall()
+        for (dq,) in drop_queries:
+            await cursor.execute(dq)
 
     pool.close()
     await pool.wait_closed()
+
+    # Restore original bot state
+    set_bot(original_bot)

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -18,6 +18,7 @@ Usage:
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
+import asyncmy
 import pytest
 
 import tests.mock_config as mock_config
@@ -25,7 +26,8 @@ import tests.mock_config as mock_config
 mock_config.patch_config_module()
 
 # Mock discord before importing any project modules
-import sys
+import sys  # noqa: E402
+
 _discord_mock = MagicMock()
 _discord_mock.Entitlement = MagicMock()
 sys.modules["discord"] = _discord_mock
@@ -33,19 +35,18 @@ sys.modules["discord.ext"] = MagicMock()
 sys.modules["discord.ext.commands"] = MagicMock()
 sys.modules["discord.app_commands"] = MagicMock()
 
-from api import (
-    add_warning,
-    get_warnings,
-    remove_warning,
+from api import (  # noqa: E402
     add_channel_to_blacklist,
-    add_role_to_blacklist,
-    get_level_roles,
     add_level_role,
-    remove_level_role,
-    set_level_system_status,
-    get_level_system_status,
+    add_role_to_blacklist,
+    add_warning,
     check_pool_health,
-    set_bot,
+    get_level_roles,
+    get_level_system_status,
+    get_warnings,
+    remove_level_role,
+    remove_warning,
+    set_level_system_status,
 )
 
 pytestmark = [
@@ -68,7 +69,7 @@ TEST_CHANNEL = "66666666666666666"
 # ── Pool health ──────────────────────────────────────────────────────────────
 
 
-async def test_pool_health_returns_true_when_db_is_reachable(integration_db_pool):
+async def test_pool_health_returns_true_when_db_is_reachable(integration_db_pool: asyncmy.Pool):
     """Verify check_pool_health returns True against a real database."""
     healthy = await check_pool_health()
     assert healthy is True, "Pool should be healthy against a reachable DB"
@@ -77,13 +78,12 @@ async def test_pool_health_returns_true_when_db_is_reachable(integration_db_pool
 # ── Table creation ───────────────────────────────────────────────────────────
 
 
-async def test_tables_are_created_via_create_tables(integration_db_pool):
+async def test_tables_are_created_via_create_tables(integration_db_pool: asyncmy.Pool):
     """Verify that create_tables creates all expected tables."""
     pool = integration_db_pool
-    async with pool.acquire() as conn:
-        async with conn.cursor() as cursor:
-            await cursor.execute("SHOW TABLES")
-            tables = {row[0] for row in await cursor.fetchall()}
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute("SHOW TABLES")
+        tables = {row[0] for row in await cursor.fetchall()}
 
     # Core expected tables
     expected = {
@@ -106,7 +106,7 @@ async def test_tables_are_created_via_create_tables(integration_db_pool):
 # ── Warnings CRUD ────────────────────────────────────────────────────────────
 
 
-async def test_add_and_retrieve_warning(integration_db_pool):
+async def test_add_and_retrieve_warning(integration_db_pool: asyncmy.Pool):
     """Write a warning to the database and read it back."""
     expires_at = datetime.now() + timedelta(days=30)
     await add_warning(TEST_GUILD, TEST_USER, "Integration test warning", expires_at, "bot")
@@ -119,7 +119,7 @@ async def test_add_and_retrieve_warning(integration_db_pool):
     assert len(matching) >= 1, "Should find the warning we just added"
 
 
-async def test_remove_warning(integration_db_pool):
+async def test_remove_warning(integration_db_pool: asyncmy.Pool):
     """Add a warning and then remove it, verifying the removal."""
     expires_at = datetime.now() + timedelta(days=30)
     await add_warning(TEST_GUILD, TEST_USER, "To be removed", expires_at, "bot")
@@ -140,37 +140,35 @@ async def test_remove_warning(integration_db_pool):
 # ── Blacklist CRUD ───────────────────────────────────────────────────────────
 
 
-async def test_channel_blacklist_round_trip(integration_db_pool):
+async def test_channel_blacklist_round_trip(integration_db_pool: asyncmy.Pool):
     """Verify a channel can be blacklisted and the operation doesn't error."""
     await add_channel_to_blacklist(TEST_GUILD, TEST_CHANNEL, "Integration test channel blacklist")
 
     # Verify by reading directly from the database
     pool = integration_db_pool
-    async with pool.acquire() as conn:
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                "SELECT channel_id, reason FROM blacklistedChannel WHERE guild_id = %s AND channel_id = %s",
-                (TEST_GUILD, TEST_CHANNEL),
-            )
-            row = await cursor.fetchone()
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT channel_id, reason FROM blacklistedChannel WHERE guild_id = %s AND channel_id = %s",
+            (TEST_GUILD, TEST_CHANNEL),
+        )
+        row = await cursor.fetchone()
     assert row is not None, "Channel should appear in blacklist"
     assert row[0] == TEST_CHANNEL
     assert row[1] == "Integration test channel blacklist"
 
 
-async def test_role_blacklist_round_trip(integration_db_pool):
+async def test_role_blacklist_round_trip(integration_db_pool: asyncmy.Pool):
     """Verify a role can be blacklisted and the operation doesn't error."""
     await add_role_to_blacklist(TEST_GUILD, TEST_ROLE, "Integration test role blacklist")
 
     # Verify by reading directly from the database
     pool = integration_db_pool
-    async with pool.acquire() as conn:
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                "SELECT role_id, reason FROM blacklistedRole WHERE guild_id = %s AND role_id = %s",
-                (TEST_GUILD, TEST_ROLE),
-            )
-            row = await cursor.fetchone()
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT role_id, reason FROM blacklistedRole WHERE guild_id = %s AND role_id = %s",
+            (TEST_GUILD, TEST_ROLE),
+        )
+        row = await cursor.fetchone()
     assert row is not None, "Role should appear in blacklist"
     assert row[0] == TEST_ROLE
     assert row[1] == "Integration test role blacklist"
@@ -179,7 +177,7 @@ async def test_role_blacklist_round_trip(integration_db_pool):
 # ── Level system CRUD ────────────────────────────────────────────────────────
 
 
-async def test_level_system_status_toggle(integration_db_pool):
+async def test_level_system_status_toggle(integration_db_pool: asyncmy.Pool):
     """Enable and disable the level system for a guild."""
     # Start with disabled
     await set_level_system_status(TEST_GUILD, False)
@@ -192,7 +190,7 @@ async def test_level_system_status_toggle(integration_db_pool):
     assert enabled is True, "Level system should be enabled"
 
 
-async def test_level_role_add_and_remove(integration_db_pool):
+async def test_level_role_add_and_remove(integration_db_pool: asyncmy.Pool):
     """Add a level role, verify it's returned, then remove it."""
     await add_level_role(TEST_GUILD, TEST_ROLE, 10)
 
@@ -211,20 +209,19 @@ async def test_level_role_add_and_remove(integration_db_pool):
 # ── XP CRUD ──────────────────────────────────────────────────────────────────
 
 
-async def test_xp_insert_and_retrieve(integration_db_pool):
+async def test_xp_insert_and_retrieve(integration_db_pool: asyncmy.Pool):
     """Write XP for a user and verify it reads back correctly."""
-    from api import update_user_xp, get_user_xp
+    from api import get_user_xp, update_user_xp
 
     xp_amount = 500
-    result = await update_user_xp(TEST_GUILD, TEST_USER, xp_amount)
-    assert result is not None or result is None  # update_user_xp may not return the count
+    await update_user_xp(TEST_GUILD, TEST_USER, xp_amount)
 
     xp = await get_user_xp(TEST_GUILD, TEST_USER)
     assert xp is not None, "XP should be retrievable after insert"
     assert xp >= xp_amount, f"Expected at least {xp_amount} XP, got {xp}"
 
 
-async def test_bulk_xp_update(integration_db_pool):
+async def test_bulk_xp_update(integration_db_pool: asyncmy.Pool):
     """Bulk-update XP for multiple users and verify results."""
     from api import bulk_update_user_xp, get_user_xp
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,244 @@
+"""
+Database integration tests for api.py.
+
+These tests connect to a real MariaDB/MySQL database running on port 3307
+(see docker-compose.test.yml) and verify that SQL queries, table creation,
+and CRUD operations work correctly at the database level.
+
+Usage:
+    # Start the test database container first
+    docker compose -f docker-compose.test.yml up -d
+
+    # Run integration tests
+    TANJUN_INTEGRATION=true pytest tests/test_api_integration.py -v
+
+    # Without TANJUN_INTEGRATION=true, all tests in this file are skipped.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+# Mock discord before importing any project modules
+import sys
+_discord_mock = MagicMock()
+_discord_mock.Entitlement = MagicMock()
+sys.modules["discord"] = _discord_mock
+sys.modules["discord.ext"] = MagicMock()
+sys.modules["discord.ext.commands"] = MagicMock()
+sys.modules["discord.app_commands"] = MagicMock()
+
+from api import (
+    add_warning,
+    get_warnings,
+    remove_warning,
+    add_channel_to_blacklist,
+    add_role_to_blacklist,
+    get_level_roles,
+    add_level_role,
+    remove_level_role,
+    set_level_system_status,
+    get_level_system_status,
+    check_pool_health,
+    set_bot,
+)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        "__import__('os').environ.get('TANJUN_INTEGRATION') != 'true'",
+        reason="Set TANJUN_INTEGRATION=true to run database integration tests. "
+               "Requires a running test DB (docker compose -f docker-compose.test.yml up -d)",
+    ),
+]
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+TEST_GUILD = "99999999999999999"
+TEST_USER = "88888888888888888"
+TEST_ROLE = "77777777777777777"
+TEST_CHANNEL = "66666666666666666"
+
+
+# ── Pool health ──────────────────────────────────────────────────────────────
+
+
+async def test_pool_health_returns_true_when_db_is_reachable(integration_db_pool):
+    """Verify check_pool_health returns True against a real database."""
+    healthy = await check_pool_health()
+    assert healthy is True, "Pool should be healthy against a reachable DB"
+
+
+# ── Table creation ───────────────────────────────────────────────────────────
+
+
+async def test_tables_are_created_via_create_tables(integration_db_pool):
+    """Verify that create_tables creates all expected tables."""
+    pool = integration_db_pool
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute("SHOW TABLES")
+            tables = {row[0] for row in await cursor.fetchall()}
+
+    # Core expected tables
+    expected = {
+        "warnings",
+        "warn_config",
+        "level",
+        "levelConfig",
+        "levelRole",
+        "blacklistedChannel",
+        "blacklistedRole",
+        "blacklistedUser",
+        "userXpBoost",
+        "channelXpBoost",
+        "roleXpBoost",
+    }
+    missing = expected - tables
+    assert not missing, f"Expected tables missing: {missing}"
+
+
+# ── Warnings CRUD ────────────────────────────────────────────────────────────
+
+
+async def test_add_and_retrieve_warning(integration_db_pool):
+    """Write a warning to the database and read it back."""
+    expires_at = datetime.now() + timedelta(days=30)
+    await add_warning(TEST_GUILD, TEST_USER, "Integration test warning", expires_at, "bot")
+
+    warnings = await get_warnings(TEST_GUILD, TEST_USER)
+    assert warnings is not None, "get_warnings should return a list"
+    assert len(warnings) >= 1, "Should have at least one warning"
+
+    matching = [w for w in warnings if w.reason == "Integration test warning"]
+    assert len(matching) >= 1, "Should find the warning we just added"
+
+
+async def test_remove_warning(integration_db_pool):
+    """Add a warning and then remove it, verifying the removal."""
+    expires_at = datetime.now() + timedelta(days=30)
+    await add_warning(TEST_GUILD, TEST_USER, "To be removed", expires_at, "bot")
+
+    warnings_before = await get_warnings(TEST_GUILD, TEST_USER)
+    target = [w for w in (warnings_before or []) if w.reason == "To be removed"]
+    assert len(target) >= 1, "Should find the warning to remove"
+
+    # Remove the first matching warning
+    warning_id = target[0].id
+    await remove_warning(warning_id)
+
+    warnings_after = await get_warnings(TEST_GUILD, TEST_USER) or []
+    still_around = [w for w in warnings_after if w.id == warning_id]
+    assert len(still_around) == 0, "Warning should no longer be present after removal"
+
+
+# ── Blacklist CRUD ───────────────────────────────────────────────────────────
+
+
+async def test_channel_blacklist_round_trip(integration_db_pool):
+    """Verify a channel can be blacklisted and the operation doesn't error."""
+    await add_channel_to_blacklist(TEST_GUILD, TEST_CHANNEL, "Integration test channel blacklist")
+
+    # Verify by reading directly from the database
+    pool = integration_db_pool
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "SELECT channel_id, reason FROM blacklistedChannel WHERE guild_id = %s AND channel_id = %s",
+                (TEST_GUILD, TEST_CHANNEL),
+            )
+            row = await cursor.fetchone()
+    assert row is not None, "Channel should appear in blacklist"
+    assert row[0] == TEST_CHANNEL
+    assert row[1] == "Integration test channel blacklist"
+
+
+async def test_role_blacklist_round_trip(integration_db_pool):
+    """Verify a role can be blacklisted and the operation doesn't error."""
+    await add_role_to_blacklist(TEST_GUILD, TEST_ROLE, "Integration test role blacklist")
+
+    # Verify by reading directly from the database
+    pool = integration_db_pool
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "SELECT role_id, reason FROM blacklistedRole WHERE guild_id = %s AND role_id = %s",
+                (TEST_GUILD, TEST_ROLE),
+            )
+            row = await cursor.fetchone()
+    assert row is not None, "Role should appear in blacklist"
+    assert row[0] == TEST_ROLE
+    assert row[1] == "Integration test role blacklist"
+
+
+# ── Level system CRUD ────────────────────────────────────────────────────────
+
+
+async def test_level_system_status_toggle(integration_db_pool):
+    """Enable and disable the level system for a guild."""
+    # Start with disabled
+    await set_level_system_status(TEST_GUILD, False)
+    enabled = await get_level_system_status(TEST_GUILD)
+    assert enabled is False, "Level system should be disabled"
+
+    # Enable
+    await set_level_system_status(TEST_GUILD, True)
+    enabled = await get_level_system_status(TEST_GUILD)
+    assert enabled is True, "Level system should be enabled"
+
+
+async def test_level_role_add_and_remove(integration_db_pool):
+    """Add a level role, verify it's returned, then remove it."""
+    await add_level_role(TEST_GUILD, TEST_ROLE, 10)
+
+    roles = await get_level_roles(TEST_GUILD)
+    matching = [r for r in (roles or []) if r.role_id == TEST_ROLE]
+    assert len(matching) >= 1, "Level role should be present after adding"
+    assert matching[0].level == 10
+
+    # Remove
+    await remove_level_role(TEST_GUILD, TEST_ROLE)
+    roles_after = await get_level_roles(TEST_GUILD) or []
+    still_around = [r for r in roles_after if r.role_id == TEST_ROLE]
+    assert len(still_around) == 0, "Level role should be gone after removal"
+
+
+# ── XP CRUD ──────────────────────────────────────────────────────────────────
+
+
+async def test_xp_insert_and_retrieve(integration_db_pool):
+    """Write XP for a user and verify it reads back correctly."""
+    from api import update_user_xp, get_user_xp
+
+    xp_amount = 500
+    result = await update_user_xp(TEST_GUILD, TEST_USER, xp_amount)
+    assert result is not None or result is None  # update_user_xp may not return the count
+
+    xp = await get_user_xp(TEST_GUILD, TEST_USER)
+    assert xp is not None, "XP should be retrievable after insert"
+    assert xp >= xp_amount, f"Expected at least {xp_amount} XP, got {xp}"
+
+
+async def test_bulk_xp_update(integration_db_pool):
+    """Bulk-update XP for multiple users and verify results."""
+    from api import bulk_update_user_xp, get_user_xp
+
+    user_a = "10000000000000001"
+    user_b = "10000000000000002"
+    entries = [
+        (user_a, 200),
+        (user_b, 300),
+    ]
+
+    await bulk_update_user_xp(TEST_GUILD, entries)
+
+    xp_a = await get_user_xp(TEST_GUILD, user_a)
+    xp_b = await get_user_xp(TEST_GUILD, user_b)
+    # Since other tests may have inserted XP, we verify at-minimum values
+    assert xp_a is not None and xp_a >= 200, f"user_a XP should be >= 200, got {xp_a}"
+    assert xp_b is not None and xp_b >= 300, f"user_b XP should be >= 300, got {xp_b}"


### PR DESCRIPTION
## Summary

Adds infrastructure for database integration tests that validate actual SQL queries against a real MariaDB instance.

### Changes

1. **docker-compose.test.yml** — MariaDB 11 service on port 3307 for isolated testing, with its own user/password and volume.

2. **tests/conftest.py** — New `integration_db_pool` session-scoped fixture that:
   - Creates a real `asyncmy` connection pool (configurable via env vars)
   - Runs `create_tables()` to set up the full schema
   - Cleans up by dropping all tables after the session

3. **tests/test_api_integration.py** — Integration tests covering:
   - Pool health check against a real DB
   - Table creation verification
   - Warning CRUD (add, retrieve, remove)
   - Channel and role blacklist insert + direct DB verification
   - Level system status toggle
   - Level role add and remove
   - XP insert and retrieve
   - Bulk XP updates

### Usage

```bash
# Terminal 1: Start test DB
docker compose -f docker-compose.test.yml up -d

# Terminal 2: Run integration tests
TANJUN_INTEGRATION=true pytest tests/test_api_integration.py -v
``"

All tests are **skipped by default** — only active when `TANJUN_INTEGRATION=true` is set.

Closes #1404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration testing infrastructure that can run against a real MariaDB test database.
  * Introduced session-scoped fixtures and an async test pool for end-to-end database tests.
  * Added a comprehensive integration test suite covering connectivity, schema creation, warnings, channel/role blacklists, level-system toggles and role mappings, and XP persistence (single and bulk updates).
* **Chores**
  * Added Docker Compose config to provision the test database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->