### PR TITLE
fix(#1351): remove redundant role_boost loop in calculate_xp that double-counted boosts

### DIFF
--- a/minigames/_xp_core.py
+++ b/minigames/_xp_core.py
@@ -1,8 +1,8 @@
 """Shared XP calculation for both voice and message XP.
 
-The calculate_xp function was duplicated between loops/level.py and
-minigames/add_level_xp.py with nearly identical logic. This module provides
-a single implementation that both can use.
+Provides a single canonical calculate_xp used by both loops/level.py and
+minigames/add_level_xp.py. The voice XP double-counting bug has been fixed
+by removing the redundant role_boost loop.
 """
 
 import math
@@ -27,13 +27,6 @@ async def calculate_xp(guild_id: str, user_id: str, channel_id: str, role_ids: l
             total_additive_boost += user_boost.boost - 1
         else:
             total_multiplicative_boost *= user_boost.boost
-
-    if role_boosts:
-        for role_boost in role_boosts:
-            if role_boost.additive:
-                total_additive_boost += role_boost.boost - 1
-            else:
-                total_multiplicative_boost *= role_boost.boost
 
     if channel_boost:
         if channel_boost.additive:


### PR DESCRIPTION
## Summary

The refactoring that consolidated `calculate_xp` into `minigames/_xp_core.py` (commit `5a2f7d0`) already resolved the code duplication issue from #1351. Both `loops/level.py` and `minigames/add_level_xp.py` now import from the shared module.

However, a **double-counting bug** from the original `loops/level.py` was carried over into the shared module. Role boosts were being processed **twice**:

1. **Lines 23-24**: via `sum()` and `math.prod()` — sets the initial boost values
2. **Lines 34-40**: via an explicit `for role_boost in role_boosts` loop — **adds them again**

This means voice XP (and message XP) was applying role boosts at 2× the intended rate.

## Changes

- **`minigames/_xp_core.py`**: Removed the redundant `role_boosts` loop (lines 32-40)
- Updated the module docstring to reflect the current state

## Testing

The logic still processes role boosts exactly once — the `sum()`/`math.prod()` on lines 23-24 remain, and user/channel boosts are still applied correctly.

Fixes #1351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed voice XP double-counting issue where experience points were incorrectly inflated from voice activities. XP calculations are now accurate and consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->