### PR TITLE
feat: Standardize semantic embed colors with EmbedColor enum (#1334)

### DIFF
--- a/commands/admin/ban.py
+++ b/commands/admin/ban.py
@@ -2,7 +2,7 @@ import discord
 
 import utility
 from localizer import tanjunLocalizer
-from utility import CommandInfo
+from utility import CommandInfo, EmbedColor
 
 
 async def ban(
@@ -17,6 +17,7 @@ async def ban(
         and not command_info.channel.permissions_for(command_info.user).ban_members
     ):
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.missingPermission.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.missingPermission.description"),
         )
@@ -26,6 +27,7 @@ async def ban(
     assert command_info.guild is not None
     if not command_info.guild.me.guild_permissions.ban_members:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.missingPermissionBot.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -37,6 +39,7 @@ async def ban(
 
     if isinstance(command_info.user, discord.Member) and target.top_role >= CommandInfo.user.top_role:  # type: ignore[misc, union-attr]
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.targetTooHigh.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.targetTooHigh.description"),
         )
@@ -46,6 +49,7 @@ async def ban(
     try:
         await target.ban(reason=reason, delete_message_days=delete_message_days)
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.success.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -61,12 +65,14 @@ async def ban(
         await command_info.reply(embed=embed)
     except discord.Forbidden:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.forbidden.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.forbidden.description"),
         )
         await command_info.reply(embed=embed)
     except discord.HTTPException:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.error.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.ban.error.description"),
         )

--- a/commands/admin/copy_emoji.py
+++ b/commands/admin/copy_emoji.py
@@ -7,6 +7,7 @@ from aiohttp import ClientTimeout
 
 import utility
 from localizer import tanjunLocalizer
+from utility import EmbedColor
 
 
 async def copy_emoji(
@@ -19,6 +20,7 @@ async def copy_emoji(
         and not command_info.channel.permissions_for(command_info.user).manage_emojis
     ):
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.missingPermission.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -31,6 +33,7 @@ async def copy_emoji(
     assert command_info.guild is not None
     if not command_info.guild.me.guild_permissions.manage_emojis:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(
                 command_info.locale,
                 "commands.admin.copyEmoji.missingPermissionBot.title",
@@ -49,6 +52,7 @@ async def copy_emoji(
 
     if not matches:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.error.noEmojis.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -111,6 +115,7 @@ async def copy_emoji(
         # Handle different response scenarios
         if not successful_emojis:
             embed = utility.tanjunEmbed(
+                colour=EmbedColor.ERROR,
                 title=tanjunLocalizer.localize(
                     command_info.locale,
                     "commands.admin.copyEmoji.error.limitReached.title",
@@ -122,6 +127,7 @@ async def copy_emoji(
             )
         elif len(successful_emojis) == 1 and not failed_emojis:
             embed = utility.tanjunEmbed(
+                colour=EmbedColor.SUCCESS,
                 title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.success.title"),
                 description=tanjunLocalizer.localize(
                     command_info.locale,
@@ -147,6 +153,7 @@ async def copy_emoji(
                 )
 
             embed = utility.tanjunEmbed(
+                colour=EmbedColor.SUCCESS if not failed_emojis else EmbedColor.WARNING,
                 title=tanjunLocalizer.localize(
                     command_info.locale,
                     (
@@ -163,6 +170,7 @@ async def copy_emoji(
     except Exception:
         logging.exception("Unexpected error in copy_emoji command")
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.error.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.copyEmoji.error.description"),
         )

--- a/commands/admin/kick.py
+++ b/commands/admin/kick.py
@@ -2,7 +2,7 @@ import discord
 
 import utility
 from localizer import tanjunLocalizer
-from utility import CommandInfo
+from utility import CommandInfo, EmbedColor
 
 
 async def kick(command_info: utility.CommandInfo, target: discord.Member, reason: str | None = None) -> None:
@@ -12,6 +12,7 @@ async def kick(command_info: utility.CommandInfo, target: discord.Member, reason
         and not command_info.channel.permissions_for(command_info.user).kick_members
     ):
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.missingPermission.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.missingPermission.description"),
         )
@@ -21,6 +22,7 @@ async def kick(command_info: utility.CommandInfo, target: discord.Member, reason
     assert command_info.guild is not None
     if not command_info.guild.me.guild_permissions.kick_members:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.missingPermissionBot.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -32,6 +34,7 @@ async def kick(command_info: utility.CommandInfo, target: discord.Member, reason
 
     if isinstance(command_info.user, discord.Member) and target.top_role >= CommandInfo.user.top_role:  # type: ignore[misc, union-attr]
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.targetTooHigh.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.targetTooHigh.description"),
         )
@@ -41,6 +44,7 @@ async def kick(command_info: utility.CommandInfo, target: discord.Member, reason
     try:
         await target.kick(reason=reason)
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.success.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -56,12 +60,14 @@ async def kick(command_info: utility.CommandInfo, target: discord.Member, reason
         await command_info.reply(embed=embed)
     except discord.Forbidden:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.forbidden.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.forbidden.description"),
         )
         await command_info.reply(embed=embed)
     except discord.HTTPException:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.error.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.kick.error.description"),
         )

--- a/commands/admin/nuke.py
+++ b/commands/admin/nuke.py
@@ -5,6 +5,7 @@ from discord.ui import View
 
 import utility
 from localizer import tanjunLocalizer
+from utility import EmbedColor
 
 
 async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextChannel | None = None) -> None:
@@ -55,6 +56,7 @@ async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextC
         and not command_info.channel.permissions_for(command_info.user).manage_channels
     ):
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.missingPermission.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.missingPermission.description"),
         )
@@ -66,6 +68,7 @@ async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextC
 
     if not channel.guild.me.guild_permissions.manage_channels:  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.missingPermissionBot.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -76,6 +79,7 @@ async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextC
         return
 
     embed = utility.tanjunEmbed(
+        colour=EmbedColor.WARNING,
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.confirmationTitle"),
         description=tanjunLocalizer.localize(
             command_info.locale,

--- a/commands/admin/say.py
+++ b/commands/admin/say.py
@@ -2,6 +2,7 @@ import discord
 
 import utility
 from localizer import tanjunLocalizer
+from utility import EmbedColor
 
 
 async def say(command_info: utility.CommandInfo, channel: discord.TextChannel, *, message: str) -> None:
@@ -11,6 +12,7 @@ async def say(command_info: utility.CommandInfo, channel: discord.TextChannel, *
         and not command_info.channel.permissions_for(command_info.user).manage_messages
     ):
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.missingPermission.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.missingPermission.description"),
         )
@@ -20,6 +22,7 @@ async def say(command_info: utility.CommandInfo, channel: discord.TextChannel, *
     assert command_info.guild is not None
     if not channel.permissions_for(command_info.guild.me).send_messages:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.missingPermissionBot.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -32,6 +35,7 @@ async def say(command_info: utility.CommandInfo, channel: discord.TextChannel, *
     try:
         await channel.send(message)
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.success.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
@@ -42,6 +46,7 @@ async def say(command_info: utility.CommandInfo, channel: discord.TextChannel, *
         await command_info.reply(embed=embed)
     except discord.HTTPException:
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.error.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.say.error.description"),
         )

--- a/commands/utility/feedback.py
+++ b/commands/utility/feedback.py
@@ -3,7 +3,7 @@ from discord import ui
 
 from api import feedbackIsBlocked
 from localizer import tanjunLocalizer
-from utility import CommandInfo, tanjunEmbed
+from utility import CommandInfo, EmbedColor, tanjunEmbed
 
 
 class FeedbackModal(ui.Modal):

--- a/commands/utility/feedback.py
+++ b/commands/utility/feedback.py
@@ -78,6 +78,7 @@ class FeedbackModal(ui.Modal):
         )
 
         embed = tanjunEmbed(
+            colour=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(
                 self.command_info.locale,
                 "commands.utility.feedback.modal.submitted.title",

--- a/commands/utility/help.py
+++ b/commands/utility/help.py
@@ -2,6 +2,7 @@ import discord
 from discord import app_commands
 
 import utility
+from localizer import tanjunLocalizer
 from utility import EmbedColor
 
 

--- a/commands/utility/help.py
+++ b/commands/utility/help.py
@@ -2,7 +2,7 @@ import discord
 from discord import app_commands
 
 import utility
-from localizer import tanjunLocalizer
+from utility import EmbedColor
 
 
 async def help(command_info, ctx):
@@ -195,7 +195,7 @@ async def help(command_info, ctx):
                                 total_pages=len(texts),
                             ),
                             description=text,
-                            color=0xCB33F5,
+                            color=EmbedColor.BRAND,
                         )
                     else:
                         embed = discord.Embed(
@@ -205,7 +205,7 @@ async def help(command_info, ctx):
                                 group_name=group_name_locale,
                             ),
                             description=text,
-                            color=0xCB33F5,
+                            color=EmbedColor.BRAND,
                         )
                     embeds.append(embed)
 

--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -31,16 +31,9 @@ from commands.logs.configure_logs import configure_logs
 from commands.logs.remove_log_channel import remove_log_channel
 from commands.logs.set_log_channel import set_log_channel
 from localizer import tanjunLocalizer
-from utility import upload_image_to_imgbb, upload_to_tanjun_logs
+from utility import EmbedColor, upload_image_to_imgbb, upload_to_tanjun_logs
 
 embeds = {}  # type: ignore[var-annotated]
-
-
-class EmbedColors:
-    green = 0x4BB543
-    yellow = 0xFFBF00
-    red = 0xFF0000
-
 
 _log_queue: asyncio.Queue[tuple[str, discord.Embed]] = asyncio.Queue(maxsize=200)
 
@@ -499,7 +492,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.automodRuleCreate.title"),
             description=description,
         )
@@ -666,7 +659,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.automodRuleUpdate.title"),
             description=description,
         )
@@ -834,7 +827,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.automodRuleDelete.title"),
             description=description,
         )
@@ -918,7 +911,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.automodRuleDelete.title"),
             description=description,
         )
@@ -1012,7 +1005,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.guild_channelDelete.title"),
             description=description,
         )
@@ -1087,7 +1080,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.guild_channelCreate.title"),
             description=description,
         )
@@ -1372,7 +1365,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.guild_channelUpdate.title"),
             description=description,
         )
@@ -1798,7 +1791,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.guildUpdate.title"),
             description=description,
         )
@@ -1893,7 +1886,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.inviteCreate.title"),
             description=description,
         )
@@ -1985,7 +1978,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.inviteDelete.title"),
             description=description,
         )
@@ -2014,7 +2007,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.memberJoin.title"),
             description=description,
         )
@@ -2050,7 +2043,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.memberJoin.title"),
             description=description,
         )
@@ -2184,7 +2177,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.memberUpdate.title"),
             description=description,
         )
@@ -2254,7 +2247,7 @@ class LogsCog(commands.Cog):
             description = "\n".join(description_parts)
 
             embed = discord.Embed(
-                color=EmbedColors.yellow,
+                color=EmbedColor.WARNING,
                 title=tanjunLocalizer.localize(locale, "logs.userUpdate.title"),
                 description=description,
             )
@@ -2290,7 +2283,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.memberBan.title"),
             description=description,
         )
@@ -2327,7 +2320,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.memberUnban.title"),
             description=description,
         )
@@ -2369,7 +2362,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.presenceUpdate.title"),
             description=description,
         )
@@ -2513,7 +2506,7 @@ class LogsCog(commands.Cog):
             description = description[:3000] + f" {truncated_notice}"  # type: ignore[possibly-undefined]
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.messageEdit.title"),
             description=description,
         )
@@ -2609,7 +2602,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.messageDelete.title"),
             description=description,
         )
@@ -2651,7 +2644,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.reactionAdd.title"),
             description=description,
         )
@@ -2691,7 +2684,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.reactionRemove.title"),
             description=description,
         )
@@ -2769,7 +2762,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.green,
+            color=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "logs.guildRoleCreate.title"),
             description=description,
         )
@@ -2848,7 +2841,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.red,
+            color=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "logs.guildRoleDelete.title"),
             description=description,
         )
@@ -2977,7 +2970,7 @@ class LogsCog(commands.Cog):
         description = "\n".join(description_parts)
 
         embed = discord.Embed(
-            color=EmbedColors.yellow,
+            color=EmbedColor.WARNING,
             title=tanjunLocalizer.localize(locale, "logs.guildRoleUpdate.title"),
             description=description,
         )

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -20,6 +20,7 @@ from loops.create_database_backup import create_database_backup
 from loops.giveaway import checkVoiceUsers, endGiveaways, sendReadyGiveaways
 from loops.level import addXpToVoiceUsers
 from minigames.add_level_xp import clearNotifiedUsers
+from utility import EmbedColor
 
 embeds = {}  # type: ignore[var-annotated]
 
@@ -172,7 +173,7 @@ Jede(r) ist ♥️-lich willkommen! Wir freuen uns über jeden Neuzugang! Schaut
             """
             channel = self.bot.get_channel(923337160600477777)
             if isinstance(channel, discord.TextChannel):
-                embed = discord.Embed(description=message, color=0xCB33F5, title="🐾Pokémon🐾")
+                embed = discord.Embed(description=message, color=EmbedColor.BRAND.value, title="🐾Pokémon🐾")
                 sent_message = await channel.send(embed=embed)
                 if sent_message.guild:
                     await sent_message.publish()

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -5,6 +5,7 @@ from discord import app_commands
 from discord.ext import commands
 
 import utility
+from utility import EmbedColor
 from commands.utility.afk import afk as afkCommand
 from commands.utility.autopublish import autopublish as autopublishCommand
 from commands.utility.autopublish import autopublish_remove as autopublishRemoveCommand
@@ -198,6 +199,7 @@ class BoosterRoleCommands(discord.app_commands.Group):
         )
 
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.INFO,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.boosterroleinfo.info.title"),
             description=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.boosterroleinfo.info.description"),
         )
@@ -287,6 +289,7 @@ class BoosterChannelCommands(discord.app_commands.Group):
         )
 
         embed = utility.tanjunEmbed(
+            colour=EmbedColor.INFO,
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.boosterchannelinfo.info.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,

--- a/health/notifier.py
+++ b/health/notifier.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from health.checks import HealthCheckResult, HealthStatus
+from utility import EmbedColor
 
 if TYPE_CHECKING:
     from discord.ext import commands
@@ -80,7 +81,7 @@ async def notify_health_failures(
         title = f"⚠️ Health Check Failure ({idx}/{len(chunks)})" if len(chunks) > 1 else "⚠️ Health Check Failure"
         embed = discord.Embed(
             title=title,
-            color=0xFF0000,
+            color=EmbedColor.ERROR.value,
             timestamp=datetime.now(UTC),
         )
 

--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -5,7 +5,7 @@ import discord
 
 from api import check_if_opted_out
 from localizer import tanjunLocalizer
-from utility import tanjunEmbed
+from utility import EmbedColor, tanjunEmbed
 
 
 async def _handle_guild_check(message: discord.Message) -> bool:
@@ -14,6 +14,7 @@ async def _handle_guild_check(message: discord.Message) -> bool:
         return False
 
     embed: discord.Embed = tanjunEmbed(
+        colour=EmbedColor.ERROR,
         title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
         description=tanjunLocalizer.localize("en_US", "errors.guildonly.description"),
     )

--- a/minigames/counting_challenge.py
+++ b/minigames/counting_challenge.py
@@ -8,12 +8,13 @@ from api import (
 )
 from localizer import tanjunLocalizer
 from minigames._counting_common import counting as _counting_base
-from utility import tanjunEmbed
+from utility import EmbedColor, tanjunEmbed
 
 
 async def _challenge_failure(message: discord.Message, locale: str, _correct_number: int) -> None:
     await message.add_reaction("\U0001f480")
     embed = tanjunEmbed(
+        colour=EmbedColor.ERROR,
         title=tanjunLocalizer.localize(locale, "minigames.counting.failed.title"),
         description=tanjunLocalizer.localize(locale, "minigames.counting.failed.description"),
     )
@@ -24,6 +25,7 @@ async def _challenge_failure(message: discord.Message, locale: str, _correct_num
 async def _challenge_double_count(message: discord.Message, locale: str, _correct_number: int) -> None:
     await message.add_reaction("\U0001f480")
     embed = tanjunEmbed(
+        colour=EmbedColor.ERROR,
         title=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.title"),
         description=tanjunLocalizer.localize(locale, "minigames.counting.failed_double.description"),
     )

--- a/minigames/counting_modes.py
+++ b/minigames/counting_modes.py
@@ -14,7 +14,7 @@ from api import (
     set_counting_mode_progress,
 )
 from localizer import tanjunLocalizer
-from utility import tanjunEmbed
+from utility import EmbedColor, tanjunEmbed
 
 modeMap = {
     1: "normal",

--- a/minigames/counting_modes.py
+++ b/minigames/counting_modes.py
@@ -350,6 +350,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
         new_mode = random.randint(1, len(modeMap))
         goal = get_goal(new_mode)
         embed = tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "minigames.counting.modes.failed.title"),
             description=tanjunLocalizer.localize(
                 locale,
@@ -386,6 +387,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
         new_mode = random.randint(1, len(modeMap))
         goal = get_goal(new_mode)
         embed = tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "minigames.counting.modes.failed.title"),
             description=tanjunLocalizer.localize(
                 locale,
@@ -420,6 +422,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
         new_mode = random.randint(1, len(modeMap))
         goal = get_goal(new_mode)
         embed = tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "minigames.counting.modes.failed.title"),
             description=tanjunLocalizer.localize(
                 locale,
@@ -457,6 +460,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
         new_mode = random.randint(1, len(modeMap))
         goal = get_goal(new_mode)
         embed = tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize(locale, "minigames.counting.modes.failed_double.title"),
             description=tanjunLocalizer.localize(
                 locale,
@@ -499,6 +503,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
         if mode == 12:
             new_goal = romeal_to_number(new_goal)
         embed = tanjunEmbed(
+            colour=EmbedColor.SUCCESS,
             title=tanjunLocalizer.localize(locale, "minigames.counting.modes.won.title"),
             description=tanjunLocalizer.localize(
                 locale,

--- a/minigames/wordchain.py
+++ b/minigames/wordchain.py
@@ -4,12 +4,13 @@ import discord
 
 from api import check_if_opted_out, clear_wordchain, get_wordchain_last_user_id, get_wordchain_word, set_wordchain_word
 from localizer import tanjunLocalizer
-from utility import tanjunEmbed
+from utility import EmbedColor, tanjunEmbed
 
 
 async def wordchain(message: discord.Message) -> None:
     if message.guild is None:
         embed: discord.Embed = tanjunEmbed(
+            colour=EmbedColor.ERROR,
             title=tanjunLocalizer.localize("en_US", "errors.guildonly.title"),
             description=tanjunLocalizer.localize(
                 "en_US",
@@ -52,6 +53,7 @@ async def wordchain(message: discord.Message) -> None:
             await clear_wordchain(message.channel.id)
             await set_wordchain_word(channel_id=message.channel.id, guild_id=message.guild.id, word="", worder_id="nobody")
             embed = tanjunEmbed(
+                colour=EmbedColor.SUCCESS,
                 title=tanjunLocalizer.localize(locale, "minigames.wordchain.finished.title"),
                 description=tanjunLocalizer.localize(
                     locale,

--- a/utility.py
+++ b/utility.py
@@ -3,6 +3,7 @@ import bisect
 import collections
 import contextlib
 import datetime
+import enum
 import gzip
 import logging
 import math
@@ -42,6 +43,17 @@ from config import (
     giphyAPIKey,
 )
 from utils.async_io import _io_executor
+
+
+class EmbedColor(enum.IntEnum):
+    """Standardized embed colors for semantic use across the bot."""
+
+    BRAND = 0xCB33F5  # Default for info/neutral messages
+    SUCCESS = 0x4BB543  # Green: success confirmations
+    WARNING = 0xFFBF00  # Yellow: warnings, rate limits
+    ERROR = 0xE74C3C  # Red: errors, failures
+    INFO = 0x3498DB  # Blue: information
+    TIMEOUT = 0x95A5A6  # Gray: disabled/timeout
 
 
 class EmbedProxy:
@@ -175,8 +187,8 @@ class TanjunEmbed:
     def __init__(
         self,
         *,
-        colour: int | discord.Colour | None = 0xCB33F5,
-        color: int | discord.Colour | None = 0xCB33F5,
+        colour: int | discord.Colour | EmbedColor | None = EmbedColor.BRAND,
+        color: int | discord.Colour | EmbedColor | None = EmbedColor.BRAND,
         title: Any | None = None,
         type="rich",
         url: Any | None = None,

--- a/utility.py
+++ b/utility.py
@@ -187,8 +187,8 @@ class TanjunEmbed:
     def __init__(
         self,
         *,
-        colour: int | discord.Colour | EmbedColor | None = EmbedColor.BRAND,
-        color: int | discord.Colour | EmbedColor | None = EmbedColor.BRAND,
+        colour: int | discord.Colour | EmbedColor | None = None,
+        color: int | discord.Colour | EmbedColor | None = None,
         title: Any | None = None,
         type="rich",
         url: Any | None = None,
@@ -196,6 +196,8 @@ class TanjunEmbed:
         timestamp: datetime.datetime | None = None,
     ):
         self.colour = colour if colour is not None else color
+        if self.colour is None:
+            self.colour = EmbedColor.BRAND
         self.title: str | None = title
         self.type = type
         self.url: str | None = url


### PR DESCRIPTION
## Summary

Adds a shared  IntEnum to  and migrates the codebase to use semantic colors instead of hardcoded hex values or the default purple for all embed types.

## Changes

### EmbedColor enum (utility.py)
- **BRAND** `0xCB33F5` — default for info/neutral messages (keeps existing default)
- **SUCCESS** `0x4BB543` — green for success confirmations
- **WARNING** `0xFFBF00` — yellow for warnings, rate limits
- **ERROR** `0xE74C3C` — red for errors, failures
- **INFO** `0x3498DB` — blue for information embeds
- **TIMEOUT** `0x95A5A6` — gray for disabled/timeout states

### Migrated files

| File | Change |
|------|--------|
| `utility.py` | Added EmbedColor enum, updated TanjunEmbed default to EmbedColor.BRAND |
| `extensions/logs.py` | Replaced EmbedColors class with shared EmbedColor.SUCCESS/WARNING/ERROR |
| `commands/admin/kick.py` | Permission errors → ERROR, success → SUCCESS, target too high → WARNING |
| `commands/admin/ban.py` | Permission errors → ERROR, success → SUCCESS, target too high → WARNING |
| `commands/admin/nuke.py` | Permission errors → ERROR, confirmation → WARNING |
| `commands/admin/say.py` | Permission errors → ERROR, success → SUCCESS |
| `commands/admin/copy_emoji.py` | Permission errors → ERROR, success → SUCCESS, partial → WARNING |
| `commands/utility/help.py` | Hardcoded `0xCB33F5` → EmbedColor.BRAND |
| `commands/utility/feedback.py` | Submitted → SUCCESS, blocked → ERROR, feedback post → INFO |
| `extensions/utility.py` | Booster info embeds → INFO blue |
| `extensions/loops.py` | Pokémon auto-post → EmbedColor.BRAND |
| `health/notifier.py` | Health failure embed `0xFF0000` → EmbedColor.ERROR |
| `minigames/counting_modes.py` | Failures → ERROR, won → SUCCESS |
| `minigames/counting_challenge.py` | Failures → ERROR |
| `minigames/_counting_common.py` | Guild-only error → ERROR |
| `minigames/wordchain.py` | Guild-only error → ERROR, finished → SUCCESS |

## Benefits
- Users can visually distinguish errors (red) from success (green) from warnings (yellow)
- Consistent color meaning across all bot features
- Single enum to maintain — all embed colors in one place
- Professional UX similar to major bots

Closes #1334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized embed colors across the app using a central color set.
  * Error, success, warning, brand, info, and timeout responses now use distinct, consistent colors for clearer, more consistent visual feedback.
  * Help pages, admin commands, logs, minigames, utility responses, and health notifications updated to use the standardized colors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->