### PR TITLE
Global app command error handler: Catch all unhandled errors into localized error embeds

### DIFF
--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -1,0 +1,159 @@
+"""Global app command error handler.
+
+Catches all unhandled application command errors and responds with localized
+error embeds instead of Discord's generic "Interaction failed" message.
+"""
+
+import logging
+import traceback
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from localizer import tanjunLocalizer
+
+logger = logging.getLogger(__name__)
+
+
+def _get_locale(interaction: discord.Interaction) -> str:
+    """Resolve a usable locale string from the interaction.
+
+    Falls back to ``"en"`` when the interaction has no guild or locale.
+    """
+    if interaction.guild_locale is not None:
+        return str(interaction.guild_locale.value)
+    # Fall back to user locale when guild locale is unavailable (DMs etc.)
+    if interaction.locale is not None:
+        return str(interaction.locale.value)
+    return "en"
+
+
+class ErrorHandlerCog(commands.Cog):
+    """Cog that registers a global tree.on_error handler at startup."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        """Replace the default tree.on_error with our handler once the bot is ready."""
+        self.bot.tree.on_error = self._on_app_command_error
+        logger.info("Global app command error handler registered on ready.")
+
+    async def _build_error_embed(
+        self,
+        interaction: discord.Interaction,
+        locale_key: str,
+        **kwargs: Any,
+    ) -> discord.Embed:
+        """Build a localized error embed for the given translation key.
+
+        Parameters
+        ----------
+        interaction:
+            The interaction to derive the locale and guild from.
+        locale_key:
+            The dot-notation localizer key (e.g. ``"errors.cooldown"``).
+        **kwargs:
+            Extra substitution variables for the translation template.
+        """
+        locale = _get_locale(interaction)
+
+        title_key = f"{locale_key}.title"
+        desc_key = f"{locale_key}.description"
+
+        title: str = tanjunLocalizer.localize(locale, title_key, **kwargs)
+        description: str = tanjunLocalizer.localize(locale, desc_key, **kwargs)
+
+        embed = discord.Embed(
+            title=title if "no translation found" not in title.lower() else "Error",
+            description=description if "no translation found" not in description.lower() else "An unexpected error occurred.",
+            colour=0xFF6B6B,  # Soft red for errors
+        )
+        return embed
+
+    async def _on_app_command_error(
+        self,
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        """Global error handler for all tree / slash command errors."""
+        # Unwrap from CommandInvokeError if needed
+        original = error.original if isinstance(error, app_commands.CommandInvokeError) else error
+
+        # ── Known error types ──────────────────────────────────────────────
+
+        if isinstance(original, app_commands.CommandOnCooldown):
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.cooldown",
+                retry_after=round(original.retry_after, 1),
+            )
+
+        elif isinstance(original, app_commands.CheckFailure):
+            # Covers MissingPermissions, BotMissingPermissions, etc.
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.missing_permissions",
+            )
+
+        elif isinstance(original, discord.Forbidden):
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.forbidden",
+            )
+
+        elif isinstance(original, discord.HTTPException):
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.http_error",
+                status_code=original.status,
+            )
+
+        elif isinstance(original, app_commands.CommandNotFound):
+            # Silently drop – these are noise.
+            return
+
+        elif isinstance(original, app_commands.TransformerError):
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.transformer_error",
+            )
+
+        elif isinstance(original, commands.CommandInvokeError):
+            # This shouldn't normally reach here but just in case.
+            traceback.print_exception(type(original), original, original.__traceback__)
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.unexpected_error",
+            )
+
+        else:
+            # Log unexpected errors with full traceback.
+            logger.exception(
+                "Unhandled app command error in %s: %s",
+                interaction.command.qualified_name if interaction.command else "unknown",
+                original,
+            )
+            traceback.print_exception(type(original), original, original.__traceback__)
+            embed = await self._build_error_embed(
+                interaction,
+                "errors.unexpected_error",
+            )
+
+        # ── Send the embed (graceful fallback) ─────────────────────────────
+        try:
+            if interaction.response.is_done():
+                await interaction.followup.send(embed=embed, ephemeral=True)
+            else:
+                await interaction.response.send_message(embed=embed, ephemeral=True)
+        except Exception:
+            logger.exception("Failed to send error embed — giving up.")
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Load the ErrorHandlerCog."""
+    await bot.add_cog(ErrorHandlerCog(bot))
+    logger.info("ErrorHandlerCog loaded.")

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -21,13 +21,21 @@ def _get_locale(interaction: discord.Interaction) -> str:
     """Resolve a usable locale string from the interaction.
 
     Falls back to ``"en"`` when the interaction has no guild or locale.
+    Normalizes locale strings to primary language subtag (e.g. "de-DE" -> "de").
     """
+    locale_str = None
     if interaction.guild_locale is not None:
-        return str(interaction.guild_locale.value)
+        locale_str = interaction.guild_locale.value
     # Fall back to user locale when guild locale is unavailable (DMs etc.)
-    if interaction.locale is not None:
-        return str(interaction.locale.value)
-    return "en"
+    elif interaction.locale is not None:
+        locale_str = interaction.locale.value
+
+    if locale_str is None:
+        return "en"
+
+    # Normalize to primary language subtag: "de-DE" -> "de", "en_US" -> "en"
+    primary_lang = str(locale_str).split('-')[0].split('_')[0].lower()
+    return primary_lang if primary_lang else "en"
 
 
 class ErrorHandlerCog(commands.Cog):
@@ -94,9 +102,17 @@ class ErrorHandlerCog(commands.Cog):
 
         elif isinstance(original, app_commands.CheckFailure):
             # Covers MissingPermissions, BotMissingPermissions, etc.
+            missing_permissions = None
+            if isinstance(original, (app_commands.MissingPermissions, app_commands.BotMissingPermissions)):
+                # Extract missing permissions and format as comma-separated list
+                perms = getattr(original, 'missing_permissions', None)
+                if perms:
+                    missing_permissions = ", ".join(str(p).replace("_", " ").title() for p in perms)
+
             embed = await self._build_error_embed(
                 interaction,
                 "errors.missing_permissions",
+                missing_permissions=missing_permissions or "Unknown",
             )
 
         elif isinstance(original, discord.Forbidden):

--- a/locales/de.json
+++ b/locales/de.json
@@ -31321,8 +31321,8 @@
   },
   {
     "identifier": "errors.cooldown.description",
-    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
-    "translation": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
+    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in $retry_after Sekunden erneut.",
+    "translation": "Dieser Befehl hat eine Abklingzeit. Versuche es in $retry_after Sekunden erneut.",
     "context": "Description when command is on cooldown",
     "labels": "unassigned",
     "max_length": null
@@ -31337,8 +31337,8 @@
   },
   {
     "identifier": "errors.missing_permissions.description",
-    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
-    "translation": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
+    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen. Fehlende Berechtigungen: $missing_permissions",
+    "translation": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen. Fehlende Berechtigungen: $missing_permissions",
     "context": "Description when user lacks permissions",
     "labels": "unassigned",
     "max_length": null
@@ -31369,8 +31369,8 @@
   },
   {
     "identifier": "errors.http_error.description",
-    "source_string": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
-    "translation": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
+    "source_string": "Ein API-Fehler ist aufgetreten (Code $status_code). Bitte versuche es später erneut.",
+    "translation": "Ein API-Fehler ist aufgetreten (Code $status_code). Bitte versuche es später erneut.",
     "context": "Description for HTTP errors with status code",
     "labels": "unassigned",
     "max_length": null

--- a/locales/de.json
+++ b/locales/de.json
@@ -31310,5 +31310,101 @@
     "context": "Generic error message for unexpected exceptions during interaction handling",
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "errors.cooldown.title",
+    "source_string": "Cooldown aktiv",
+    "translation": "Cooldown aktiv",
+    "context": "Title for cooldown error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.cooldown.description",
+    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
+    "translation": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
+    "context": "Description when command is on cooldown",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.missing_permissions.title",
+    "source_string": "Fehlende Berechtigungen",
+    "translation": "Fehlende Berechtigungen",
+    "context": "Title for missing permissions error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.missing_permissions.description",
+    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
+    "translation": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
+    "context": "Description when user lacks permissions",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.forbidden.title",
+    "source_string": "Kein Zugriff",
+    "translation": "Kein Zugriff",
+    "context": "Title for forbidden/403 error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.forbidden.description",
+    "source_string": "Ich habe keine Berechtigung, diese Aktion auszuführen.",
+    "translation": "Ich habe keine Berechtigung, diese Aktion auszuführen.",
+    "context": "Description when the bot is forbidden from performing an action",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.http_error.title",
+    "source_string": "Discord API-Fehler",
+    "translation": "Discord API-Fehler",
+    "context": "Title for HTTP error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.http_error.description",
+    "source_string": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
+    "translation": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
+    "context": "Description for HTTP errors with status code",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.transformer_error.title",
+    "source_string": "Ungültige Eingabe",
+    "translation": "Ungültige Eingabe",
+    "context": "Title for transformer/argument conversion error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.transformer_error.description",
+    "source_string": "Ein übergebener Wert konnte nicht verarbeitet werden. Bitte überprüfe deine Eingabe.",
+    "translation": "Ein übergebener Wert konnte nicht verarbeitet werden. Bitte überprüfe deine Eingabe.",
+    "context": "Description when argument transformation fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.unexpected_error.title",
+    "source_string": "Unerwarteter Fehler",
+    "translation": "Unerwarteter Fehler",
+    "context": "Title for unexpected/catch-all error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.unexpected_error.description",
+    "source_string": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut oder kontaktiere den Support.",
+    "translation": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut oder kontaktiere den Support.",
+    "context": "Generic fallback description for unhandled errors",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -31369,8 +31369,8 @@
   },
   {
     "identifier": "errors.cooldown.description",
-    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
-    "translation": "This command is on cooldown. Try again in ** seconds**.",
+    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in $retry_after Sekunden erneut.",
+    "translation": "This command is on cooldown. Try again in $retry_after seconds.",
     "context": "Description when command is on cooldown",
     "labels": "unassigned",
     "max_length": null
@@ -31385,8 +31385,8 @@
   },
   {
     "identifier": "errors.missing_permissions.description",
-    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
-    "translation": "You do not have the required permissions to use this command.",
+    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen. Fehlende Berechtigungen: $missing_permissions",
+    "translation": "You do not have the required permissions to use this command. Missing permissions: $missing_permissions",
     "context": "Description when user lacks permissions",
     "labels": "unassigned",
     "max_length": null
@@ -31417,8 +31417,8 @@
   },
   {
     "identifier": "errors.http_error.description",
-    "source_string": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
-    "translation": "An API error occurred (code ). Please try again later.",
+    "source_string": "Ein API-Fehler ist aufgetreten (Code $status_code). Bitte versuche es später erneut.",
+    "translation": "An API error occurred (code $status_code). Please try again later.",
     "context": "Description for HTTP errors with status code",
     "labels": "unassigned",
     "max_length": null

--- a/locales/en.json
+++ b/locales/en.json
@@ -31358,5 +31358,101 @@
     "context": "Generic error message for unexpected exceptions during interaction handling",
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "errors.cooldown.title",
+    "source_string": "Cooldown aktiv",
+    "translation": "Cooldown active",
+    "context": "Title for cooldown error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.cooldown.description",
+    "source_string": "Dieser Befehl hat eine Abklingzeit. Versuche es in ** Sekunden** erneut.",
+    "translation": "This command is on cooldown. Try again in ** seconds**.",
+    "context": "Description when command is on cooldown",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.missing_permissions.title",
+    "source_string": "Fehlende Berechtigungen",
+    "translation": "Missing permissions",
+    "context": "Title for missing permissions error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.missing_permissions.description",
+    "source_string": "Du hast nicht die erforderlichen Berechtigungen, um diesen Befehl auszuführen.",
+    "translation": "You do not have the required permissions to use this command.",
+    "context": "Description when user lacks permissions",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.forbidden.title",
+    "source_string": "Kein Zugriff",
+    "translation": "Access denied",
+    "context": "Title for forbidden/403 error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.forbidden.description",
+    "source_string": "Ich habe keine Berechtigung, diese Aktion auszuführen.",
+    "translation": "I do not have permission to perform this action.",
+    "context": "Description when the bot is forbidden from performing an action",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.http_error.title",
+    "source_string": "Discord API-Fehler",
+    "translation": "Discord API error",
+    "context": "Title for HTTP error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.http_error.description",
+    "source_string": "Ein API-Fehler ist aufgetreten (Code ). Bitte versuche es später erneut.",
+    "translation": "An API error occurred (code ). Please try again later.",
+    "context": "Description for HTTP errors with status code",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.transformer_error.title",
+    "source_string": "Ungültige Eingabe",
+    "translation": "Invalid input",
+    "context": "Title for transformer/argument conversion error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.transformer_error.description",
+    "source_string": "Ein übergebener Wert konnte nicht verarbeitet werden. Bitte überprüfe deine Eingabe.",
+    "translation": "A provided value could not be processed. Please check your input.",
+    "context": "Description when argument transformation fails",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.unexpected_error.title",
+    "source_string": "Unerwarteter Fehler",
+    "translation": "Unexpected error",
+    "context": "Title for unexpected/catch-all error embed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.unexpected_error.description",
+    "source_string": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut oder kontaktiere den Support.",
+    "translation": "An unexpected error occurred. Please try again or contact support.",
+    "context": "Generic fallback description for unhandled errors",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/localizer.py
+++ b/localizer.py
@@ -89,6 +89,8 @@ class Localizer:
         locale_str: str = str(locale)
         if locale_str in ["en", "en-US", "en-GB"]:
             locale_str = "en"
+        elif locale_str.startswith("de"):
+            locale_str = "de"
         translations: list[dict[str, object]] = self.load_translations(locale_str)
         translation: dict[str, object] | None = self.get_translation(translations, key)
         if translation is None:

--- a/utility.py
+++ b/utility.py
@@ -1332,3 +1332,7 @@ def similar(a, b):
 
 def addThousandsSeparator(number: int) -> str:
     return f"{number:,}".replace(",", " ")
+
+
+tanjunEmbed = TanjunEmbed
+#: Backward-compatible alias so that ``from utility import tanjunEmbed`` still works.


### PR DESCRIPTION
Closes #1324

## Summary
Adds a global error handler for application commands via `tree.on_error`. Every unhandled exception in a slash command now returns a localized, descriptive embed instead of Discord's generic "Interaction failed" message.

## Changes
- **New `extensions/error_handler.py`**: `ErrorHandlerCog` that registers the global handler on `on_ready`
- **Handled error types**: `CommandOnCooldown`, `CheckFailure`/permissions, `Forbidden`, `HTTPException`, `TransformerError`, and a catch-all for unexpected errors
- **Graceful fallback**: Uses `interaction.followup.send` if the initial response was already sent
- **Full traceback logging** for unexpected/unhandled errors
- **Localized strings**: Added `errors.cooldown`, `errors.missing_permissions`, `errors.forbidden`, `errors.http_error`, `errors.transformer_error`, `errors.unexpected_error` (each with `.title` and `.description`) to both en.json and de.json
- **Backward compat**: Added `tanjunEmbed` alias in `utility.py` for existing imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized error handling for Discord commands in English and German.
  * Error messages give specific, contextual details (cooldowns with retry time, missing permissions, forbidden/API errors, argument/transformer issues, and an unexpected-error fallback).
  * Error responses are sent ephemerally to the invoking user.
  * Locale detection improved to better normalize German and English variants for accurate translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->