### PR TITLE
Use batch INSERT for giveaway requirements (replace sequential inserts with bulk queries)

### DIFF
--- a/api.py
+++ b/api.py
@@ -272,8 +272,9 @@ async def execute_batch(query: str, params_list: list[tuple], bot=None) -> None:
     if pool is None:
         raise RuntimeError("Database pool is not initialized")
 
+    last_exception = None
+    safe_id = _query_safe_id(query)
     for attempt in range(_MAX_DB_RETRIES):
-        safe_id = str(uuid.uuid4())
         try:
             conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
             async with conn:
@@ -282,13 +283,28 @@ async def execute_batch(query: str, params_list: list[tuple], bot=None) -> None:
                 await conn.commit()
             return
         except TimeoutError:
-            print(f"Timeout on execute_batch acquire attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
+            msg = f"Timeout on execute_batch attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}"
+            print(msg)
+            last_exception = TimeoutError(msg)
             if attempt < _MAX_DB_RETRIES - 1:
                 await asyncio.sleep(0.5 * (attempt + 1))
             continue
-        except Exception:
+        except Exception as e:
+            err_str = str(e).lower()
+            # Determine which errors are safe to retry (mirroring _execute_with_retry for write operations)
+            retryable = "deadlock" in err_str or "duplicate" in err_str or "abort" in err_str
+            if attempt < _MAX_DB_RETRIES - 1 and retryable:
+                print(f"Transient error on execute_batch attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
+                await asyncio.sleep(0.5 * (attempt + 1))
+                last_exception = e
+                continue
+            # Non-retryable error or final attempt: raise instead of silently failing
+            print(f"Error during execute_batch: {e} — {safe_id}")
             raise
-    raise RuntimeError(f"Could not acquire database connection after {_MAX_DB_RETRIES} attempts [{safe_id}]")
+
+    if last_exception:
+        print(f"All retries exhausted for execute_batch: {safe_id}")
+        raise last_exception
 
 
 async def execute_insert_and_get_id(query: str, params: Any = None, bot=None) -> int | None:

--- a/api.py
+++ b/api.py
@@ -263,6 +263,34 @@ async def execute_action(query: str, params: Any = None, bot=None) -> Any:
     return await _execute_with_retry("execute_action", _callback, query, params, bot, is_write=True)
 
 
+async def execute_batch(query: str, params_list: list[tuple], bot=None) -> None:
+    """Execute a batch INSERT using executemany for bulk operations.
+
+    Reduces database round-trips by sending all rows in one query.
+    """
+    pool = _get_pool() if bot is None else (bot._pool if hasattr(bot, "_pool") else None)
+    if pool is None:
+        raise RuntimeError("Database pool is not initialized")
+
+    for attempt in range(_MAX_DB_RETRIES):
+        safe_id = str(uuid.uuid4())
+        try:
+            conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
+            async with conn:
+                async with conn.cursor() as cursor:
+                    await asyncio.wait_for(cursor.executemany(query, params_list), timeout=_QUERY_TIMEOUT)
+                await conn.commit()
+            return
+        except TimeoutError:
+            print(f"Timeout on execute_batch acquire attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
+            if attempt < _MAX_DB_RETRIES - 1:
+                await asyncio.sleep(0.5 * (attempt + 1))
+            continue
+        except Exception:
+            raise
+    raise RuntimeError(f"Could not acquire database connection after {_MAX_DB_RETRIES} attempts [{safe_id}]")
+
+
 async def execute_insert_and_get_id(query: str, params: Any = None, bot=None) -> int | None:
     async def _callback(cursor, connection):
         await connection.commit()
@@ -1867,16 +1895,19 @@ async def add_giveaway(
             if giveaway_id is None:
                 raise RuntimeError("Failed to get last insert ID for giveaway")
 
-            for ch_id, amount in channel_requirements.items():
-                await cursor.execute(
-                    "INSERT INTO giveaway_channelRequirement (giveaway_id, channel_id, amount) VALUES (%s, %s, %s)",
-                    (giveaway_id, ch_id, amount),
+            if channel_requirements:
+                channel_req_query = (
+                    "INSERT INTO giveaway_channelRequirement (giveaway_id, channel_id, amount) VALUES (%s, %s, %s)"
                 )
-            for role_id in role_requirement:
-                await cursor.execute(
-                    "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)",
-                    (role_id, giveaway_id),
+                channel_req_params = [(giveaway_id, ch_id, amount) for ch_id, amount in channel_requirements.items()]
+                await cursor.executemany(channel_req_query, channel_req_params)
+
+            if role_requirement:
+                role_req_query = (
+                    "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)"
                 )
+                role_req_params = [(role_id, giveaway_id) for role_id in role_requirement]
+                await cursor.executemany(role_req_query, role_req_params)
     except Exception as e:
         print(f"Error creating giveaway: {e}")
         return None


### PR DESCRIPTION
## Summary

Replaces sequential INSERT loops in `add_giveaway()` with single `cursor.executemany()` calls, reducing database round-trips.

## Changes

- **`api.py`**: Replace two `for` loops inserting channel and role requirements one-by-one with `executemany()` calls
- **`api.py`**: Add reusable `execute_batch()` helper for future batch insert operations

## Before

Each requirement item caused a separate DB round-trip:
- O(channel_requirements) inserts for channels
- O(role_requirements) inserts for roles

## After

Single batch insert per requirement type:
- 1 round-trip for all channel requirements
- 1 round-trip for all role requirements

## Testing

Existing transaction wrapper is retained - all inserts happen within the same DB transaction in `add_giveaway`.

Closes #1341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved batch database handling for giveaway creation to increase reliability and error resilience.

* **Refactor**
  * Switched giveaway requirement inserts to efficient bulk operations for better performance and reduced overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->