### PR TITLE
Replace polling loop for pool readiness with asyncio.Event

### DIFF
--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -181,9 +181,10 @@ Jede(r) ist ♥️-lich willkommen! Wir freuen uns über jeden Neuzugang! Schaut
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
-        # Wait until the database pool is initialized
-        while not hasattr(self.bot, "_pool") or self.bot._pool is None:
-            await asyncio.sleep(1)
+        # Wait until the database pool is initialized (signaled via Event)
+        if not hasattr(self.bot, "_pool_ready"):
+            self.bot._pool_ready = asyncio.Event()
+        await self.bot._pool_ready.wait()
 
         self.pollTwitchStreams.start()  # type: ignore[unused-awaitable]
         self.sendSendReadyGiveaways.start()  # type: ignore[unused-awaitable]

--- a/main.py
+++ b/main.py
@@ -91,6 +91,10 @@ async def main():
     print("starting bot...")
     print("discord.py version: ", discord.__version__)
 
+    # Create pool-ready event before loading extensions
+    # so LoopCog.on_ready can wait on it asyncio.Event-style instead of polling
+    bot._pool_ready = asyncio.Event()
+
     # Load all extensions
     for filename in os.listdir("extensions"):
         if filename.endswith(".py") and not filename.startswith("__"):
@@ -112,6 +116,7 @@ async def main():
             minsize=1,
         )
         bot._pool = pool
+        bot._pool_ready.set()  # Signal waiting tasks that pool is ready
         print("Database pool initialized successfully!")
     except Exception as e:
         print(f"Failed to initialize database pool: {e}")


### PR DESCRIPTION
Closes #1347

## Summary

Replaced the wasteful polling loop in `extensions/loops.py` that checked every second for database pool readiness with an `asyncio.Event`-based signal pattern.

## Changes

- **`main.py`**: Created `bot._pool_ready = asyncio.Event()` before extensions are loaded, and set it (`bot._pool_ready.set()`) right after pool initialization
- **`extensions/loops.py`**: Replaced the `while/asyncio.sleep(1)` polling loop with `await self.bot._pool_ready.wait()`, with a fallback `Event()` creation if it doesn't exist yet

## Benefits

- Zero CPU waste during startup — no polling/sleeping while waiting
- Instant response when pool is ready instead of up to 1-second polling granularity
- Cleaner event-driven code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Improved bot startup efficiency by replacing database readiness polling with event-based signaling, allowing background services to initialize more reliably and efficiently once database connectivity is confirmed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->