### PR TITLE
Run concurrent DB queries in fetch_xp_details with asyncio.gather

### DIFF
--- a/minigames/add_level_xp.py
+++ b/minigames/add_level_xp.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 
 import discord
@@ -50,14 +51,16 @@ async def addLevelXp(message: discord.Message) -> None:
 
 
 async def fetch_xp_details(message: discord.Message, guild_id: str) -> tuple[str, str | None, int]:
-    scaling = await _get_cached_config(guild_id, "scaling", "medium")
-    custom_formula = await _get_cached_config(guild_id, "custom_formula")
-    xp_to_add = await calculate_xp(
+    scaling_task = _get_cached_config(guild_id, "scaling", "medium")
+    formula_task = _get_cached_config(guild_id, "custom_formula")
+    xp_task = calculate_xp(
         guild_id,
         str(message.author.id),
         str(message.channel.id),
         [str(role.id) for role in (message.author.roles if hasattr(message.author, "roles") else [])],
     )
+
+    scaling, custom_formula, xp_to_add = await asyncio.gather(scaling_task, formula_task, xp_task)
     return scaling, custom_formula, xp_to_add
 
 


### PR DESCRIPTION
## Description

Both `minigames/add_level_xp.py`'s `fetch_xp_details` called 3 independent database queries **sequentially** — each awaiting the previous one, though none depended on the others' results.

**Before:**
```python
scaling = await _get_cached_config(guild_id, "scaling", "medium")
custom_formula = await _get_cached_config(guild_id, "custom_formula")
xp_to_add = await calculate_xp(...)
```

**After:**
```python
scaling_task = _get_cached_config(guild_id, "scaling", "medium")
formula_task = _get_cached_config(guild_id, "custom_formula")
xp_task = calculate_xp(...)
scaling, custom_formula, xp_to_add = await asyncio.gather(scaling_task, formula_task, xp_task)
```

This reduces latency from sum of query times to max of query times.

## Changes
- `minigames/add_level_xp.py`: Added `import asyncio` and converted `fetch_xp_details` to use `asyncio.gather` for parallel query execution.

Closes #1343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced XP calculation performance through concurrent processing improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->