### PR TITLE
fix: Replace bare except blocks with typed error logging across 5 files (#1328)

### DIFF
--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -104,9 +104,9 @@ async def copy_emoji(
                 else:
                     static_count += 1
 
-        except Exception:
-            logging.exception("Failed to copy emoji %s (id=%s)", name, emoji_id)
-            failed_emojis.append(match.group(0))
+            except Exception:
+                logging.exception("Failed to copy emoji %s (id=%s)", name, emoji_id)
+                failed_emojis.append(match.group(0))
 
         # Handle different response scenarios
         if not successful_emojis:

--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 import aiohttp
@@ -103,8 +104,9 @@ async def copy_emoji(
                 else:
                     static_count += 1
 
-            except Exception:
-                failed_emojis.append(match.group(0))
+        except Exception:
+            logging.exception("Failed to copy emoji %s (id=%s)", name, emoji_id)
+            failed_emojis.append(match.group(0))
 
         # Handle different response scenarios
         if not successful_emojis:
@@ -159,6 +161,7 @@ async def copy_emoji(
         await command_info.reply(embed=embed)
 
     except Exception:
+        logging.exception("Unexpected error in copy_emoji command")
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.error.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.error.description"),

--- a/commands/giveaway/utility.py
+++ b/commands/giveaway/utility.py
@@ -539,6 +539,7 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
         try:
             giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
         except Exception:
+            logging.exception("Failed to fetch giveaway message %s for no-participants path", giveaway.message_id)
             return
         if not giveawaymessage:
             return
@@ -603,6 +604,7 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
     try:
         giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
     except Exception:
+        logging.exception("Failed to fetch giveaway message %s for winner announcement path", giveaway.message_id)
         return
     if not giveawaymessage:
         return

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 
 import discord
@@ -233,4 +234,4 @@ async def send_scheduled_messages(client: discord.Client) -> None:
                 await remove_scheduled_message(message_id)
 
         except Exception:
-            pass
+            logging.exception("Failed to send scheduled message %s", message_id)

--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -1,5 +1,6 @@
 import asyncio
 import difflib
+import logging
 
 import discord
 from discord import app_commands
@@ -72,7 +73,7 @@ async def log_event_consumer(bot: commands.Bot) -> None:
                 continue
             await destination_channel.send(embed=embed)
         except Exception:
-            pass  # Log failure but do not crash consumer
+            logging.exception("Error in log event consumer loop processing guild %s", guild_id)
 
 
 class ChannelBlacklistCommands(discord.app_commands.Group):

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -177,7 +177,7 @@ Jede(r) ist ♥️-lich willkommen! Wir freuen uns über jeden Neuzugang! Schaut
                 if sent_message.guild:
                     await sent_message.publish()
         except Exception:
-            raise
+            logging.exception("Error in pokemon advertising loop")
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:


### PR DESCRIPTION
## Summary

Closes #1328

Replaces bare/silent `except Exception` blocks with proper error logging across the codebase. This ensures background task failures are visible in logs instead of being silently swallowed.

## Changes

| File | Before | After |
|------|--------|-------|
| `extensions/loops.py` | `except Exception: raise` | `logging.exception(...)` |
| `extensions/logs.py` | `except Exception: pass` | `logging.exception(...)` |
| `commands/utility/schedulemessage.py` | `except Exception: pass` | `logging.exception(...)` |
| `commands/giveaway/utility.py` | 2× `except Exception: return` | `logging.exception(...)` + `return` |
| `commands/admin/copy_emoji.py` | silent `except Exception` | `logging.exception(...)` |

Also added missing `import logging` where needed.

## Notes

- Several files mentioned in the issue (`extensions/loops.py`, `extensions/listeners.py`) already had proper logging.exception calls due to prior work — only remaining bare blocks were fixed.
- `contextlib.suppress(Exception)` in `autopublish.py` and the final fallback in `listeners.py`'s `_send_error` were left unchanged as they represent intentional fire-and-forget patterns.
- `discord.errors.NotFound: pass` in `giveaway/utility.py` (updateGiveawayMessage) was also left as-is — it's a legitimate case where not finding the message is not an error.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging across emoji copy, giveaway completion, scheduled message delivery, background event consumer, and scheduled advertising loops so failures are recorded with context and stack traces for easier diagnosis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->