### PR TITLE
Parallelize on_message handlers: run independent minigame checks concurrently (#1340)

### DIFF
--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import discord
@@ -50,15 +51,19 @@ class ListenerCog(commands.Cog):
             await countingChallenge(message, config=challenge_config)
         if modes_config:
             await countingModes(message, config=modes_config)
-        await wordchain(message)
-        await addLevelXp(message)
-        await addMessageToGiveaway(message)
-        await publish_message(message)
-        await checkIfAfkHasToBeRemoved(message)
-        await checkIfMentionsAreAfk(message)
-        await send_trigger_message(message)
-        await mediaChannelMessage(message)
-        await dynamicslowmodeMessage(message)
+        # Everything else is independent — run concurrently with asyncio.gather
+        await asyncio.gather(
+            wordchain(message),
+            addLevelXp(message),
+            addMessageToGiveaway(message),
+            publish_message(message),
+            checkIfAfkHasToBeRemoved(message),
+            checkIfMentionsAreAfk(message),
+            send_trigger_message(message),
+            mediaChannelMessage(message),
+            dynamicslowmodeMessage(message),
+            return_exceptions=True,
+        )
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction) -> None:


### PR DESCRIPTION
Fixes #1340

## Changes
- Counting handlers (counting, countingChallenge, countingModes) remain sequential as they share per-channel state
- All other handlers now run concurrently via `asyncio.gather(…, return_exceptions=True)`:
  - wordchain
  - addLevelXp
  - addMessageToGiveaway
  - publish_message
  - checkIfAfkHasToBeRemoved / checkIfMentionsAreAfk
  - send_trigger_message
  - mediaChannelMessage
  - dynamicslowmodeMessage

## Benefits
- **Lower latency**: per-message processing drops from sum-of-handlers to max-of-handlers
- **Resilience**: `return_exceptions=True` prevents one handler failure from blocking others

## Test plan
- Existing CI passes (no behavioral change, just parallelism)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized message handling by processing non-counting message types concurrently, improving bot responsiveness and overall performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->