### PR TITLE
Add early message filtering in on_message to skip bot/DM messages once

### DIFF
--- a/commands/admin/trigger_messages/send.py
+++ b/commands/admin/trigger_messages/send.py
@@ -13,9 +13,6 @@ async def send_trigger_message(message: discord.Message) -> None:
     if not message.content:
         return
 
-    if message.author.bot:
-        return
-
     trigger_message = await is_trigger_message(message.guild.id, message.content, message.channel.id)
     if not trigger_message:
         return

--- a/commands/channel/dynamicslowmode.py
+++ b/commands/channel/dynamicslowmode.py
@@ -191,9 +191,6 @@ async def getDynamicslowmodeChannels(commandInfo: utility.CommandInfo) -> None:
 
 async def dynamicslowmodeMessage(message: discord.Message) -> None:
     """Track messages in-memory and adjust slowmode when thresholds are exceeded."""
-    if message.author.bot:
-        return
-
     dynamicSlowmodeChannel = await get_dynamicslowmode(message.channel.id)
     if not dynamicSlowmodeChannel:
         return

--- a/commands/channel/media.py
+++ b/commands/channel/media.py
@@ -127,9 +127,6 @@ async def removeMediaChannel(commandInfo: utility.CommandInfo, channel: discord.
 
 
 async def mediaChannelMessage(message: discord.Message) -> None:
-    if message.author.bot:
-        return
-
     if not await get_media_channel(message.channel.id):
         return
 

--- a/commands/giveaway/utility.py
+++ b/commands/giveaway/utility.py
@@ -494,9 +494,6 @@ async def addMessageToGiveaway(message: discord.Message):  # type: ignore[no-unt
     if await check_if_opted_out(message.author.id):
         return
 
-    if message.author.bot:
-        return
-
     await add_giveaway_new_message_if_needed(message.author.id, message.guild.id)  # type: ignore[union-attr]
 
     await add_giveaway_new_message_channel_if_needed(message.author.id, message.guild.id, message.channel.id)  # type: ignore[union-attr]

--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -33,6 +33,12 @@ class ListenerCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
+        # Early filter: skip bot messages and DMs once for all handlers
+        if message.author.bot:
+            return
+        if message.guild is None:
+            return
+
         # Single DB check for all counting configs — skip all 3 handlers if none
         counting_config, challenge_config, modes_config = await get_counting_configs(message.channel.id)
         if counting_config:

--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -64,9 +64,6 @@ async def counting(
         Pre-fetched config with 'progress' and 'last_counter_id'. If provided,
         get_progress_func and get_last_counter_id_func are not called.
     """
-    if message.author.bot:
-        return
-
     if await _handle_guild_check(message):
         return
 

--- a/minigames/addLevelXp.py
+++ b/minigames/addLevelXp.py
@@ -20,7 +20,7 @@ _MAX_NOTIFIED_USERS = 10_000
 
 
 async def addLevelXp(message: discord.Message) -> None:
-    if message.author.bot or await check_if_opted_out(str(message.author.id)):
+    if await check_if_opted_out(str(message.author.id)):
         return
 
     if message.guild is None:

--- a/minigames/countingmodes.py
+++ b/minigames/countingmodes.py
@@ -310,9 +310,6 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
 
     The config dict should have keys: 'progress', 'mode', 'goal', 'last_counter_id', 'guild_id'.
     """
-    if message.author.bot:
-        return
-
     if config is not None:
         progress = config.get("progress")
         mode = config.get("mode")

--- a/minigames/wordchain.py
+++ b/minigames/wordchain.py
@@ -8,10 +8,7 @@ from utility import tanjunEmbed
 
 
 async def wordchain(message: discord.Message) -> None:
-    if message.author.bot:
-        return
-
-    if message.guild == None:
+    if message.guild is None:
         embed: discord.Embed = tanjunEmbed(
             title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
             description=tanjunLocalizer.localize(


### PR DESCRIPTION
## Summary

Adds early return guards at the top of the main `on_message` listener to skip bot messages and DMs before any handler is called. Removes redundant `message.author.bot` checks from individual handlers.

## Changes

**`extensions/listeners.py`** - Added:
```python
if message.author.bot:
    return
if message.guild is None:
    return
```

**Removed redundant `message.author.bot` checks from:**
- `minigames/addLevelXp.py`
- `minigames/wordchain.py`
- `minigames/_counting_common.py` (used by counting + countingChallenge)
- `minigames/countingmodes.py`
- `commands/channel/media.py`
- `commands/channel/dynamicslowmode.py`
- `commands/admin/trigger_messages/send.py`
- `commands/giveaway/utility.py`

## Benefits
- ~N-1 redundant checks eliminated per message (N = number of handlers)
- Cleaner handler code — no duplicated guard clauses
- Marginal perf gain from avoiding function call overhead for bot/DM messages

Fixes #1352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized bot and direct message filtering to ensure consistent handling across all features (trigger messages, slowmode, media channels, giveaways, counting, XP, and wordchain).

* **Bug Fixes**
  * Improved guild-context detection logic in wordchain feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->