### PR TITLE
fix: Add PermissionError handling to unprotected admin commands (createrole, deleterole, nuke)

### DIFF
--- a/commands/admin/createrole.py
+++ b/commands/admin/createrole.py
@@ -156,14 +156,38 @@ async def createrole(
         display_icon_data = await display_icon.read()
     elif isinstance(display_icon, str):
         display_icon_data = display_icon
-    role = await command_info.guild.create_role(
-        name=name,
-        color=color if color is not None else discord.Color.default(),  # type: ignore[arg-type]
-        reason=reason,
-        hoist=hoist,
-        mentionable=mentionable,
-        display_icon=display_icon_data,  # type: ignore[arg-type]
-    )
+
+    try:
+        role = await command_info.guild.create_role(
+            name=name,
+            color=color if color is not None else discord.Color.default(),  # type: ignore[arg-type]
+            reason=reason,
+            hoist=hoist,
+            mentionable=mentionable,
+            display_icon=display_icon_data,  # type: ignore[arg-type]
+        )
+    except discord.Forbidden:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.forbidden.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.forbidden.description"),
+        )
+        await command_info.reply(embed=embed)
+        return
+    except discord.HTTPException as e:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.http_error.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.http_error.description", status=e.status),
+        )
+        await command_info.reply(embed=embed)
+        return
+    except discord.NotFound:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.notfound.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.notfound.description"),
+        )
+        await command_info.reply(embed=embed)
+        return
+
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.createrole.success.title"),
         description=tanjunLocalizer.localize(

--- a/commands/admin/deleterole.py
+++ b/commands/admin/deleterole.py
@@ -61,7 +61,30 @@ async def deleterole(command_info: utility.CommandInfo, role: discord.Role, reas
         return
 
     role_name: str = str(role.name)
-    await role.delete(reason=reason)
+    try:
+        await role.delete(reason=reason)
+    except discord.Forbidden:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.forbidden.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.forbidden.description"),
+        )
+        await command_info.reply(embed=embed)
+        return
+    except discord.HTTPException as e:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.http_error.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.http_error.description", status=e.status),
+        )
+        await command_info.reply(embed=embed)
+        return
+    except discord.NotFound:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.notfound.title"),
+            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.notfound.description"),
+        )
+        await command_info.reply(embed=embed)
+        return
+
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.deleterole.success.title"),
         description=tanjunLocalizer.localize(

--- a/commands/admin/nuke.py
+++ b/commands/admin/nuke.py
@@ -128,3 +128,5 @@ async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextC
         await command_info.channel.send(tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.forbiddenError"))
     except discord.HTTPException:
         await command_info.channel.send(tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.httpError"))
+    except discord.NotFound:
+        await command_info.channel.send(tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.notfoundError"))

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,5 +1,109 @@
 [
   {
+    "identifier": "commands.admin.createrole.forbidden.description",
+    "source_string": "Der Bot konnte die Rolle nicht erstellen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "translation": "Der Bot konnte die Rolle nicht erstellen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "context": "commands -> admin -> createrole -> forbidden -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.forbidden.title",
+    "source_string": "Erstellen nicht möglich",
+    "translation": "Erstellen nicht möglich",
+    "context": "commands -> admin -> createrole -> forbidden -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.http_error.description",
+    "source_string": "Beim Erstellen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "translation": "Beim Erstellen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "context": "commands -> admin -> createrole -> http_error -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.http_error.title",
+    "source_string": "Fehler beim Erstellen",
+    "translation": "Fehler beim Erstellen",
+    "context": "commands -> admin -> createrole -> http_error -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.notfound.description",
+    "source_string": "Der Server wurde nicht gefunden. Möglicherweise wurde der Bot entfernt.",
+    "translation": "Der Server wurde nicht gefunden. Möglicherweise wurde der Bot entfernt.",
+    "context": "commands -> admin -> createrole -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.notfound.title",
+    "source_string": "Server nicht gefunden",
+    "translation": "Server nicht gefunden",
+    "context": "commands -> admin -> createrole -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.forbidden.description",
+    "source_string": "Der Bot konnte die Rolle nicht löschen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "translation": "Der Bot konnte die Rolle nicht löschen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "context": "commands -> admin -> deleterole -> forbidden -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.forbidden.title",
+    "source_string": "Löschen nicht möglich",
+    "translation": "Löschen nicht möglich",
+    "context": "commands -> admin -> deleterole -> forbidden -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.http_error.description",
+    "source_string": "Beim Löschen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "translation": "Beim Löschen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "context": "commands -> admin -> deleterole -> http_error -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.http_error.title",
+    "source_string": "Fehler beim Löschen",
+    "translation": "Fehler beim Löschen",
+    "context": "commands -> admin -> deleterole -> http_error -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.notfound.description",
+    "source_string": "Die Rolle wurde nicht gefunden. Möglicherweise wurde sie bereits gelöscht.",
+    "translation": "Die Rolle wurde nicht gefunden. Möglicherweise wurde sie bereits gelöscht.",
+    "context": "commands -> admin -> deleterole -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.notfound.title",
+    "source_string": "Rolle nicht gefunden",
+    "translation": "Rolle nicht gefunden",
+    "context": "commands -> admin -> deleterole -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfoundError",
+    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "translation": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "context": "commands -> admin -> nuke -> notfoundError -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.help.select.placeholder",
     "source_string": "Befehls-Kategorie",
     "translation": "Befehls-Kategorie",

--- a/locales/de.json
+++ b/locales/de.json
@@ -96,10 +96,18 @@
     "max_length": null
   },
   {
-    "identifier": "commands.admin.nuke.notfoundError",
+    "identifier": "commands.admin.nuke.notfound.description",
     "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
     "translation": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
-    "context": "commands -> admin -> nuke -> notfoundError -> description",
+    "context": "commands -> admin -> nuke -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfound.title",
+    "source_string": "Kanal nicht gefunden",
+    "translation": "Kanal nicht gefunden",
+    "context": "commands -> admin -> nuke -> notfound -> title",
     "labels": "unassigned",
     "max_length": null
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,109 @@
 [
   {
+    "identifier": "commands.admin.createrole.forbidden.description",
+    "source_string": "Der Bot konnte die Rolle nicht erstellen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "translation": "The bot could not create the role. The required permissions may be missing.",
+    "context": "commands -> admin -> createrole -> forbidden -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.forbidden.title",
+    "source_string": "Erstellen nicht möglich",
+    "translation": "Creation not possible",
+    "context": "commands -> admin -> createrole -> forbidden -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.http_error.description",
+    "source_string": "Beim Erstellen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "translation": "An error occurred while creating the role (code ${status}).",
+    "context": "commands -> admin -> createrole -> http_error -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.http_error.title",
+    "source_string": "Fehler beim Erstellen",
+    "translation": "Creation error",
+    "context": "commands -> admin -> createrole -> http_error -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.notfound.description",
+    "source_string": "Der Server wurde nicht gefunden. Möglicherweise wurde der Bot entfernt.",
+    "translation": "The server was not found. The bot may have been removed.",
+    "context": "commands -> admin -> createrole -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.createrole.notfound.title",
+    "source_string": "Server nicht gefunden",
+    "translation": "Server not found",
+    "context": "commands -> admin -> createrole -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.forbidden.description",
+    "source_string": "Der Bot konnte die Rolle nicht löschen. Möglicherweise fehlen die erforderlichen Berechtigungen.",
+    "translation": "The bot could not delete the role. The required permissions may be missing.",
+    "context": "commands -> admin -> deleterole -> forbidden -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.forbidden.title",
+    "source_string": "Löschen nicht möglich",
+    "translation": "Deletion not possible",
+    "context": "commands -> admin -> deleterole -> forbidden -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.http_error.description",
+    "source_string": "Beim Löschen der Rolle ist ein Fehler aufgetreten (Code ${status}).",
+    "translation": "An error occurred while deleting the role (code ${status}).",
+    "context": "commands -> admin -> deleterole -> http_error -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.http_error.title",
+    "source_string": "Fehler beim Löschen",
+    "translation": "Deletion error",
+    "context": "commands -> admin -> deleterole -> http_error -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.notfound.description",
+    "source_string": "Die Rolle wurde nicht gefunden. Möglicherweise wurde sie bereits gelöscht.",
+    "translation": "The role was not found. It may have already been deleted.",
+    "context": "commands -> admin -> deleterole -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.deleterole.notfound.title",
+    "source_string": "Rolle nicht gefunden",
+    "translation": "Role not found",
+    "context": "commands -> admin -> deleterole -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfoundError",
+    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "translation": "The channel was not found. It may have already been deleted.",
+    "context": "commands -> admin -> nuke -> notfoundError -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.help.select.placeholder",
     "source_string": "Befehls-Kategorie",
     "translation": "Command category",

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,10 +96,18 @@
     "max_length": null
   },
   {
-    "identifier": "commands.admin.nuke.notfoundError",
+    "identifier": "commands.admin.nuke.notfound.description",
     "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
     "translation": "The channel was not found. It may have already been deleted.",
-    "context": "commands -> admin -> nuke -> notfoundError -> description",
+    "context": "commands -> admin -> nuke -> notfound -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfound.title",
+    "source_string": "Kanal nicht gefunden",
+    "translation": "Channel not found",
+    "context": "commands -> admin -> nuke -> notfound -> title",
     "labels": "unassigned",
     "max_length": null
   },


### PR DESCRIPTION
Closes #1331

## Summary

Adds proper error handling to three admin commands that were missing try/except protection on their Discord API calls.

## Changes

### deleterole.py
- Wrapped `await role.delete()` with try/except for:
  - `discord.Forbidden` — bot lacks Manage Roles permission
  - `discord.HTTPException` — rate limit or other HTTP error
  - `discord.NotFound` — role was deleted by another admin

### createrole.py
- Wrapped `await guild.create_role()` with try/except for:
  - `discord.Forbidden` — bot lacks Manage Roles permission
  - `discord.HTTPException` — rate limit or payload too large
  - `discord.NotFound` — guild was deleted mid-command

### nuke.py
- Added `discord.NotFound` catch to the existing channel clone/delete block

### locales
- Added German source strings and English translations for all new error messages in both en.json and de.json

## Pattern
Follows the existing error handling pattern used in other admin commands (kick, ban, etc.) with informative embed messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user-facing feedback for admin commands, with clear localized error messages for permission, network, and missing-resource failures.
  * Admin channel actions now report not-found and failure cases more reliably.

* **Localization**
  * Added English and German error message translations for admin command failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->