### PR TITLE
fix: Move CPU-bound formula evaluation to thread executor (#1344)

### DIFF
--- a/api.py
+++ b/api.py
@@ -44,7 +44,7 @@ from models import (
     WelcomeChannelModel,
     XpBoostModel,
 )
-from utility import get_level_for_xp, get_xp_for_level
+from utility import get_level_for_xp_async, get_xp_for_level_async
 
 # Remove global pool and set_pool functions
 # The pool will be accessed from the bot object
@@ -1733,9 +1733,9 @@ async def get_user_level_info(guild_id: str, user_id: str) -> UserLevelInfoModel
         formula = custom_formula or ""
 
         xp, custom_background = result[0]
-        level = get_level_for_xp(xp, scaling, formula)
-        xp_needed = get_xp_for_level(level, scaling, formula)
-        xp_for_last_level_needed = get_xp_for_level(level - 1, scaling, formula)
+        level = await get_level_for_xp_async(xp, scaling, formula)
+        xp_needed = await get_xp_for_level_async(level, scaling, formula)
+        xp_for_last_level_needed = await get_xp_for_level_async(level - 1, scaling, formula)
         return UserLevelInfoModel(
             xp=xp - xp_for_last_level_needed,
             level=level,

--- a/commands/level/change_xp_scaling.py
+++ b/commands/level/change_xp_scaling.py
@@ -8,7 +8,7 @@ from localizer import tanjunLocalizer
 from utility import (
     LEVEL_SCALINGS,
     command_info,
-    get_xp_for_level,
+    get_xp_for_level_async,
     tanjunEmbed,
 )
 
@@ -106,7 +106,7 @@ async def change_xp_scaling_command(command_info: command_info, scaling: str, cu
     )
 
     # Add field to show XP required for first 5 levels
-    xp_examples = "\n".join([f"Level {i}: {get_xp_for_level(i, scaling, custom_formula)} XP" for i in range(1, 6)])
+    xp_examples = "\n".join([f"Level {i}: {await get_xp_for_level_async(i, scaling, custom_formula)} XP" for i in range(1, 6)])
     embed.add_field(
         name=tanjunLocalizer.localize(command_info.locale, "commands.level.changexpscaling.xp_examples"),
         value=xp_examples,
@@ -157,7 +157,7 @@ async def show_xp_scalings(command_info: command_info, start_level: int = 1, end
                         command_info.locale,
                         "commands.level.showxpscalings.data",
                         level=i,
-                        xp=get_xp_for_level(i, scaling, custom_formula if scaling == "custom" else None),
+                        xp=await get_xp_for_level_async(i, scaling, custom_formula if scaling == "custom" else None),
                     )
                     for i in range(current_start, current_end + 1)
                 ]

--- a/commands/level/give_xp.py
+++ b/commands/level/give_xp.py
@@ -2,7 +2,7 @@ import discord
 
 from api import get_custom_formula, get_user_xp, get_xp_scaling, update_user_xp
 from localizer import tanjunLocalizer
-from utility import CommandInfo, get_level_for_xp, tanjunEmbed
+from utility import CommandInfo, get_level_for_xp_async, tanjunEmbed
 
 
 async def give_xp_command(command_info: CommandInfo, user: discord.Member, amount: int) -> None:
@@ -44,8 +44,8 @@ async def give_xp_command(command_info: CommandInfo, user: discord.Member, amoun
     scaling = await get_xp_scaling(str(command_info.guild.id))
     custom_formula = await get_custom_formula(str(command_info.guild.id))
 
-    old_level = get_level_for_xp(current_xp, scaling, custom_formula)
-    new_level = get_level_for_xp(new_xp, scaling, custom_formula)
+    old_level = await get_level_for_xp_async(current_xp, scaling, custom_formula)
+    new_level = await get_level_for_xp_async(new_xp, scaling, custom_formula)
 
     await update_user_xp(str(command_info.guild.id), str(user.id), new_xp)
 

--- a/commands/level/leaderboard.py
+++ b/commands/level/leaderboard.py
@@ -8,6 +8,7 @@ from api import (
     get_xp_scaling,
 )
 from localizer import tanjunLocalizer
+from utility import get_level_for_xp_async, get_xp_for_level_async
 
 ITEMS_PER_PAGE = 10
 
@@ -45,9 +46,9 @@ async def leaderboard(command_info: utility.command_info, page: int = 1):
         for i, entry in enumerate(entries):
             user = entry.user_id
             xp = entry.xp
-            level = utility.get_level_for_xp(xp, scaling, custom_formula)
-            xp_from_last_level = xp - utility.get_xp_for_level(level - 1, scaling, custom_formula)
-            xp_till_next_level = utility.get_xp_for_level(level, scaling, custom_formula)
+            level = await get_level_for_xp_async(xp, scaling, custom_formula)
+            xp_from_last_level = xp - await get_xp_for_level_async(level - 1, scaling, custom_formula)
+            xp_till_next_level = await get_xp_for_level_async(level, scaling, custom_formula)
             description += (
                 f"\n{base_rank + i}. <@{user}> - "
                 f"{tanjunLocalizer.localize(command_info.locale, 'commands.level.leaderboard.data', level=level, xp_from_last_level=xp_from_last_level, xp_till_next_level=xp_till_next_level)}"

--- a/commands/level/take_xp.py
+++ b/commands/level/take_xp.py
@@ -2,7 +2,7 @@ import discord
 
 from api import get_custom_formula, get_user_xp, get_xp_scaling, update_user_xp
 from localizer import tanjunLocalizer
-from utility import CommandInfo, get_level_for_xp, tanjunEmbed
+from utility import CommandInfo, get_level_for_xp_async, tanjunEmbed
 
 
 async def take_xp_command(command_info: CommandInfo, user: discord.Member, amount: int) -> None:
@@ -39,8 +39,8 @@ async def take_xp_command(command_info: CommandInfo, user: discord.Member, amoun
     scaling = await get_xp_scaling(str(command_info.guild.id))
     custom_formula = await get_custom_formula(str(command_info.guild.id))
 
-    old_level = get_level_for_xp(current_xp, scaling, custom_formula)
-    new_level = get_level_for_xp(new_xp, scaling, custom_formula)
+    old_level = await get_level_for_xp_async(current_xp, scaling, custom_formula)
+    new_level = await get_level_for_xp_async(new_xp, scaling, custom_formula)
 
     await update_user_xp(str(command_info.guild.id), str(user.id), new_xp)
 

--- a/minigames/add_level_xp.py
+++ b/minigames/add_level_xp.py
@@ -15,7 +15,7 @@ from api import (
 )
 from localizer import tanjunLocalizer
 from minigames._xp_core import calculate_xp, is_entity_blacklisted
-from utility import get_level_for_xp
+from utility import get_level_for_xp_async, get_xp_for_level_async
 
 notifiedUsers: set[int] = set()
 _MAX_NOTIFIED_USERS = 10_000
@@ -39,10 +39,10 @@ async def addLevelXp(message: discord.Message) -> None:
     scaling, custom_formula, xp_to_add = await fetch_xp_details(message, guild_id)
 
     current_xp = await get_user_xp(guild_id, str(message.author.id)) or 0
-    current_level = get_level_for_xp(current_xp, scaling, custom_formula)
+    current_level = await get_level_for_xp_async(current_xp, scaling, custom_formula)
 
     new_xp = current_xp + xp_to_add
-    new_level = get_level_for_xp(new_xp, scaling, custom_formula)
+    new_level = await get_level_for_xp_async(new_xp, scaling, custom_formula)
 
     await update_user_xp(guild_id, str(message.author.id), xp_to_add, respect_cooldown=True)
     if new_level > current_level:

--- a/minigames/add_level_xp.py
+++ b/minigames/add_level_xp.py
@@ -15,7 +15,7 @@ from api import (
 )
 from localizer import tanjunLocalizer
 from minigames._xp_core import calculate_xp, is_entity_blacklisted
-from utility import get_level_for_xp_async, get_xp_for_level_async
+from utility import get_level_for_xp_async
 
 notifiedUsers: set[int] = set()
 _MAX_NOTIFIED_USERS = 10_000

--- a/utility.py
+++ b/utility.py
@@ -1018,6 +1018,7 @@ class LevelThresholdCache:
     _thresholds: collections.OrderedDict[tuple[str, str | None], tuple[list[int], int]] = collections.OrderedDict()
     _MAX_LEVEL = 10000
     _MAX_ENTRIES = 50  # Prevent unbounded growth: ~50 scaling/formula combos max
+    _lock: asyncio.Lock = asyncio.Lock()
 
     @classmethod
     def get_level_for_xp(cls, xp: int, scaling: str, custom_formula: str | None = None) -> int:
@@ -1080,26 +1081,38 @@ class LevelThresholdCache:
 
         if thresholds is None or thresholds[-1] < xp:
             # Build or extend thresholds if needed
-            if thresholds is None:
-                start_level = 1
-                thresholds = []
-                max_level = cls._MAX_LEVEL
-            else:
-                # Extend from current; don't rebuild from scratch
-                if max_level >= cls._MAX_LEVEL and thresholds[-1] >= xp:
-                    return bisect.bisect_right(thresholds, xp)
-                start_level = len(thresholds) + 1
-                max_level = cls._MAX_LEVEL
-            for level in range(start_level, max_level + 1):
-                xp_needed = await get_xp_for_level_async(level, scaling, effective_formula)
-                thresholds.append(xp_needed)
-                if thresholds[-1] > xp and level >= start_level + 10:
-                    max_level = level
-                    break
-            cls._thresholds[key] = (thresholds, max_level)
-            # Evict oldest entries if cache exceeds limit
-            while len(cls._thresholds) > cls._MAX_ENTRIES:
-                cls._thresholds.popitem(last=False)
+            async with cls._lock:
+                # Re-check after acquiring lock (another coroutine may have built it)
+                entry = cls._thresholds.get(key)
+                if entry is not None:
+                    thresholds, max_level = entry
+                    if thresholds is not None and thresholds[-1] >= xp:
+                        return bisect.bisect_right(thresholds, xp)
+
+                # Use local list to avoid mutating shared state during await
+                if thresholds is None:
+                    start_level = 1
+                    new_thresholds = []
+                    max_level = cls._MAX_LEVEL
+                else:
+                    # Extend from current; don't rebuild from scratch
+                    if max_level >= cls._MAX_LEVEL and thresholds[-1] >= xp:
+                        return bisect.bisect_right(thresholds, xp)
+                    start_level = len(thresholds) + 1
+                    new_thresholds = thresholds.copy()
+                    max_level = cls._MAX_LEVEL
+                for level in range(start_level, max_level + 1):
+                    xp_needed = await get_xp_for_level_async(level, scaling, effective_formula)
+                    new_thresholds.append(xp_needed)
+                    if new_thresholds[-1] > xp and level >= start_level + 10:
+                        max_level = level
+                        break
+                # Atomic assignment to shared cache
+                cls._thresholds[key] = (new_thresholds, max_level)
+                # Evict oldest entries if cache exceeds limit
+                while len(cls._thresholds) > cls._MAX_ENTRIES:
+                    cls._thresholds.popitem(last=False)
+                thresholds = new_thresholds
         return bisect.bisect_right(thresholds, xp)
 
 

--- a/utility.py
+++ b/utility.py
@@ -1,6 +1,8 @@
+import asyncio
 import ast
 import bisect
 import collections
+import concurrent.futures
 import contextlib
 import datetime
 import gzip
@@ -1058,6 +1060,48 @@ class LevelThresholdCache:
                 cls._thresholds.popitem(last=False)
         return bisect.bisect_right(thresholds, xp)
 
+    @classmethod
+    async def get_level_for_xp_async(cls, xp: int, scaling: str, custom_formula: str | None = None) -> int:
+        """Async version that runs CPU-bound formula evaluation in a thread executor.
+
+        Only used for custom formulas (built-in scalings use the fast O(1) sync path).
+        """
+        # Only custom formulas reach here
+        effective_formula = custom_formula
+        key = (scaling, effective_formula)
+        entry = cls._thresholds.get(key)
+        thresholds: list[int] | None
+        max_level: int
+        if entry is not None:
+            thresholds, max_level = entry
+        else:
+            thresholds = None
+            max_level = cls._MAX_LEVEL
+
+        if thresholds is None or thresholds[-1] < xp:
+            # Build or extend thresholds if needed
+            if thresholds is None:
+                start_level = 1
+                thresholds = []
+                max_level = cls._MAX_LEVEL
+            else:
+                # Extend from current; don't rebuild from scratch
+                if max_level >= cls._MAX_LEVEL and thresholds[-1] >= xp:
+                    return bisect.bisect_right(thresholds, xp)
+                start_level = len(thresholds) + 1
+                max_level = cls._MAX_LEVEL
+            for level in range(start_level, max_level + 1):
+                xp_needed = await get_xp_for_level_async(level, scaling, effective_formula)
+                thresholds.append(xp_needed)
+                if thresholds[-1] > xp and level >= start_level + 10:
+                    max_level = level
+                    break
+            cls._thresholds[key] = (thresholds, max_level)
+            # Evict oldest entries if cache exceeds limit
+            while len(cls._thresholds) > cls._MAX_ENTRIES:
+                cls._thresholds.popitem(last=False)
+        return bisect.bisect_right(thresholds, xp)
+
 
 operators = {
     ast.Add: op.add,
@@ -1077,6 +1121,16 @@ def sqrt_n(x: float, n: float = 2) -> float:
 
 def log_n(x: float, base: float = math.e) -> float:
     return math.log(x, base)
+
+
+# Thread pool executor for CPU-bound formula evaluation
+_eval_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+
+
+async def eval_expr_async(expr: str, variables=None) -> float:
+    """Async version of eval_expr that runs the CPU-bound AST evaluation in a thread executor."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_eval_executor, eval_expr, expr, variables)
 
 
 def eval_expr(expr: str, variables=None) -> float:
@@ -1165,6 +1219,22 @@ def get_xp_for_level(level: int, scaling: str, custom_formula: str | None = None
     return math.floor(result)
 
 
+async def get_xp_for_level_async(level: int, scaling: str, custom_formula: str | None = None) -> int:
+    """Async version of get_xp_for_level that runs CPU-bound formula evaluation in a thread executor."""
+    if level <= 0:
+        return 0
+    if scaling == "custom" and custom_formula:
+        try:
+            result = await eval_expr_async(custom_formula.replace("level", str(level)))
+        except Exception:
+            return 0
+    else:
+        result = LEVEL_SCALINGS.get(scaling, LEVEL_SCALINGS["medium"])(level)
+    if isinstance(result, complex):
+        return 0
+    return math.floor(result)
+
+
 def get_level_for_xp(xp: int, scaling: str, custom_formula: str | None = None) -> int:
     """Get the level for a given XP value.
 
@@ -1172,6 +1242,17 @@ def get_level_for_xp(xp: int, scaling: str, custom_formula: str | None = None) -
     inversion of the formula. For custom formulas, binary search is used.
     """
     return LevelThresholdCache.get_level_for_xp(xp, scaling, custom_formula)
+
+
+async def get_level_for_xp_async(xp: int, scaling: str, custom_formula: str | None = None) -> int:
+    """Async version of get_level_for_xp for custom formulas.
+
+    For built-in scalings, delegates to the O(1) sync version.
+    For custom formulas, uses the async eval to prevent event loop blocking.
+    """
+    if scaling != "custom":
+        return get_level_for_xp(xp, scaling, custom_formula)
+    return await LevelThresholdCache.get_level_for_xp_async(xp, scaling, custom_formula)
 
 
 def relativeTimeStrToDate(time_string: str) -> datetime.datetime:


### PR DESCRIPTION
Closes #1344

## Summary

Moves CPU-bound formula evaluation (`eval_expr`, `eval_`) out of the event loop by running it in a dedicated `ThreadPoolExecutor`. This prevents complex custom XP formulas from blocking the event loop during per-message XP processing.

## Changes

- **utility.py**: Added `_eval_executor` (`ThreadPoolExecutor(max_workers=1)`) and `eval_expr_async()` wrapper
- **utility.py**: Added `get_xp_for_level_async()` and `get_level_for_xp_async()` that use the async eval path for custom formulas  
- **utility.py**: Added `LevelThresholdCache.get_level_for_xp_async()` — async threshold building using `get_xp_for_level_async`
- **Callers updated** to use async versions:
  - `minigames/add_level_xp.py` (hot path — every message)
  - `api.py` (get_user_level_info)
  - `commands/level/leaderboard.py`
  - `commands/level/give_xp.py`
  - `commands/level/take_xp.py`
  - `commands/level/change_xp_scaling.py`
- Sync versions (`eval_expr`, `get_xp_for_level`, `get_level_for_xp`) kept for:
  - Internal utility use (threshold cache building, inversion verification)
  - Test compatibility (`tests/test_eval.py`)

## Design

- Only custom formulas (where `scaling == "custom"`) go through the executor
- Built-in scalings (easy/medium/hard/extreme) use O(1) mathematical inversion — no overhead added
- The cache (LevelThresholdCache) is shared between sync and async paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Converted internal XP and level calculations to asynchronous processing, improving responsiveness, consistency, and reliability across level-related features (leaderboards, XP commands, minigames, and XP-scaling displays). Users should experience snappier responses and smoother level/xp displays with no visible behavior changes beyond performance and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->