### PR TITLE
Add SafeInteraction helper to prevent double-respond errors

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -1334,5 +1334,80 @@ def addThousandsSeparator(number: int) -> str:
     return f"{number:,}".replace(",", " ")
 
 
+class SafeInteraction:
+    """Helper for safely responding to Discord interactions, preventing double-respond errors.
+
+    Use instead of ``interaction.response.send_message()``,
+    ``interaction.response.defer()``, and ``interaction.edit_original_response()``
+    to handle race conditions when ``interaction_check`` or other code paths
+    may have already responded.
+
+    Usage::
+
+        embed = utility.tanjunEmbed(title="Done", description="Operation complete.")
+        await SafeInteraction.respond(interaction, embed=embed)
+    """
+
+    @staticmethod
+    async def respond(
+        interaction: discord.Interaction,
+        embed: discord.Embed | None = None,
+        content: str | None = None,
+        ephemeral: bool = False,
+        view: discord.ui.View | None = None,
+    ) -> None:
+        """Respond to an interaction, safely handling already-responded state.
+
+        If the interaction has already been responded to, this falls back to
+        ``interaction.followup.send()`` instead of raising.
+        """
+        kwargs: dict[str, Any] = {"ephemeral": ephemeral}
+        if embed is not None:
+            kwargs["embed"] = embed
+        if content is not None:
+            kwargs["content"] = content
+        if view is not None:
+            kwargs["view"] = view
+
+        if interaction.response.is_done():
+            await interaction.followup.send(**kwargs)
+        else:
+            await interaction.response.send_message(**kwargs)
+
+    @staticmethod
+    async def defer(
+        interaction: discord.Interaction,
+        ephemeral: bool = False,
+    ) -> None:
+        """Safely defer an interaction, skipping if already done."""
+        if not interaction.response.is_done():
+            await interaction.response.defer(ephemeral=ephemeral)
+
+    @staticmethod
+    async def edit(
+        interaction: discord.Interaction,
+        embed: discord.Embed | None = None,
+        content: str | None = None,
+        view: discord.ui.View | None = None,
+    ) -> None:
+        """Safely edit the original interaction response.
+
+        If the interaction has not yet been responded to, this sends an initial
+        message instead of trying to edit a non-existent response.
+        """
+        kwargs: dict[str, Any] = {}
+        if embed is not None:
+            kwargs["embed"] = embed
+        if content is not None:
+            kwargs["content"] = content
+        if view is not None:
+            kwargs["view"] = view
+
+        if interaction.response.is_done():
+            await interaction.edit_original_response(**kwargs)
+        else:
+            await interaction.response.send_message(**kwargs)
+
+
 tanjunEmbed = TanjunEmbed
 #: Backward-compatible alias so that ``from utility import tanjunEmbed`` still works.

--- a/utility.py
+++ b/utility.py
@@ -1372,7 +1372,10 @@ class SafeInteraction:
         if interaction.response.is_done():
             await interaction.followup.send(**kwargs)
         else:
-            await interaction.response.send_message(**kwargs)
+            try:
+                await interaction.response.send_message(**kwargs)
+            except discord.InteractionResponded:
+                await interaction.followup.send(**kwargs)
 
     @staticmethod
     async def defer(
@@ -1381,7 +1384,10 @@ class SafeInteraction:
     ) -> None:
         """Safely defer an interaction, skipping if already done."""
         if not interaction.response.is_done():
-            await interaction.response.defer(ephemeral=ephemeral)
+            try:
+                await interaction.response.defer(ephemeral=ephemeral)
+            except discord.InteractionResponded:
+                pass  # Already responded, silently ignore
 
     @staticmethod
     async def edit(
@@ -1406,7 +1412,10 @@ class SafeInteraction:
         if interaction.response.is_done():
             await interaction.edit_original_response(**kwargs)
         else:
-            await interaction.response.send_message(**kwargs)
+            try:
+                await interaction.response.send_message(**kwargs)
+            except discord.InteractionResponded:
+                await interaction.edit_original_response(**kwargs)
 
 
 tanjunEmbed = TanjunEmbed


### PR DESCRIPTION
## Summary

Closes #1325

Adds a `SafeInteraction` helper class to `utility.py` that prevents `InteractionResponded` crashes caused by race conditions (e.g., when `interaction_check` responds before the command callback).

## Changes

- **`utility.py`** — Added `SafeInteraction` class with three static methods:
  - `SafeInteraction.respond()` — sends or followup-sends, checking `is_done()`
  - `SafeInteraction.defer()` — defers only if not already responded
  - `SafeInteraction.edit()` — edits or sends initial response safely

## Usage

```python
from utility import SafeInteraction

embed = utility.tanjunEmbed(title="Success", description="Done.")
await SafeInteraction.respond(interaction, embed=embed, ephemeral=True)
```

## Migration scope

This PR introduces the helper only. A follow-up issue will migrate existing `interaction.response.send_message()` calls across `commands/` and `extensions/` to use `SafeInteraction.respond()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Discord interaction handling with better fallback logic for responses and message editing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->