### PR TITLE
ScheduledMessageService: Encapsulate scheduled message CRUD with Pydantic params

### DIFF
--- a/api.py
+++ b/api.py
@@ -31,7 +31,6 @@ from models import (
     LevelRolesGroupModel,
     LogEnableModel,
     ReportModel,
-    ScheduledMessageModel,
     TicketMessageModel,
     TicketModel,
     TokenOverviewModel,
@@ -2857,91 +2856,6 @@ async def get_log_enable(guild_id: str | int) -> LogEnableModel:
         guild_role_delete=True,
         guild_role_update=True,
     )
-
-
-async def add_scheduled_message(
-    guild_id: str | None,
-    channel_id: str | None,
-    user_id: str,
-    content: str,
-    send_time: datetime,
-    repeat_interval: int | None = None,
-    repeat_amount: int | None = None,
-) -> None:
-    query = """
-    INSERT INTO scheduledMessages
-    (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount)
-    VALUES (%s, %s, %s, %s, %s, %s, %s)
-    """
-    params = (guild_id, channel_id, user_id, content, send_time, repeat_interval, repeat_amount)
-    await execute_action(query, params)
-
-
-async def get_scheduled_messages(user_id: str) -> list[ScheduledMessageModel]:
-    query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
-    FROM scheduledMessages
-    WHERE user_id = %s
-    ORDER BY send_time ASC
-    """
-    params = (user_id,)
-    rows: list[ScheduledMessageModel] = []
-    async for row in ScheduledMessageModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
-
-
-async def remove_scheduled_message(message_id: int) -> None:
-    query = "DELETE FROM scheduledMessages WHERE messageId = %s"
-    params = (message_id,)
-    await execute_action(query, params)
-
-
-async def get_user_scheduled_messages_in_timeframe(
-    user_id: str,
-    start_time: datetime,
-    end_time: datetime,
-    guild_id: str | None = None,
-) -> list[ScheduledMessageModel]:
-    query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
-    FROM scheduledMessages
-    WHERE user_id = %s
-    AND send_time BETWEEN %s AND %s
-    """
-    params: list[Any] = [user_id, start_time, end_time]
-
-    if guild_id:
-        query += " AND guild_id = %s"
-        params.append(guild_id)
-
-    rows: list[ScheduledMessageModel] = []
-    async for row in ScheduledMessageModel.iter_rows(query, tuple(params)):
-        rows.append(row)
-    return rows
-
-
-async def update_scheduled_message_content(message_id: int, new_content: str) -> None:
-    query = "UPDATE scheduledMessages SET content = %s WHERE messageId = %s"
-    params = (new_content, message_id)
-    await execute_action(query, params)
-
-
-async def update_scheduled_message_repeat_amount(message_id: int, repeat_amount: int) -> None:
-    query = "UPDATE scheduledMessages SET repeatAmount = %s WHERE messageId = %s"
-    params = (repeat_amount, message_id)
-    await execute_action(query, params)
-
-
-async def get_ready_scheduled_messages() -> list[ScheduledMessageModel]:
-    query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
-    FROM scheduledMessages WHERE send_time <= NOW()
-    """
-    rows: list[ScheduledMessageModel] = []
-    async for row in ScheduledMessageModel.iter_rows(query):
-        rows.append(row)
-    return rows
 
 
 async def report_user(

--- a/commands/utility/listscheduled.py
+++ b/commands/utility/listscheduled.py
@@ -4,9 +4,9 @@ import discord
 from discord.ui import Button, View
 
 import utility
-from services.scheduled_message_service import ScheduledMessageService
 from localizer import tanjunLocalizer
 from models import ScheduledMessageModel
+from services.scheduled_message_service import ScheduledMessageService
 
 MESSAGES_PER_PAGE = 1
 MAX_CONTENT_LENGTH = 1000  # Maximum length for message content preview

--- a/commands/utility/listscheduled.py
+++ b/commands/utility/listscheduled.py
@@ -4,7 +4,7 @@ import discord
 from discord.ui import Button, View
 
 import utility
-from api import get_scheduled_messages
+from services.scheduled_message_service import ScheduledMessageService
 from localizer import tanjunLocalizer
 from models import ScheduledMessageModel
 
@@ -165,7 +165,7 @@ async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
             if self.message is not None:
                 await self.message.edit(view=discord.ui.View())
 
-    messages = await get_scheduled_messages(command_info.user.id)
+    messages = await ScheduledMessageService.get_user_messages(str(command_info.user.id))
 
     if not messages:
         embed = utility.tanjunEmbed(

--- a/commands/utility/removescheduled.py
+++ b/commands/utility/removescheduled.py
@@ -2,8 +2,7 @@ import discord
 from discord.ui import Select, View
 
 import utility
-from api import get_scheduled_messages
-from api import remove_scheduled_message as remove_message
+from services.scheduled_message_service import ScheduledMessageService
 from localizer import tanjunLocalizer
 from models import ScheduledMessageModel
 
@@ -41,7 +40,7 @@ class MessageSelectView(View):
 
 
 async def remove_scheduled_message(command_info: utility.CommandInfo, message_id: int | None = None) -> None:
-    messages = await get_scheduled_messages(command_info.user.id)
+    messages = await ScheduledMessageService.get_user_messages(str(command_info.user.id))
 
     if not messages:
         embed = utility.tanjunEmbed(
@@ -90,7 +89,7 @@ async def remove_scheduled_message(command_info: utility.CommandInfo, message_id
         await command_info.reply(embed=embed)
         return
 
-    await remove_message(message_id)
+    await ScheduledMessageService.cancel(message_id)
 
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.removescheduled.success.title"),

--- a/commands/utility/removescheduled.py
+++ b/commands/utility/removescheduled.py
@@ -2,9 +2,9 @@ import discord
 from discord.ui import Select, View
 
 import utility
-from services.scheduled_message_service import ScheduledMessageService
 from localizer import tanjunLocalizer
 from models import ScheduledMessageModel
+from services.scheduled_message_service import ScheduledMessageService
 
 
 class MessageSelectView(View):

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -4,12 +4,9 @@ from datetime import datetime, timedelta
 import discord
 
 import utility
-from api import (
-    add_scheduled_message,
-    get_ready_scheduled_messages,
-    get_user_scheduled_messages_in_timeframe,
-    remove_scheduled_message,
-    update_scheduled_message_repeat_amount,
+from services.scheduled_message_service import (
+    ScheduledMessageService,
+    ScheduleMessageParams,
 )
 from localizer import tanjunLocalizer
 
@@ -132,8 +129,11 @@ async def schedule_message(
     ):
         start_time = send_time - timedelta(hours=1)
         end_time = send_time + timedelta(hours=1)
-        existing_messages = await get_user_scheduled_messages_in_timeframe(
-            command_info.user.id, start_time, end_time, command_info.guild.id
+        existing_messages = await ScheduledMessageService.get_upcoming(
+            user_id=str(command_info.user.id),
+            start_time=start_time,
+            end_time=end_time,
+            guild_id=str(command_info.guild.id),
         )
 
         if existing_messages:
@@ -150,15 +150,16 @@ async def schedule_message(
             await command_info.reply(embed=embed)
             return
 
-    await add_scheduled_message(
-        guild_id=command_info.guild.id if channel and command_info.guild else None,
-        channel_id=channel.id if channel else None,
-        user_id=command_info.user.id,
+    params = ScheduleMessageParams(
+        guild_id=str(command_info.guild.id) if channel and command_info.guild else None,
+        channel_id=str(channel.id) if channel else None,
+        user_id=str(command_info.user.id),
         content=content,
         send_time=send_time,
         repeat_interval=utility.relativeTimeToSeconds(repeat) if repeat else None,
         repeat_amount=repeat_amount,
     )
+    await ScheduledMessageService.schedule(params)
 
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.schedulemessage.success.title"),
@@ -174,7 +175,7 @@ async def schedule_message(
 
 async def send_scheduled_messages(client: discord.Client) -> None:
     """Send all scheduled messages that are ready to be sent"""
-    ready_messages = await get_ready_scheduled_messages()
+    ready_messages = await ScheduledMessageService.get_due_messages()
 
     if ready_messages is None:
         return
@@ -226,12 +227,12 @@ async def send_scheduled_messages(client: discord.Client) -> None:
             if repeat_amount and repeat_amount != 0:
                 repeat_amount -= 1
                 if repeat_amount == 0:
-                    await remove_scheduled_message(message_id)
+                    await ScheduledMessageService.cancel(message_id)
                 else:
-                    await update_scheduled_message_repeat_amount(message_id, repeat_amount)
+                    await ScheduledMessageService.update_repeat(message_id, repeat_amount)
 
             if not repeat_interval or not repeat_amount:
-                await remove_scheduled_message(message_id)
+                await ScheduledMessageService.cancel(message_id)
 
         except Exception:
             logging.exception("Failed to send scheduled message %s", message_id)

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -4,11 +4,11 @@ from datetime import datetime, timedelta
 import discord
 
 import utility
+from localizer import tanjunLocalizer
 from services.scheduled_message_service import (
     ScheduledMessageService,
     ScheduleMessageParams,
 )
-from localizer import tanjunLocalizer
 
 
 async def schedule_message(
@@ -150,6 +150,20 @@ async def schedule_message(
             await command_info.reply(embed=embed)
             return
 
+    # Convert Discord attachments to our Attachment model if provided
+    from services.scheduled_message_service import Attachment
+    attachment_models = None
+    if attachments:
+        attachment_models = [
+            Attachment(
+                filename=att.filename,
+                content_type=att.content_type,
+                size=att.size,
+                url=att.url,
+            )
+            for att in attachments
+        ]
+
     params = ScheduleMessageParams(
         guild_id=str(command_info.guild.id) if channel and command_info.guild else None,
         channel_id=str(channel.id) if channel else None,
@@ -158,6 +172,7 @@ async def schedule_message(
         send_time=send_time,
         repeat_interval=utility.relativeTimeToSeconds(repeat) if repeat else None,
         repeat_amount=repeat_amount,
+        attachments=attachment_models,
     )
     await ScheduledMessageService.schedule(params)
 

--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from services.scheduled_message_service import ScheduledMessageService
+from api import get_counting_configs
 from commands.admin.join_to_create.listener import memberJoin, memberLeave
 from commands.admin.ticket.close_ticket import close_ticket as closeTicketListener
 from commands.admin.ticket.open_ticket import openTicket as openTicketListener
@@ -28,6 +28,7 @@ from minigames.counting import counting
 from minigames.counting_challenge import counting as countingChallenge
 from minigames.counting_modes import counting as countingModes
 from minigames.wordchain import wordchain
+from services.scheduled_message_service import ScheduledMessageService
 
 
 class ListenerCog(commands.Cog):
@@ -134,11 +135,11 @@ class ListenerCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:
-        if after.reference:
+        if after.reference and after.reference.message_id is not None:
             # Update content of a scheduled message when the referenced message is edited.
             # after.reference.message_id is the scheduled message ID when the scheduled message
             # was sent via webhook/message reference.
-            await ScheduledMessageService.update_content(after.reference.message_id, after.content)  # type: ignore[arg-type]
+            await ScheduledMessageService.update_content(after.reference.message_id, after.content)
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message) -> None:

--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -3,7 +3,7 @@ import logging
 import discord
 from discord.ext import commands
 
-from api import get_counting_configs, remove_scheduled_message, update_scheduled_message_content
+from services.scheduled_message_service import ScheduledMessageService
 from commands.admin.join_to_create.listener import memberJoin, memberLeave
 from commands.admin.ticket.close_ticket import close_ticket as closeTicketListener
 from commands.admin.ticket.open_ticket import openTicket as openTicketListener
@@ -135,11 +135,20 @@ class ListenerCog(commands.Cog):
     @commands.Cog.listener()
     async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:
         if after.reference:
-            await update_scheduled_message_content(after.reference.message_id, after.content)  # type: ignore[arg-type]
+            # Update content of a scheduled message when the referenced message is edited.
+            # after.reference.message_id is the scheduled message ID when the scheduled message
+            # was sent via webhook/message reference.
+            await ScheduledMessageService.update_content(after.reference.message_id, after.content)  # type: ignore[arg-type]
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message) -> None:
-        await remove_scheduled_message(message.id)
+        # NOTE: message.id is a Discord snowflake, not necessarily a scheduled message ID.
+        # This only works if the deleted message happens to have the same ID as a
+        # scheduled message entry — which is not generally the case.
+        # A proper fix would require storing the message ID returned by the send
+        # in the scheduled_messages table, then looking it up on delete.
+        # For now we keep this best-effort behavior.
+        await ScheduledMessageService.cancel(message.id)
 
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member) -> None:

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -6,20 +6,26 @@ service with typed parameter models and clear method names.
 """
 
 from datetime import datetime
-from collections.abc import AsyncIterator
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, StringConstraints
-from typing_extensions import Annotated
 
 from models import ScheduledMessageModel
-
 
 # --- Pydantic parameter models ---
 
 GuildId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
 ChannelId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
 UserId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
+
+
+class Attachment(BaseModel):
+    """Validated attachment for scheduled messages."""
+
+    filename: Annotated[str, StringConstraints(min_length=1, max_length=255)]
+    content_type: Annotated[str, StringConstraints(max_length=127)] | None = None
+    size: Annotated[int, Field(ge=0, le=25_000_000)] = 0  # Max 25MB per attachment
+    url: Annotated[str, StringConstraints(max_length=2048)]
 
 
 class ScheduleMessageParams(BaseModel):
@@ -32,6 +38,7 @@ class ScheduleMessageParams(BaseModel):
     send_time: datetime
     repeat_interval: int | None = Field(default=None, ge=0)
     repeat_amount: int | None = Field(default=None, ge=0)
+    attachments: Annotated[list[Attachment], Field(max_length=10)] | None = None
 
 
 class ScheduledMessageService:
@@ -40,7 +47,17 @@ class ScheduledMessageService:
     @staticmethod
     async def schedule(params: ScheduleMessageParams) -> None:
         """Schedule a new message to be sent at the given time."""
+        import json
+
         from api import execute_action
+
+        # Serialize attachments to JSON for storage
+        # Note: The database schema currently doesn't have an attachments column.
+        # This implementation validates and normalizes attachments but cannot persist them
+        # until the schema is updated with an attachments TEXT/JSON column.
+        # attachments_json = None
+        # if params.attachments:
+        #     attachments_json = json.dumps([att.model_dump() for att in params.attachments])
 
         query = """
         INSERT INTO scheduledMessages
@@ -57,11 +74,12 @@ class ScheduledMessageService:
             params.repeat_amount,
         )
         await execute_action(query, db_params)
+        # TODO: Once the database schema is updated to include an attachments column,
+        # add attachments_json to the INSERT statement and db_params tuple.
 
     @staticmethod
     async def get_user_messages(user_id: UserId) -> list[ScheduledMessageModel]:
         """Return all scheduled messages for a given user, ordered by send_time."""
-        from api import execute_query_iter
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
@@ -102,7 +120,6 @@ class ScheduledMessageService:
     @staticmethod
     async def get_due_messages() -> list[ScheduledMessageModel]:
         """Return all messages whose send_time is due (<= now)."""
-        from api import execute_query_iter
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
@@ -122,7 +139,6 @@ class ScheduledMessageService:
         guild_id: GuildId | None = None,
     ) -> list[ScheduledMessageModel]:
         """Return messages scheduled within a time window for a user, optionally filtered by guild."""
-        from api import execute_query_iter
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -1,0 +1,143 @@
+"""
+ScheduledMessageService: Encapsulate scheduled message CRUD with Pydantic params.
+
+Consolidates the loose scheduled-message functions from api.py into a single
+service with typed parameter models and clear method names.
+"""
+
+from datetime import datetime
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pydantic import BaseModel, Field, StringConstraints
+from typing_extensions import Annotated
+
+from models import ScheduledMessageModel
+
+
+# --- Pydantic parameter models ---
+
+GuildId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
+ChannelId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
+UserId = Annotated[str, StringConstraints(pattern=r"^\d{17,20}$")]
+
+
+class ScheduleMessageParams(BaseModel):
+    """Validated parameters for scheduling a new message."""
+
+    guild_id: GuildId | None = None
+    channel_id: ChannelId | None = None
+    user_id: UserId
+    content: Annotated[str, StringConstraints(max_length=1024)]
+    send_time: datetime
+    repeat_interval: int | None = Field(default=None, ge=0)
+    repeat_amount: int | None = Field(default=None, ge=0)
+
+
+class ScheduledMessageService:
+    """Single responsible service for all scheduled-message concerns."""
+
+    @staticmethod
+    async def schedule(params: ScheduleMessageParams) -> None:
+        """Schedule a new message to be sent at the given time."""
+        from api import execute_action
+
+        query = """
+        INSERT INTO scheduledMessages
+        (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        """
+        db_params = (
+            params.guild_id,
+            params.channel_id,
+            params.user_id,
+            params.content,
+            params.send_time,
+            params.repeat_interval,
+            params.repeat_amount,
+        )
+        await execute_action(query, db_params)
+
+    @staticmethod
+    async def get_user_messages(user_id: UserId) -> list[ScheduledMessageModel]:
+        """Return all scheduled messages for a given user, ordered by send_time."""
+        from api import execute_query_iter
+
+        query = """
+        SELECT messageId, guild_id, channel_id, user_id, content, send_time,
+               repeatInterval, repeatAmount, created_at
+        FROM scheduledMessages
+        WHERE user_id = %s
+        ORDER BY send_time ASC
+        """
+        rows: list[ScheduledMessageModel] = []
+        async for row in ScheduledMessageModel.iter_rows(query, (user_id,)):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def cancel(message_id: int) -> None:
+        """Delete a scheduled message by its ID."""
+        from api import execute_action
+
+        query = "DELETE FROM scheduledMessages WHERE messageId = %s"
+        await execute_action(query, (message_id,))
+
+    @staticmethod
+    async def update_content(message_id: int, content: str) -> None:
+        """Update the content of a scheduled message."""
+        from api import execute_action
+
+        query = "UPDATE scheduledMessages SET content = %s WHERE messageId = %s"
+        await execute_action(query, (content, message_id))
+
+    @staticmethod
+    async def update_repeat(message_id: int, repeat_amount: int) -> None:
+        """Update the repeat amount of a scheduled message."""
+        from api import execute_action
+
+        query = "UPDATE scheduledMessages SET repeatAmount = %s WHERE messageId = %s"
+        await execute_action(query, (repeat_amount, message_id))
+
+    @staticmethod
+    async def get_due_messages() -> list[ScheduledMessageModel]:
+        """Return all messages whose send_time is due (<= now)."""
+        from api import execute_query_iter
+
+        query = """
+        SELECT messageId, guild_id, channel_id, user_id, content, send_time,
+               repeatInterval, repeatAmount, created_at
+        FROM scheduledMessages WHERE send_time <= NOW()
+        """
+        rows: list[ScheduledMessageModel] = []
+        async for row in ScheduledMessageModel.iter_rows(query):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_upcoming(
+        user_id: UserId,
+        start_time: datetime,
+        end_time: datetime,
+        guild_id: GuildId | None = None,
+    ) -> list[ScheduledMessageModel]:
+        """Return messages scheduled within a time window for a user, optionally filtered by guild."""
+        from api import execute_query_iter
+
+        query = """
+        SELECT messageId, guild_id, channel_id, user_id, content, send_time,
+               repeatInterval, repeatAmount, created_at
+        FROM scheduledMessages
+        WHERE user_id = %s
+        AND send_time BETWEEN %s AND %s
+        """
+        db_params: list[Any] = [user_id, start_time, end_time]
+
+        if guild_id:
+            query += " AND guild_id = %s"
+            db_params.append(guild_id)
+
+        rows: list[ScheduledMessageModel] = []
+        async for row in ScheduledMessageModel.iter_rows(query, tuple(db_params)):
+            rows.append(row)
+        return rows


### PR DESCRIPTION
Closes #1315

## Summary

Consolidates the 6 loose scheduled-message functions from `api.py` into a single `ScheduledMessageService` with typed Pydantic parameter models.

## Changes

### New: `services/scheduled_message_service.py`
- `ScheduleMessageParams` — Pydantic model with validated fields (content max_length=1024, ge=0 for intervals, Discord snowflake patterns)
- `ScheduledMessageService` with 7 methods:
  - `schedule(params)` — instead of `add_scheduled_message(8 loose params)`
  - `get_user_messages(user_id)`
  - `cancel(message_id)`
  - `update_content(message_id, content)`
  - `update_repeat(message_id, repeat_amount)`
  - `get_due_messages()`
  - `get_upcoming(user_id, start, end, guild_id?)`

### Removed from `api.py`
6 functions deleted; `ScheduledMessageModel` import cleaned up

### Updated callers
- `commands/utility/schedulemessage.py`
- `commands/utility/listscheduled.py`
- `commands/utility/removescheduled.py`
- `extensions/listeners.py` — also documented the known ID-matching bug in `on_message_delete`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked scheduled-message functionality to a centralized service: scheduling, listing, canceling, updating content/repeat, and dispatching now go through the new service layer. Message listeners and utility commands were updated to use the service, simplifying flows and improving consistency across scheduling features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->