### PR TITLE
feat(#1294): Encapsulate giveaway CRUD into GiveawayService with Pydantic models

### DIFF
--- a/api.py
+++ b/api.py
@@ -1972,315 +1972,202 @@ async def add_giveaway(
     role_requirement: list[str],
     voice_requirement: int | None,
 ) -> int | None:
-    query = """
-    INSERT INTO giveaway (
-        guild_id, title, description, winners, withButton, customName, sponsor, price, message,
-        endtime, starttime, newMessageRequirement, dayRequirement, voiceRequirement, channel_id
+    from services.giveaway_service import GiveawayCreateParams, giveaway_service
+
+    params = GiveawayCreateParams(
+        guild_id=guild_id,
+        title=title,
+        description=description,
+        winners=winners,
+        with_button=with_button,
+        channel_id=channel_id,
+        custom_name=custom_name,
+        sponsor=sponsor,
+        price=price,
+        message=message,
+        end_time=endtime,
+        start_time=starttime,
+        new_message_requirement=new_message_requirement,
+        day_requirement=day_requirement,
+        channel_requirements=channel_requirements,
+        role_requirement=role_requirement,
+        voice_requirement=voice_requirement,
     )
-    VALUES (
-        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
-    )
-
-    """
-    params = (
-        guild_id,
-        title,
-        description,
-        winners,
-        with_button,
-        custom_name,
-        sponsor,
-        price,
-        message,
-        endtime,
-        starttime,
-        new_message_requirement,
-        day_requirement,
-        voice_requirement,
-        channel_id,
-    )
-    try:
-        async with transaction() as conn, conn.cursor() as cursor:
-            await cursor.execute(query, params)
-            await cursor.execute("SELECT LAST_INSERT_ID()")
-            last_id = await cursor.fetchone()
-            giveaway_id = last_id[0] if last_id else None
-            if giveaway_id is None:
-                raise RuntimeError("Failed to get last insert ID for giveaway")
-
-            if channel_requirements:
-                channel_req_query = (
-                    "INSERT INTO giveaway_channelRequirement (giveaway_id, channel_id, amount) VALUES (%s, %s, %s)"
-                )
-                channel_req_params = [(giveaway_id, ch_id, amount) for ch_id, amount in channel_requirements.items()]
-                await cursor.executemany(channel_req_query, channel_req_params)
-
-            if role_requirement:
-                role_req_query = (
-                    "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)"
-                )
-                role_req_params = [(role_id, giveaway_id) for role_id in role_requirement]
-                await cursor.executemany(role_req_query, role_req_params)
-    except Exception as e:
-        print(f"Error creating giveaway: {e}")
-        return None
-
-    return giveaway_id
+    return await giveaway_service.create(params)
 
 
 async def set_giveaway_message_id(giveaway_id: int, message_id: int) -> None:
-    query = "UPDATE giveaway SET messageId = %s WHERE giveaway_id = %s"
-    params = (message_id, giveaway_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.set_message_id(giveaway_id, message_id)
 
 
 async def get_giveaway(giveaway_id: int) -> GiveawayModel | None:
-    query = (
-        "SELECT giveaway_id, guild_id, title, description, winners, withButton, "
-        "customName, sponsor, price, message, endtime, starttime, started, ended, "
-        "newMessageRequirement, dayRequirement, voiceRequirement, sendFailed, "
-        "channel_id, messageId, created_at "
-        "FROM giveaway WHERE giveaway_id = %s"
-    )
-    params = (giveaway_id,)
-    result = await safe_execute_query(query, params)
-    return GiveawayModel.from_row(result[0]) if result else None
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get(giveaway_id)
 
 
 async def get_giveaway_channel_requirements(giveaway_id: int) -> list[GiveawayChannelRequirementModel]:
-    query = "SELECT channel_id, amount FROM giveaway_channelRequirement WHERE giveaway_id = %s"
-    params = (giveaway_id,)
-    rows: list[GiveawayChannelRequirementModel] = []
-    async for row in GiveawayChannelRequirementModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_channel_requirements(giveaway_id)
 
 
 async def get_giveaway_role_requirements(giveaway_id: int) -> list[str]:
-    query = "SELECT role_id FROM giveawayRoleRequirement WHERE giveaway_id = %s"
-    params = (giveaway_id,)
-    role_ids: list[str] = []
-    async for row in execute_query_iter(query, params):
-        role_ids.append(row[0])
-    return role_ids
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_role_requirements(giveaway_id)
 
 
 async def set_giveaway_started(giveaway_id: int) -> None:
-    query = "UPDATE giveaway SET started = 1 WHERE giveaway_id = %s"
-    params = (giveaway_id,)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.set_started(giveaway_id)
 
 
 async def set_giveaway_ended(giveaway_id: int) -> None:
-    query = "UPDATE giveaway SET ended = 1 WHERE giveaway_id = %s"
-    params = (giveaway_id,)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.set_ended(giveaway_id)
 
 
 async def delete_old_giveaways() -> None:
-    """Delete old ended giveaways and their related data in a single transaction."""
-    try:
-        async with transaction() as conn, conn.cursor() as cursor:
-            # Find old giveaways first
-            await cursor.execute("SELECT giveaway_id FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK")
-            old_ids = [row[0] for row in await cursor.fetchall()]
-            if not old_ids:
-                return
+    from services.giveaway_service import giveaway_service
 
-            related_tables = [
-                "giveaway_channelRequirement",
-                "giveawayRoleRequirement",
-                "giveawayParticipant",
-                "giveawayVoiceTime",
-                "giveawayNewMessage",
-                "giveaway_channelMessages",
-            ]
-            for give_id in old_ids:
-                for table in related_tables:
-                    await cursor.execute(f"DELETE FROM {table} WHERE giveaway_id = %s", (give_id,))
-            await cursor.execute("DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK")
-    except Exception as e:
-        print(f"Error deleting old giveaways: {e}")
-        raise
+    await giveaway_service.delete_old()
 
 
 async def get_giveaway_participants(giveaway_id: int) -> list[str]:
-    query = "SELECT user_id FROM giveawayParticipant WHERE giveaway_id = %s"
-    params = (giveaway_id,)
-    user_ids: list[str] = []
-    async for row in execute_query_iter(query, params):
-        user_ids.append(row[0])
-    return user_ids
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_participants(giveaway_id)
 
 
 async def get_new_messages(giveaway_id: int, user_id: str) -> int | None:
-    query = "SELECT messages FROM giveawayNewMessage WHERE giveaway_id = %s AND user_id = %s"
-    params = (giveaway_id, user_id)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_new_messages(giveaway_id, user_id)
 
 
 async def get_new_messages_channel(giveaway_id: int, channel_id: str, user_id: str) -> int | None:
-    query = "SELECT amount FROM giveaway_channelMessages WHERE giveaway_id = %s AND channel_id = %s AND user_id = %s"
-    params = (giveaway_id, channel_id, user_id)
-    result = await safe_execute_query(query, params)
-    return result[0][0] if result else None
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_new_messages_channel(giveaway_id, channel_id, user_id)
 
 
 async def get_voice_time(giveaway_id: int, user_id: str) -> int | None:
-    query = "SELECT voiceMinutes FROM giveawayVoiceTime WHERE giveaway_id = %s AND user_id = %s"
-    params = (giveaway_id, user_id)
-    result = await safe_execute_query(query, params)
-    return result[0][0] if result else None
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_voice_time(giveaway_id, user_id)
 
 
 async def get_blacklisted_roles(guild_id: str) -> list[GiveawayBlacklistEntryModel]:
-    query = "SELECT role_id, reason FROM giveawayBlacklistedRole WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[GiveawayBlacklistEntryModel] = []
-    async for row in GiveawayBlacklistEntryModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_blacklisted_roles(guild_id)
 
 
 async def check_if_user_blacklisted(guild_id: str, user_id: str) -> bool:
-    query = "SELECT * FROM giveawayBlacklistedUser WHERE guild_id = %s AND user_id = %s"
-    params = (guild_id, user_id)
-    result = await execute_query(query, params)
-    return result is not None and len(result) > 0
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.is_user_blacklisted(guild_id, user_id)
 
 
 async def check_if_giveaway_participant(giveaway_id: int, user_id: str) -> bool:
-    query = "SELECT * FROM giveawayParticipant WHERE giveaway_id = %s AND user_id = %s"
-    params = (giveaway_id, user_id)
-    result = await safe_execute_query(query, params)
-    return result is not None and len(result) > 0
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.is_participant(giveaway_id, user_id)
 
 
 async def remove_giveaway_participant(giveaway_id: int, user_id: str) -> None:
-    query = "DELETE FROM giveawayParticipant WHERE giveaway_id = %s AND user_id = %s"
-    params = (giveaway_id, user_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.remove_participant(giveaway_id, user_id)
 
 
 async def add_giveaway_participant(giveaway_id: int, user_id: str) -> None:
-    query = "INSERT INTO giveawayParticipant (user_id, giveaway_id) VALUES (%s, %s)"
-    params = (user_id, giveaway_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_participant(giveaway_id, user_id)
 
 
 async def get_send_ready_giveaways() -> list[int]:
-    query = "SELECT giveaway_id FROM giveaway WHERE started = 0 AND starttime < NOW()"
-    giveaway_ids: list[int] = []
-    async for row in execute_query_iter(query):
-        giveaway_ids.append(row[0])
-    return giveaway_ids
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_send_ready()
 
 
 async def add_giveaway_voice_minutes_if_needed(user_id: Any, guild_id: Any) -> None:
-    query = """
-        INSERT INTO giveawayVoiceTime (giveaway_id, user_id, voiceMinutes)
-        SELECT giveaway_id, %s, 1 FROM giveaway
-        WHERE guild_id = %s AND voiceRequirement IS NOT NULL
-        ON DUPLICATE KEY UPDATE voiceMinutes = voiceMinutes + 1
-    """
-    await execute_action(query, (user_id, guild_id))
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_voice_minutes(user_id, guild_id)
 
 
 async def add_giveaway_new_message_if_needed(user_id: Any, guild_id: Any) -> None:
-    query = """
-        INSERT INTO giveawayNewMessage (giveaway_id, user_id, messages)
-        SELECT giveaway_id, %s, 1 FROM giveaway
-        WHERE guild_id = %s AND newMessageRequirement IS NOT NULL
-        ON DUPLICATE KEY UPDATE messages = messages + 1
-    """
-    await execute_action(query, (user_id, guild_id))
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_new_message(user_id, guild_id)
 
 
 async def add_giveaway_new_message_channel_if_needed(user_id: Any, guild_id: Any, channel_id: Any) -> None:
-    query = """
-        INSERT INTO giveaway_channelMessages (giveaway_id, channel_id, user_id, amount)
-        SELECT giveaway_id, %s, %s, 1 FROM giveaway
-        WHERE guild_id = %s AND newMessageRequirement IS NOT NULL
-        ON DUPLICATE KEY UPDATE amount = amount + 1
-    """
-    await execute_action(query, (channel_id, user_id, guild_id))
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_new_message_channel(user_id, guild_id, channel_id)
 
 
 async def get_end_ready_giveaways() -> list[int]:
-    query = "SELECT giveaway_id FROM giveaway WHERE ended = 0 AND endtime < NOW() AND started = 1 AND messageId <> 'pending'"
-    giveaway_ids: list[int] = []
-    async for row in execute_query_iter(query):
-        giveaway_ids.append(row[0])
-    return giveaway_ids
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_end_ready()
 
 
 async def add_giveaway_blacklisted_user(guild_id: str, user_id: str) -> None:
-    query = "INSERT INTO giveawayBlacklistedUser (guild_id, user_id) VALUES (%s, %s)"
-    params = (guild_id, user_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_blacklisted_user(guild_id, user_id)
 
 
 async def add_giveaway_blacklisted_role(guild_id: str, role_id: str) -> None:
-    query = "INSERT INTO giveawayBlacklistedRole (guild_id, role_id) VALUES (%s, %s)"
-    params = (guild_id, role_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.add_blacklisted_role(guild_id, role_id)
 
 
 async def remove_giveaway_blacklisted_user(guild_id: str, user_id: str) -> None:
-    query = "DELETE FROM giveawayBlacklistedUser WHERE guild_id = %s AND user_id = %s"
-    params = (guild_id, user_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.remove_blacklisted_user(guild_id, user_id)
 
 
 async def remove_giveaway_blacklisted_role(guild_id: str, role_id: str) -> None:
-    query = "DELETE FROM giveawayBlacklistedRole WHERE guild_id = %s AND role_id = %s"
-    params = (guild_id, role_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.remove_blacklisted_role(guild_id, role_id)
 
 
 async def get_giveaway_blacklisted_users(guild_id: str) -> list[GiveawayBlacklistEntryModel]:
-    query = "SELECT user_id, reason FROM giveawayBlacklistedUser WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[GiveawayBlacklistEntryModel] = []
-    async for row in GiveawayBlacklistEntryModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_blacklisted_users(guild_id)
 
 
 async def get_giveaway_blacklisted_roles(guild_id: str) -> list[GiveawayBlacklistEntryModel]:
-    query = "SELECT role_id, reason FROM giveawayBlacklistedRole WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[GiveawayBlacklistEntryModel] = []
-    async for row in GiveawayBlacklistEntryModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.giveaway_service import giveaway_service
+
+    return await giveaway_service.get_blacklisted_roles(guild_id)
 
 
 async def delete_giveaway(giveaway_id: int) -> None:
-    """Delete a giveaway and all related data in a single transaction."""
-    related_tables = [
-        "giveaway_channelRequirement",
-        "giveawayRoleRequirement",
-        "giveawayParticipant",
-        "giveawayVoiceTime",
-        "giveawayNewMessage",
-        "giveaway_channelMessages",
-    ]
-    try:
-        async with transaction() as conn, conn.cursor() as cursor:
-            for table in related_tables:
-                await cursor.execute(f"DELETE FROM {table} WHERE giveaway_id = %s", (giveaway_id,))
-            await cursor.execute("DELETE FROM giveaway WHERE giveaway_id = %s", (giveaway_id,))
-    except Exception as e:
-        print(f"Error deleting giveaway {giveaway_id}: {e}")
-        raise
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.delete(giveaway_id)
 
 
 async def set_giveaway_endtime(giveaway_id: int, endtime: datetime) -> None:
-    query = "UPDATE giveaway SET endtime = %s WHERE giveaway_id = %s"
-    params = (endtime, giveaway_id)
-    await execute_action(query, params)
+    from services.giveaway_service import giveaway_service
+
+    await giveaway_service.set_endtime(giveaway_id, endtime)
 
 
 async def update_giveaway(
@@ -2303,67 +2190,28 @@ async def update_giveaway(
     voice_requirement: int | None,
     channel_id: str,
 ) -> None:
-    query = """
-    UPDATE giveaway SET
-        guild_id = %s,
-        title = %s,
-        description = %s,
-        winners = %s,
-        withButton = %s,
-        customName = %s,
-        sponsor = %s,
-        price = %s,
-        message = %s,
-        endtime = %s,
-        starttime = %s,
-        newMessageRequirement = %s,
-        dayRequirement = %s,
-        voiceRequirement = %s,
-        channel_id = %s
-    WHERE giveaway_id = %s
-    """
-    params = (
-        guild_id,
-        title,
-        description,
-        winners,
-        with_button,
-        custom_name,
-        sponsor,
-        price,
-        message,
-        endtime,
-        starttime,
-        new_message_requirement,
-        day_requirement,
-        voice_requirement,
-        channel_id,
-        giveaway_id,
+    from services.giveaway_service import GiveawayUpdateParams, giveaway_service
+
+    params = GiveawayUpdateParams(
+        guild_id=guild_id,
+        title=title,
+        description=description,
+        winners=winners,
+        with_button=with_button,
+        custom_name=custom_name,
+        sponsor=sponsor,
+        price=price,
+        message=message,
+        end_time=endtime,
+        start_time=starttime,
+        new_message_requirement=new_message_requirement,
+        day_requirement=day_requirement,
+        channel_requirements=channel_requirements,
+        role_requirement=role_requirement,
+        voice_requirement=voice_requirement,
+        channel_id=channel_id,
     )
-    try:
-        async with transaction() as conn, conn.cursor() as cursor:
-            await cursor.execute(query, params)
-            await cursor.execute(
-                "DELETE FROM giveaway_channelRequirement WHERE giveaway_id = %s",
-                (giveaway_id,),
-            )
-            if channel_requirements is not None and len(channel_requirements) > 0 and channel_requirements != {}:
-                for ch_id, amount in channel_requirements.items():
-                    await cursor.execute(
-                        "INSERT INTO giveaway_channelRequirement (giveaway_id, channel_id, amount) VALUES (%s, %s, %s)",
-                        (giveaway_id, ch_id, amount),
-                    )
-            await cursor.execute(
-                "DELETE FROM giveawayRoleRequirement WHERE giveaway_id = %s",
-                (giveaway_id,),
-            )
-            for role_id in role_requirement:
-                await cursor.execute(
-                    "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)",
-                    (role_id, giveaway_id),
-                )
-    except Exception as e:
-        print(f"Error during giveaway update for {giveaway_id}: {e}")
+    await giveaway_service.update(giveaway_id, params)
 
 
 async def set_text_cooldown(guild_id: str, cooldown: int) -> None:

--- a/commands/giveaway/add_blacklist_role.py
+++ b/commands/giveaway/add_blacklist_role.py
@@ -1,12 +1,7 @@
 import discord
 
 import utility
-from api import (
-    add_giveaway_blacklisted_role as add_blacklist_role_api,
-)
-from api import (
-    get_blacklisted_roles as get_giveaway_blacklisted_roles,
-)
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -28,7 +23,7 @@ async def add_blacklist_role(
         await command_info.reply(embed=embed)
         return
 
-    blacklisted_roles = [role.entity_id for role in await get_giveaway_blacklisted_roles(command_info.guild.id)]  # type: ignore[union-attr]
+    blacklisted_roles = [role.entity_id for role in await giveaway_service.get_blacklisted_roles(str(command_info.guild.id))]  # type: ignore[union-attr]
 
     if str(role.id) in blacklisted_roles:
         embed = utility.tanjunEmbed(
@@ -44,7 +39,7 @@ async def add_blacklist_role(
         await command_info.reply(embed=embed)
         return
 
-    await add_blacklist_role_api(command_info.guild.id, role.id)  # type: ignore[union-attr]
+    await giveaway_service.add_blacklisted_role(str(command_info.guild.id), str(role.id))  # type: ignore[union-attr]
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.giveaway.add_blacklist_role.success.title"),
         description=tanjunLocalizer.localize(

--- a/commands/giveaway/add_blacklist_role.py
+++ b/commands/giveaway/add_blacklist_role.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def add_blacklist_role(

--- a/commands/giveaway/add_blacklist_user.py
+++ b/commands/giveaway/add_blacklist_user.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def add_blacklist_user(

--- a/commands/giveaway/add_blacklist_user.py
+++ b/commands/giveaway/add_blacklist_user.py
@@ -1,12 +1,7 @@
 import discord
 
 import utility
-from api import (
-    add_giveaway_blacklisted_user as add_blacklist_user_api,
-)
-from api import (
-    check_if_user_blacklisted,
-)
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -28,7 +23,7 @@ async def add_blacklist_user(
         await command_info.reply(embed=embed)
         return
 
-    if await check_if_user_blacklisted(command_info.guild.id, user.id):  # type: ignore[union-attr]
+    if await giveaway_service.is_user_blacklisted(str(command_info.guild.id), str(user.id)):  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
                 command_info.locale,
@@ -42,9 +37,9 @@ async def add_blacklist_user(
         await command_info.reply(embed=embed)
         return
 
-    await add_blacklist_user_api(
-        guild_id=command_info.guild.id,  # type: ignore[union-attr]
-        user_id=user.id,
+    await giveaway_service.add_blacklisted_user(
+        guild_id=str(command_info.guild.id),  # type: ignore[union-attr]
+        user_id=str(user.id),
     )
 
     embed = utility.tanjunEmbed(

--- a/commands/giveaway/edit_giveaway.py
+++ b/commands/giveaway/edit_giveaway.py
@@ -3,12 +3,12 @@ from discord import ui
 
 import commands.giveaway.start as start_giveaway
 import utility
+from commands.giveaway.utility import generateGiveawayEmbed, updateGiveawayMessage
+from localizer import tanjunLocalizer
 from services.giveaway_service import (
     GiveawayUpdateParams,
     giveaway_service,
 )
-from commands.giveaway.utility import generateGiveawayEmbed, updateGiveawayMessage
-from localizer import tanjunLocalizer
 from utility import dateToRelativeTimeStr, relativeTimeStrToDate
 
 

--- a/commands/giveaway/edit_giveaway.py
+++ b/commands/giveaway/edit_giveaway.py
@@ -3,11 +3,9 @@ from discord import ui
 
 import commands.giveaway.start as start_giveaway
 import utility
-from api import (
-    get_giveaway,
-    get_giveaway_channel_requirements,
-    get_giveaway_role_requirements,
-    update_giveaway,
+from services.giveaway_service import (
+    GiveawayUpdateParams,
+    giveaway_service,
 )
 from commands.giveaway.utility import generateGiveawayEmbed, updateGiveawayMessage
 from localizer import tanjunLocalizer
@@ -29,12 +27,12 @@ class GiveawayEditor(ui.View):
         self.generator_message = None
 
     async def load_giveaway_data(self) -> None:
-        giveaway = await get_giveaway(self.giveaway_id)
+        giveaway = await giveaway_service.get(self.giveaway_id)
         if not giveaway:
-            return False  # type: ignore[return-value]
+            return
 
-        role_requirements = await get_giveaway_role_requirements(self.giveaway_id)
-        channel_requirements = await get_giveaway_channel_requirements(self.giveaway_id)
+        role_requirements = await giveaway_service.get_role_requirements(self.giveaway_id)
+        channel_requirements = await giveaway_service.get_channel_requirements(self.giveaway_id)
 
         self.giveaway_data = {
             "title": giveaway.title,
@@ -410,25 +408,27 @@ class GiveawayEditor(ui.View):
 
     async def confirm(self, interaction: discord.Interaction, button: ui.Button) -> None:  # type: ignore[type-arg]
         # Update the giveaway in the database
-        await update_giveaway(
+        await giveaway_service.update(
             giveaway_id=self.giveaway_id,
-            guild_id=str(self.command_info.guild.id),  # type: ignore[union-attr]
-            title=self.giveaway_data["title"],
-            description=self.giveaway_data["description"],
-            winners=self.giveaway_data["winners"],
-            with_button=self.giveaway_data["with_button"],
-            custom_name=self.giveaway_data["custom_name"],
-            sponsor=self.giveaway_data["sponsor"],
-            price=self.giveaway_data["price"],
-            message=self.giveaway_data["message"],
-            endtime=relativeTimeStrToDate(self.giveaway_data["end_time"]),
-            starttime=relativeTimeStrToDate(self.giveaway_data["start_time"]),
-            new_message_requirement=self.giveaway_data["new_message_requirement"],
-            day_requirement=self.giveaway_data["day_requirement"],
-            channel_requirements=self.giveaway_data["channel_requirements"],
-            role_requirement=self.giveaway_data["role_requirement"],
-            voice_requirement=self.giveaway_data["voice_requirement"],
-            channel_id=str(self.giveaway_data["target_channel"].id),
+            params=GiveawayUpdateParams(
+                guild_id=str(self.command_info.guild.id),  # type: ignore[union-attr]
+                title=self.giveaway_data["title"],
+                description=self.giveaway_data["description"],
+                winners=self.giveaway_data["winners"],
+                with_button=self.giveaway_data["with_button"],
+                custom_name=self.giveaway_data["custom_name"],
+                sponsor=self.giveaway_data["sponsor"],
+                price=self.giveaway_data["price"],
+                message=self.giveaway_data["message"],
+                end_time=relativeTimeStrToDate(self.giveaway_data["end_time"]),
+                start_time=relativeTimeStrToDate(self.giveaway_data["start_time"]),
+                new_message_requirement=self.giveaway_data["new_message_requirement"],
+                day_requirement=self.giveaway_data["day_requirement"],
+                channel_requirements=self.giveaway_data["channel_requirements"],
+                role_requirement=self.giveaway_data["role_requirement"],
+                voice_requirement=self.giveaway_data["voice_requirement"],
+                channel_id=str(self.giveaway_data["target_channel"].id),
+            ),
         )
 
         # Update the giveaway message

--- a/commands/giveaway/end_giveaway.py
+++ b/commands/giveaway/end_giveaway.py
@@ -1,7 +1,7 @@
 import utility
-from services.giveaway_service import giveaway_service
 from commands.giveaway.utility import endGiveaway
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def end_giveaway(

--- a/commands/giveaway/end_giveaway.py
+++ b/commands/giveaway/end_giveaway.py
@@ -1,5 +1,5 @@
 import utility
-from api import delete_giveaway, get_giveaway
+from services.giveaway_service import giveaway_service
 from commands.giveaway.utility import endGiveaway
 from localizer import tanjunLocalizer
 
@@ -22,7 +22,7 @@ async def end_giveaway(
         await command_info.reply(embed=embed)
         return
 
-    giveaway = await get_giveaway(giveaway_id)
+    giveaway = await giveaway_service.get(giveaway_id)
     if not giveaway:
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -66,7 +66,7 @@ async def end_giveaway(
         return
 
     if not giveaway.started:
-        await delete_giveaway(giveaway_id)
+        await giveaway_service.delete(giveaway_id)
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
                 command_info.locale,

--- a/commands/giveaway/list_blacklist.py
+++ b/commands/giveaway/list_blacklist.py
@@ -1,10 +1,5 @@
 import utility
-from api import (
-    get_giveaway_blacklisted_roles as get_blacklist_role_api,
-)
-from api import (
-    get_giveaway_blacklisted_users as get_blacklist_user_api,
-)
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -25,8 +20,8 @@ async def list_blacklist(
         await command_info.reply(embed=embed)
         return
 
-    blacklisted_roles = [role.entity_id for role in await get_blacklist_role_api(command_info.guild.id)]  # type: ignore[union-attr]
-    blacklisted_users = [user.entity_id for user in await get_blacklist_user_api(command_info.guild.id)]  # type: ignore[union-attr]
+    blacklisted_roles = [role.entity_id for role in await giveaway_service.get_blacklisted_roles(str(command_info.guild.id))]  # type: ignore[union-attr]
+    blacklisted_users = [user.entity_id for user in await giveaway_service.get_blacklisted_users(str(command_info.guild.id))]  # type: ignore[union-attr]
 
     if len(blacklisted_roles) == 0 and len(blacklisted_users) == 0:
         embed = utility.tanjunEmbed(

--- a/commands/giveaway/list_blacklist.py
+++ b/commands/giveaway/list_blacklist.py
@@ -1,6 +1,6 @@
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def list_blacklist(

--- a/commands/giveaway/remove_blacklist_role.py
+++ b/commands/giveaway/remove_blacklist_role.py
@@ -1,12 +1,7 @@
 import discord
 
 import utility
-from api import (
-    get_blacklisted_roles as get_giveaway_blacklisted_roles,
-)
-from api import (
-    remove_giveaway_blacklisted_role as remove_blacklist_role_api,
-)
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -28,7 +23,7 @@ async def remove_blacklist_role(
         await command_info.reply(embed=embed)
         return
 
-    blacklisted_roles = [role.entity_id for role in await get_giveaway_blacklisted_roles(command_info.guild.id)]  # type: ignore[union-attr]
+    blacklisted_roles = [role.entity_id for role in await giveaway_service.get_blacklisted_roles(str(command_info.guild.id))]  # type: ignore[union-attr]
 
     if str(role.id) not in blacklisted_roles:
         embed = utility.tanjunEmbed(
@@ -44,9 +39,9 @@ async def remove_blacklist_role(
         await command_info.reply(embed=embed)
         return
 
-    await remove_blacklist_role_api(
-        guild_id=command_info.guild.id,  # type: ignore[union-attr]
-        role_id=role.id,
+    await giveaway_service.remove_blacklisted_role(
+        guild_id=str(command_info.guild.id),  # type: ignore[union-attr]
+        role_id=str(role.id),
     )
 
     embed = utility.tanjunEmbed(

--- a/commands/giveaway/remove_blacklist_role.py
+++ b/commands/giveaway/remove_blacklist_role.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def remove_blacklist_role(

--- a/commands/giveaway/remove_blacklist_user.py
+++ b/commands/giveaway/remove_blacklist_user.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def remove_blacklist_user(

--- a/commands/giveaway/remove_blacklist_user.py
+++ b/commands/giveaway/remove_blacklist_user.py
@@ -1,12 +1,7 @@
 import discord
 
 import utility
-from api import (
-    check_if_user_blacklisted,
-)
-from api import (
-    remove_giveaway_blacklisted_user as remove_blacklist_user_api,
-)
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -28,7 +23,7 @@ async def remove_blacklist_user(
         await command_info.reply(embed=embed)
         return
 
-    if not await check_if_user_blacklisted(command_info.guild.id, user.id):  # type: ignore[union-attr]
+    if not await giveaway_service.is_user_blacklisted(str(command_info.guild.id), str(user.id)):  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
                 command_info.locale,
@@ -42,9 +37,9 @@ async def remove_blacklist_user(
         await command_info.reply(embed=embed)
         return
 
-    await remove_blacklist_user_api(
-        guild_id=command_info.guild.id,  # type: ignore[union-attr]
-        user_id=user.id,
+    await giveaway_service.remove_blacklisted_user(
+        guild_id=str(command_info.guild.id),  # type: ignore[union-attr]
+        user_id=str(user.id),
     )
 
     embed = utility.tanjunEmbed(

--- a/commands/giveaway/reroll_giveaway.py
+++ b/commands/giveaway/reroll_giveaway.py
@@ -3,7 +3,7 @@ import random
 import discord
 
 import utility
-from api import get_giveaway, get_giveaway_participants
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 
 
@@ -25,7 +25,7 @@ async def reroll_giveaway(
         await command_info.reply(embed=embed)
         return
 
-    giveaway = await get_giveaway(giveaway_id)
+    giveaway = await giveaway_service.get(giveaway_id)
     if not giveaway:
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -89,7 +89,7 @@ async def reroll_giveaway(
         )
         async def reroll_all(self, interaction: discord.Interaction, button: discord.ui.Button):
             await interaction.response.defer()
-            giveaway = await get_giveaway(self.giveaway_id)
+            giveaway = await giveaway_service.get(self.giveaway_id)
             await perform_reroll(self.command_info, self.giveaway_id, giveaway.winners)
             self.stop()
 
@@ -124,7 +124,7 @@ async def reroll_giveaway(
 
 
 async def perform_reroll(command_info: utility.command_info, giveaway_id: int, reroll_count: int):
-    participants = await get_giveaway_participants(giveaway_id)
+    participants = await giveaway_service.get_participants(giveaway_id)
 
     if not participants:
         embed = utility.tanjunEmbed(

--- a/commands/giveaway/reroll_giveaway.py
+++ b/commands/giveaway/reroll_giveaway.py
@@ -3,8 +3,8 @@ import random
 import discord
 
 import utility
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
+from services.giveaway_service import giveaway_service
 
 
 async def reroll_giveaway(
@@ -90,6 +90,20 @@ async def reroll_giveaway(
         async def reroll_all(self, interaction: discord.Interaction, button: discord.ui.Button):
             await interaction.response.defer()
             giveaway = await giveaway_service.get(self.giveaway_id)
+            if giveaway is None:
+                embed = utility.tanjunEmbed(
+                    title=tanjunLocalizer.localize(
+                        self.command_info.locale,
+                        "commands.giveaway.reroll_giveaway.error.notFound.title",
+                    ),
+                    description=tanjunLocalizer.localize(
+                        self.command_info.locale,
+                        "commands.giveaway.reroll_giveaway.error.notFound.description",
+                    ),
+                )
+                await self.command_info.reply(embed=embed)
+                self.stop()
+                return
             await perform_reroll(self.command_info, self.giveaway_id, giveaway.winners)
             self.stop()
 

--- a/commands/giveaway/start.py
+++ b/commands/giveaway/start.py
@@ -4,9 +4,9 @@ import discord
 from discord import ui
 
 import utility
-from services.giveaway_service import GiveawayCreateParams, giveaway_service
 from commands.giveaway.utility import generateGiveawayEmbed, sendGiveaway
 from localizer import tanjunLocalizer
+from services.giveaway_service import GiveawayCreateParams, giveaway_service
 
 
 class GiveawayBuilderButton(ui.Button):

--- a/commands/giveaway/start.py
+++ b/commands/giveaway/start.py
@@ -4,7 +4,7 @@ import discord
 from discord import ui
 
 import utility
-from api import add_giveaway
+from services.giveaway_service import GiveawayCreateParams, giveaway_service
 from commands.giveaway.utility import generateGiveawayEmbed, sendGiveaway
 from localizer import tanjunLocalizer
 
@@ -1338,24 +1338,26 @@ class GiveawayBuilder(ui.View):
         channel_requirements = self.giveaway_data["channel_requirements"]
         target_channel = self.giveaway_data["target_channel"]
 
-        giveaway_id = await add_giveaway(
-            self.command_info.guild.id,
-            title=title,
-            description=description,
-            winners=winners,
-            with_button=with_button,
-            custom_name=custom_name,
-            sponsor=sponsor,
-            price=price,
-            message=message,
-            endtime=end_time,
-            starttime=start_time,
-            new_message_requirement=new_message_requirement,
-            day_requirement=day_requirement,
-            role_requirement=role_requirement,
-            voice_requirement=voice_requirement,
-            channel_requirements=channel_requirements,
-            channel_id=target_channel.id,
+        giveaway_id = await giveaway_service.create(
+            GiveawayCreateParams(
+                guild_id=str(self.command_info.guild.id),
+                title=title,
+                description=description,
+                winners=winners,
+                with_button=with_button,
+                custom_name=custom_name,
+                sponsor=sponsor,
+                price=price,
+                message=message,
+                end_time=end_time,
+                start_time=start_time,
+                new_message_requirement=new_message_requirement,
+                day_requirement=day_requirement,
+                role_requirement=role_requirement,
+                voice_requirement=voice_requirement,
+                channel_requirements=channel_requirements,
+                channel_id=str(target_channel.id),
+            )
         )
 
         self.giveaway_data["id"] = giveaway_id

--- a/commands/giveaway/utility.py
+++ b/commands/giveaway/utility.py
@@ -5,28 +5,8 @@ import random
 
 import discord
 
-from api import (
-    add_giveaway_new_message_channel_if_needed,
-    add_giveaway_new_message_if_needed,
-    check_if_giveaway_participant,
-    check_if_opted_out,
-    check_if_user_blacklisted,
-    get_blacklisted_roles,
-    get_giveaway,
-    get_giveaway_channel_requirements,
-    get_giveaway_participants,
-    get_giveaway_role_requirements,
-    get_new_messages,
-    get_new_messages_channel,
-    get_voice_time,
-    remove_giveaway_participant,
-    set_giveaway_ended,
-    set_giveaway_message_id,
-    set_giveaway_started,
-)
-from api import (
-    add_giveaway_participant as add_giveaway_participant_api,
-)
+from api import check_if_opted_out
+from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 from models import GiveawayChannelRequirementModel, GiveawayModel
 from utility import relativeTimeStrToDate, tanjunEmbed
@@ -138,7 +118,7 @@ async def generateGiveawayEmbed(
 
 
 async def sendGiveaway(giveawayid, client) -> None:  # type: ignore[no-untyped-def]
-    giveaway = await get_giveaway(giveawayid)
+    giveaway = await giveaway_service.get(giveawayid)
 
     if not giveaway:
         return
@@ -152,9 +132,9 @@ async def sendGiveaway(giveawayid, client) -> None:  # type: ignore[no-untyped-d
 
     locale = str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US"
 
-    role_requirements = await get_giveaway_role_requirements(giveawayid)
+    role_requirements = await giveaway_service.get_role_requirements(giveawayid)
 
-    channel_requirements = await get_giveaway_channel_requirements(giveawayid)
+    channel_requirements = await giveaway_service.get_channel_requirements(giveawayid)
 
     embed = await generateGiveawayEmbed(giveaway, locale, role_requirements, channel_requirements)
 
@@ -165,7 +145,7 @@ async def sendGiveaway(giveawayid, client) -> None:  # type: ignore[no-untyped-d
 
     view = discord.ui.View()
 
-    participants = await get_giveaway_participants(giveawayid)
+    participants = await giveaway_service.get_participants(giveawayid)
 
     btn = discord.ui.Button(  # type: ignore[var-annotated]
         style=discord.ButtonStyle.primary,
@@ -179,12 +159,12 @@ async def sendGiveaway(giveawayid, client) -> None:  # type: ignore[no-untyped-d
 
     message = await channel.send(giveaway.message, embed=embed, view=view)
 
-    await set_giveaway_message_id(giveawayid, message.id)
-    await set_giveaway_started(giveawayid)
+    await giveaway_service.set_message_id(giveawayid, message.id)
+    await giveaway_service.set_started(giveawayid)
 
 
 async def updateGiveawayEmbed(giveawayid, client) -> None:  # type: ignore[no-untyped-def]
-    giveaway = await get_giveaway(giveawayid)
+    giveaway = await giveaway_service.get(giveawayid)
 
     if not giveaway:
         return
@@ -198,9 +178,9 @@ async def updateGiveawayEmbed(giveawayid, client) -> None:  # type: ignore[no-un
 
     locale = str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US"
 
-    role_requirements = await get_giveaway_role_requirements(giveawayid)
+    role_requirements = await giveaway_service.get_role_requirements(giveawayid)
 
-    channel_requirements = await get_giveaway_channel_requirements(giveawayid)
+    channel_requirements = await giveaway_service.get_channel_requirements(giveawayid)
 
     embed = await generateGiveawayEmbed(giveaway, locale, role_requirements, channel_requirements)
 
@@ -215,7 +195,7 @@ async def updateGiveawayEmbed(giveawayid, client) -> None:  # type: ignore[no-un
 
 
 async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type: ignore[no-untyped-def]
-    giveaway = await get_giveaway(giveawayid)
+    giveaway = await giveaway_service.get(giveawayid)
 
     if not giveaway:
         return
@@ -232,8 +212,8 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
     if not member:
         return
 
-    if await check_if_giveaway_participant(giveawayid, userid):
-        await remove_giveaway_participant(giveawayid, userid)
+    if await giveaway_service.is_participant(giveawayid, userid):
+        await giveaway_service.remove_participant(giveawayid, userid)
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
                 (guild.preferred_locale if hasattr(guild, "preferred_locale") else "en_US"),
@@ -250,7 +230,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
 
         view = discord.ui.View()
 
-        participants = await get_giveaway_participants(giveawayid)
+        participants = await giveaway_service.get_participants(giveawayid)
         btn = discord.ui.Button(  # type: ignore[var-annotated]
             style=discord.ButtonStyle.primary,
             label=tanjunLocalizer.localize(
@@ -268,7 +248,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
 
         return embed  # type: ignore[return-value]
 
-    if await check_if_user_blacklisted(guild_id, userid):
+    if await giveaway_service.is_user_blacklisted(guild_id, userid):
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
                 str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US",
@@ -295,7 +275,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
         return embed  # type: ignore[return-value]
 
     # check if has a role that is blacklisted
-    blacklisted_roles = await get_blacklisted_roles(guild_id)
+    blacklisted_roles = await giveaway_service.get_blacklisted_roles(guild_id)
 
     if blacklisted_roles:
         if any(str(role.id) in [bl.entity_id for bl in blacklisted_roles] for role in member.roles):  # type: ignore[comparison-overlap]
@@ -313,7 +293,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
 
     # check if new Message requirement is met
     if giveaway.new_message_requirement:
-        new_messages = await get_new_messages(giveaway_id=giveawayid, user_id=userid)
+        new_messages = await giveaway_service.get_new_messages(giveaway_id=giveawayid, user_id=userid)
         if not new_messages:
             embed = tanjunEmbed(
                 title=tanjunLocalizer.localize(
@@ -384,7 +364,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
         if not member:
             return
 
-        voice_time = await get_voice_time(giveawayid, userid)
+        voice_time = await giveaway_service.get_voice_time(giveawayid, userid)
 
         if not voice_time:
             voice_time = 0
@@ -405,7 +385,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
             return embed  # type: ignore[return-value]
 
     # check if role requirement is met
-    role_requirements = await get_giveaway_role_requirements(giveawayid)
+    role_requirements = await giveaway_service.get_role_requirements(giveawayid)
 
     if role_requirements:
         member = guild.get_member(userid)
@@ -427,7 +407,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
             return embed  # type: ignore[return-value]
 
     # check if channel requirement is met
-    channel_requirements = await get_giveaway_channel_requirements(giveawayid)
+    channel_requirements = await giveaway_service.get_channel_requirements(giveawayid)
 
     if channel_requirements:
         member = guild.get_member(userid)
@@ -435,7 +415,7 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
             return
 
         for req in channel_requirements:
-            messages = await get_new_messages_channel(giveawayid, req.channel_id, userid)
+            messages = await giveaway_service.get_new_messages_channel(giveawayid, req.channel_id, userid)
 
             if not messages or messages < req.amount:
                 embed = tanjunEmbed(
@@ -454,14 +434,14 @@ async def add_giveaway_participant(giveawayid, userid, client) -> None:  # type:
                 return embed  # type: ignore[return-value]
 
     # add participant to giveaway
-    await add_giveaway_participant_api(giveawayid, userid)
+    await giveaway_service.add_participant(giveawayid, userid)
 
     giveaway_channel = guild.get_channel(int(giveaway.channel_id))
     giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
 
     view = discord.ui.View()
 
-    participants = await get_giveaway_participants(giveawayid)
+    participants = await giveaway_service.get_participants(giveawayid)
 
     btn = discord.ui.Button(
         style=discord.ButtonStyle.primary,
@@ -496,18 +476,18 @@ async def addMessageToGiveaway(message: discord.Message):  # type: ignore[no-unt
     if await check_if_opted_out(message.author.id):
         return
 
-    await add_giveaway_new_message_if_needed(message.author.id, message.guild.id)  # type: ignore[union-attr]
+    await giveaway_service.add_new_message(message.author.id, message.guild.id)  # type: ignore[union-attr]
 
-    await add_giveaway_new_message_channel_if_needed(message.author.id, message.guild.id, message.channel.id)  # type: ignore[union-attr]
+    await giveaway_service.add_new_message_channel(message.author.id, message.guild.id, message.channel.id)  # type: ignore[union-attr]
 
 
 async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-def]
-    giveaway = await get_giveaway(giveaway_id)
+    giveaway = await giveaway_service.get(giveaway_id)
 
     if giveaway.ended:
         return
 
-    await set_giveaway_ended(giveaway_id)
+    await giveaway_service.set_ended(giveaway_id)
 
     if not giveaway:
         return
@@ -521,7 +501,7 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
 
     locale = str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US"
 
-    participants = await get_giveaway_participants(giveaway_id)
+    participants = await giveaway_service.get_participants(giveaway_id)
 
     if not participants:
         embed = tanjunEmbed(
@@ -587,7 +567,7 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
     )
 
     for winner in winners:
-        await remove_giveaway_participant(giveaway_id, winner)
+        await giveaway_service.remove_participant(giveaway_id, winner)
         member = guild.get_member(winner)
         if member:
             with contextlib.suppress(Exception):
@@ -644,7 +624,7 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
 
 
 async def updateGiveawayMessage(giveaway_id, client) -> None:  # type: ignore[no-untyped-def]
-    giveaway = await get_giveaway(giveaway_id)
+    giveaway = await giveaway_service.get(giveaway_id)
 
     if not giveaway:
         return
@@ -658,9 +638,9 @@ async def updateGiveawayMessage(giveaway_id, client) -> None:  # type: ignore[no
 
     locale = str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US"
 
-    role_requirements = await get_giveaway_role_requirements(giveaway_id)
+    role_requirements = await giveaway_service.get_role_requirements(giveaway_id)
 
-    channel_requirements = await get_giveaway_channel_requirements(giveaway_id)
+    channel_requirements = await giveaway_service.get_channel_requirements(giveaway_id)
 
     embed = await generateGiveawayEmbed(giveaway, locale, role_requirements, channel_requirements)
 

--- a/commands/giveaway/utility.py
+++ b/commands/giveaway/utility.py
@@ -6,9 +6,9 @@ import random
 import discord
 
 from api import check_if_opted_out
-from services.giveaway_service import giveaway_service
 from localizer import tanjunLocalizer
 from models import GiveawayChannelRequirementModel, GiveawayModel
+from services.giveaway_service import giveaway_service
 from utility import relativeTimeStrToDate, tanjunEmbed
 
 
@@ -159,8 +159,7 @@ async def sendGiveaway(giveawayid, client) -> None:  # type: ignore[no-untyped-d
 
     message = await channel.send(giveaway.message, embed=embed, view=view)
 
-    await giveaway_service.set_message_id(giveawayid, message.id)
-    await giveaway_service.set_started(giveawayid)
+    await giveaway_service.mark_sent(giveawayid, message.id)
 
 
 async def updateGiveawayEmbed(giveawayid, client) -> None:  # type: ignore[no-untyped-def]
@@ -484,12 +483,10 @@ async def addMessageToGiveaway(message: discord.Message):  # type: ignore[no-unt
 async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-def]
     giveaway = await giveaway_service.get(giveaway_id)
 
-    if giveaway.ended:
+    if not giveaway:
         return
 
-    await giveaway_service.set_ended(giveaway_id)
-
-    if not giveaway:
+    if giveaway.ended:
         return
 
     guild_id = giveaway.guild_id
@@ -501,124 +498,131 @@ async def endGiveaway(giveaway_id, client) -> None:  # type: ignore[no-untyped-d
 
     locale = str(guild.preferred_locale) if hasattr(guild, "preferred_locale") else "en_US"
 
-    participants = await giveaway_service.get_participants(giveaway_id)
+    try:
+        participants = await giveaway_service.get_participants(giveaway_id)
 
-    if not participants:
+        if not participants:
+            embed = tanjunEmbed(
+                title=tanjunLocalizer.localize(
+                    locale,
+                    "commands.giveaway.endedGiveaway.no_participants.title",
+                ),
+                description=tanjunLocalizer.localize(
+                    locale,
+                    "commands.giveaway.endedGiveaway.no_participants.description",
+                ),
+            )
+            giveaway_channel = guild.get_channel(int(giveaway.channel_id))
+            if not giveaway_channel:
+                return
+            try:
+                giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
+            except Exception:
+                logging.exception("Failed to fetch giveaway message %s for no-participants path", giveaway.message_id)
+                return
+            if not giveawaymessage:
+                return
+
+            view = discord.ui.View()
+
+            btn = discord.ui.Button(  # type: ignore[var-annotated]
+                style=discord.ButtonStyle.primary,
+                label=tanjunLocalizer.localize(locale, "commands.giveaway.endedGiveaway.button_text", participants=0),
+                disabled=True,
+            )
+            view.add_item(btn)
+
+            await giveawaymessage.edit(view=view)
+            await giveawaymessage.reply(embed=embed)
+            await giveaway_service.set_ended(giveaway_id)
+            return
+
+        winners = []
+
+        if not participants:
+            participants = []
+
+        participant_amount = len(participants)
+
+        if giveaway.winners > participant_amount:
+            winners = participants
+        else:
+            for _i in range(giveaway.winners):
+                # nosec: B311
+                winner = random.choice(participants)
+                participants.remove(winner)
+                winners.append(winner)
+
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
                 locale,
-                "commands.giveaway.endedGiveaway.no_participants.title",
+                "commands.giveaway.endedGiveaway.title",
             ),
             description=tanjunLocalizer.localize(
                 locale,
-                "commands.giveaway.endedGiveaway.no_participants.description",
+                "commands.giveaway.endedGiveaway.description",
+                winners=", ".join(f"<@{winner}>" for winner in winners),
             ),
         )
+
+        for winner in winners:
+            await giveaway_service.remove_participant(giveaway_id, winner)
+            member = guild.get_member(winner)
+            if member:
+                with contextlib.suppress(Exception):
+                    await member.send(
+                        tanjunLocalizer.localize(
+                            locale,
+                            "commands.giveaway.endedGiveaway.winnerDM",
+                            guild_name=guild.name,
+                        )
+                    )
+
         giveaway_channel = guild.get_channel(int(giveaway.channel_id))
         if not giveaway_channel:
             return
         try:
             giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
         except Exception:
-            logging.exception("Failed to fetch giveaway message %s for no-participants path", giveaway.message_id)
+            logging.exception("Failed to fetch giveaway message %s for winner announcement path", giveaway.message_id)
             return
         if not giveawaymessage:
             return
 
         view = discord.ui.View()
 
-        btn = discord.ui.Button(  # type: ignore[var-annotated]
+        btn = discord.ui.Button(
             style=discord.ButtonStyle.primary,
-            label=tanjunLocalizer.localize(locale, "commands.giveaway.endedGiveaway.button_text", participants=0),
+            label=tanjunLocalizer.localize(
+                locale,
+                "commands.giveaway.endedGiveaway.button_text",
+                participants=participant_amount,
+            ),
             disabled=True,
         )
         view.add_item(btn)
 
         await giveawaymessage.edit(view=view)
         await giveawaymessage.reply(embed=embed)
-        return
 
-    winners = []
+        for winner in winners:
+            member = guild.get_member(winner)
 
-    if not participants:
-        participants = []
+            if not member:
+                continue
 
-    participant_amount = len(participants)
-
-    if giveaway.winners > participant_amount:
-        winners = participants
-    else:
-        for _i in range(giveaway.winners):
-            # nosec: B311
-            winner = random.choice(participants)
-            participants.remove(winner)
-            winners.append(winner)
-
-    embed = tanjunEmbed(
-        title=tanjunLocalizer.localize(
-            locale,
-            "commands.giveaway.endedGiveaway.title",
-        ),
-        description=tanjunLocalizer.localize(
-            locale,
-            "commands.giveaway.endedGiveaway.description",
-            winners=", ".join(f"<@{winner}>" for winner in winners),
-        ),
-    )
-
-    for winner in winners:
-        await giveaway_service.remove_participant(giveaway_id, winner)
-        member = guild.get_member(winner)
-        if member:
-            with contextlib.suppress(Exception):
-                await member.send(
-                    tanjunLocalizer.localize(
-                        locale,
-                        "commands.giveaway.endedGiveaway.winnerDM",
-                        guild_name=guild.name,
-                    )
+            await member.send(
+                tanjunLocalizer.localize(
+                    locale,
+                    "commands.giveaway.endedGiveaway.dm",
+                    guild_name=guild.name,
                 )
-
-    giveaway_channel = guild.get_channel(int(giveaway.channel_id))
-    if not giveaway_channel:
-        return
-    try:
-        giveawaymessage = await giveaway_channel.fetch_message(int(giveaway.message_id))
-    except Exception:
-        logging.exception("Failed to fetch giveaway message %s for winner announcement path", giveaway.message_id)
-        return
-    if not giveawaymessage:
-        return
-
-    view = discord.ui.View()
-
-    btn = discord.ui.Button(
-        style=discord.ButtonStyle.primary,
-        label=tanjunLocalizer.localize(
-            locale,
-            "commands.giveaway.endedGiveaway.button_text",
-            participants=participant_amount,
-        ),
-        disabled=True,
-    )
-    view.add_item(btn)
-
-    await giveawaymessage.edit(view=view)
-    await giveawaymessage.reply(embed=embed)
-
-    for winner in winners:
-        member = guild.get_member(winner)
-
-        if not member:
-            continue
-
-        await member.send(
-            tanjunLocalizer.localize(
-                locale,
-                "commands.giveaway.endedGiveaway.dm",
-                guild_name=guild.name,
             )
-        )
+
+        await giveaway_service.set_ended(giveaway_id)
+    except Exception:
+        logging.exception("Failed to end giveaway %s, will retry", giveaway_id)
+        raise
 
     return embed  # type: ignore[return-value]
 

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -5,7 +5,6 @@ from discord import app_commands
 from discord.ext import commands
 
 import utility
-from utility import EmbedColor
 from commands.utility.afk import afk as afkCommand
 from commands.utility.autopublish import autopublish as autopublishCommand
 from commands.utility.autopublish import autopublish_remove as autopublishRemoveCommand
@@ -60,6 +59,7 @@ from commands.utility.twitch.see_twitch_live_notifications import (
     seeTwitchLiveNotifications as seeTwitchLiveNotificationsCommand,
 )
 from localizer import tanjunLocalizer
+from utility import EmbedColor
 
 
 class MessageTrackingCommands(discord.app_commands.Group):

--- a/loops/giveaway.py
+++ b/loops/giveaway.py
@@ -1,6 +1,6 @@
-from services.giveaway_service import giveaway_service
 from commands.giveaway.utility import endGiveaway, sendGiveaway
 from loops._voice_tracker import voice_user_ids
+from services.giveaway_service import giveaway_service
 
 
 async def sendReadyGiveaways(client):

--- a/loops/giveaway.py
+++ b/loops/giveaway.py
@@ -1,10 +1,10 @@
-from api import add_giveaway_voice_minutes_if_needed, get_end_ready_giveaways, get_send_ready_giveaways
+from services.giveaway_service import giveaway_service
 from commands.giveaway.utility import endGiveaway, sendGiveaway
 from loops._voice_tracker import voice_user_ids
 
 
 async def sendReadyGiveaways(client):
-    ready_giveaways = await get_send_ready_giveaways()
+    ready_giveaways = await giveaway_service.get_send_ready()
     if ready_giveaways:
         for giveaway_id in ready_giveaways:
             await sendGiveaway(giveawayid=giveaway_id, client=client)
@@ -12,11 +12,11 @@ async def sendReadyGiveaways(client):
 
 async def checkVoiceUsers(client):
     for user_id, guild_id in list(voice_user_ids):
-        await add_giveaway_voice_minutes_if_needed(user_id, guild_id)
+        await giveaway_service.add_voice_minutes(user_id, guild_id)
 
 
 async def endGiveaways(client):
-    ready_giveaways = await get_end_ready_giveaways()
+    ready_giveaways = await giveaway_service.get_end_ready()
     if ready_giveaways:
         for giveaway_id in ready_giveaways:
             await endGiveaway(giveaway_id=giveaway_id, client=client)

--- a/services/giveaway_service.py
+++ b/services/giveaway_service.py
@@ -1,0 +1,526 @@
+"""
+GiveawayService: Encapsulate 50+ giveaway API functions into a single service.
+
+Consolidates the loose giveaway functions from api.py (add_giveaway, get_giveaway,
+update_giveaway, delete_giveaway, participant CRUD, blacklist CRUD, etc.) into a
+single GiveawayService class with Pydantic-validated parameter models.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from api import (
+    execute_action,
+    execute_query,
+    execute_query_iter,
+    safe_execute_query,
+    transaction,
+)
+from models import GiveawayBlacklistEntryModel, GiveawayChannelRequirementModel, GiveawayModel
+
+
+# ------------------------------------------------------------------ #
+# Pydantic models
+# ------------------------------------------------------------------ #
+
+
+class GiveawayCreateParams(BaseModel):
+    """Validated parameters for creating a new giveaway."""
+
+    guild_id: str
+    title: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    winners: int = Field(default=1, ge=1)
+    with_button: bool = True
+    channel_id: str
+    custom_name: str | None = None
+    sponsor: str | None = None
+    price: str | None = None
+    message: str | None = None
+    end_time: datetime
+    start_time: datetime | None = None
+    new_message_requirement: int | None = Field(default=None, ge=0)
+    day_requirement: int | None = Field(default=None, ge=0)
+    channel_requirements: dict[str, int] = Field(default_factory=dict)
+    role_requirement: list[str] = Field(default_factory=list)
+    voice_requirement: int | None = Field(default=None, ge=0)
+
+
+class GiveawayUpdateParams(BaseModel):
+    """Validated parameters for updating an existing giveaway."""
+
+    guild_id: str
+    title: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    winners: int = Field(default=1, ge=1)
+    with_button: bool = True
+    custom_name: str | None = None
+    sponsor: str | None = None
+    price: str | None = None
+    message: str | None = None
+    end_time: datetime
+    start_time: datetime | None = None
+    new_message_requirement: int | None = Field(default=None, ge=0)
+    day_requirement: int | None = Field(default=None, ge=0)
+    channel_requirements: dict[str, int] = Field(default_factory=dict)
+    role_requirement: list[str] = Field(default_factory=list)
+    voice_requirement: int | None = Field(default=None, ge=0)
+    channel_id: str
+
+
+# ------------------------------------------------------------------ #
+# Service class
+# ------------------------------------------------------------------ #
+
+
+class GiveawayService:
+    """Service for managing giveaways, participants, and blacklists."""
+
+    # ------------------------------------------------------------------ #
+    # Giveaway CRUD
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def create(params: GiveawayCreateParams) -> int | None:
+        """Create a new giveaway and return its ID."""
+        query = """
+        INSERT INTO giveaway (
+            guild_id, title, description, winners, withButton, customName, sponsor, price, message,
+            endtime, starttime, newMessageRequirement, dayRequirement, voiceRequirement, channel_id
+        )
+        VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+        )
+        """
+        params = (
+            params.guild_id,
+            params.title,
+            params.description,
+            params.winners,
+            params.with_button,
+            params.custom_name,
+            params.sponsor,
+            params.price,
+            params.message,
+            params.end_time,
+            params.start_time,
+            params.new_message_requirement,
+            params.day_requirement,
+            params.voice_requirement,
+            params.channel_id,
+        )
+        try:
+            async with transaction() as conn, conn.cursor() as cursor:
+                await cursor.execute(query, params)
+                await cursor.execute("SELECT LAST_INSERT_ID()")
+                last_id = await cursor.fetchone()
+                giveaway_id = last_id[0] if last_id else None
+                if giveaway_id is None:
+                    raise RuntimeError("Failed to get last insert ID for giveaway")
+
+                if params.channel_requirements:
+                    channel_req_query = (
+                        "INSERT INTO giveaway_channelRequirement (giveaway_id, channel_id, amount) "
+                        "VALUES (%s, %s, %s)"
+                    )
+                    channel_req_params = [
+                        (giveaway_id, ch_id, amount)
+                        for ch_id, amount in params.channel_requirements.items()
+                    ]
+                    await cursor.executemany(channel_req_query, channel_req_params)
+
+                if params.role_requirement:
+                    role_req_query = (
+                        "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)"
+                    )
+                    role_req_params = [(role_id, giveaway_id) for role_id in params.role_requirement]
+                    await cursor.executemany(role_req_query, role_req_params)
+        except Exception as e:
+            print(f"Error creating giveaway: {e}")
+            return None
+
+        return giveaway_id
+
+    @staticmethod
+    async def get(giveaway_id: int) -> GiveawayModel | None:
+        """Get a giveaway by ID."""
+        query = (
+            "SELECT giveaway_id, guild_id, title, description, winners, withButton, "
+            "customName, sponsor, price, message, endtime, starttime, started, ended, "
+            "newMessageRequirement, dayRequirement, voiceRequirement, sendFailed, "
+            "channel_id, messageId, created_at "
+            "FROM giveaway WHERE giveaway_id = %s"
+        )
+        params = (giveaway_id,)
+        result = await safe_execute_query(query, params)
+        return GiveawayModel.from_row(result[0]) if result else None
+
+    @staticmethod
+    async def update(giveaway_id: int, params: GiveawayUpdateParams) -> None:
+        """Update an existing giveaway."""
+        query = """
+        UPDATE giveaway SET
+            guild_id = %s,
+            title = %s,
+            description = %s,
+            winners = %s,
+            withButton = %s,
+            customName = %s,
+            sponsor = %s,
+            price = %s,
+            message = %s,
+            endtime = %s,
+            starttime = %s,
+            newMessageRequirement = %s,
+            dayRequirement = %s,
+            voiceRequirement = %s,
+            channel_id = %s
+        WHERE giveaway_id = %s
+        """
+        vals = (
+            params.guild_id,
+            params.title,
+            params.description,
+            params.winners,
+            params.with_button,
+            params.custom_name,
+            params.sponsor,
+            params.price,
+            params.message,
+            params.end_time,
+            params.start_time,
+            params.new_message_requirement,
+            params.day_requirement,
+            params.voice_requirement,
+            params.channel_id,
+            giveaway_id,
+        )
+        try:
+            async with transaction() as conn, conn.cursor() as cursor:
+                await cursor.execute(query, vals)
+                await cursor.execute(
+                    "DELETE FROM giveaway_channelRequirement WHERE giveaway_id = %s",
+                    (giveaway_id,),
+                )
+                if params.channel_requirements:
+                    for ch_id, amount in params.channel_requirements.items():
+                        await cursor.execute(
+                            "INSERT INTO giveaway_channelRequirement "
+                            "(giveaway_id, channel_id, amount) VALUES (%s, %s, %s)",
+                            (giveaway_id, ch_id, amount),
+                        )
+                await cursor.execute(
+                    "DELETE FROM giveawayRoleRequirement WHERE giveaway_id = %s",
+                    (giveaway_id,),
+                )
+                for role_id in params.role_requirement:
+                    await cursor.execute(
+                        "INSERT INTO giveawayRoleRequirement (role_id, giveaway_id) VALUES (%s, %s)",
+                        (role_id, giveaway_id),
+                    )
+        except Exception as e:
+            print(f"Error during giveaway update for {giveaway_id}: {e}")
+
+    @staticmethod
+    async def delete(giveaway_id: int) -> None:
+        """Delete a giveaway and all related data in a single transaction."""
+        related_tables = [
+            "giveaway_channelRequirement",
+            "giveawayRoleRequirement",
+            "giveawayParticipant",
+            "giveawayVoiceTime",
+            "giveawayNewMessage",
+            "giveaway_channelMessages",
+        ]
+        try:
+            async with transaction() as conn, conn.cursor() as cursor:
+                for table in related_tables:
+                    await cursor.execute(
+                        f"DELETE FROM {table} WHERE giveaway_id = %s", (giveaway_id,)
+                    )
+                await cursor.execute("DELETE FROM giveaway WHERE giveaway_id = %s", (giveaway_id,))
+        except Exception as e:
+            print(f"Error deleting giveaway {giveaway_id}: {e}")
+            raise
+
+    @staticmethod
+    async def delete_old() -> None:
+        """Delete old ended giveaways and their related data."""
+        try:
+            async with transaction() as conn, conn.cursor() as cursor:
+                await cursor.execute(
+                    "SELECT giveaway_id FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
+                )
+                old_ids = [row[0] for row in await cursor.fetchall()]
+                if not old_ids:
+                    return
+
+                related_tables = [
+                    "giveaway_channelRequirement",
+                    "giveawayRoleRequirement",
+                    "giveawayParticipant",
+                    "giveawayVoiceTime",
+                    "giveawayNewMessage",
+                    "giveaway_channelMessages",
+                ]
+                for give_id in old_ids:
+                    for table in related_tables:
+                        await cursor.execute(
+                            f"DELETE FROM {table} WHERE giveaway_id = %s", (give_id,)
+                        )
+                await cursor.execute(
+                    "DELETE FROM giveaway WHERE ended = 1 AND endtime < NOW() - INTERVAL 1 WEEK"
+                )
+        except Exception as e:
+            print(f"Error deleting old giveaways: {e}")
+            raise
+
+    # ------------------------------------------------------------------ #
+    # Giveaway state management
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def set_message_id(giveaway_id: int, message_id: int) -> None:
+        """Set the Discord message ID for a giveaway."""
+        query = "UPDATE giveaway SET messageId = %s WHERE giveaway_id = %s"
+        params = (message_id, giveaway_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def set_started(giveaway_id: int) -> None:
+        """Mark a giveaway as started."""
+        query = "UPDATE giveaway SET started = 1 WHERE giveaway_id = %s"
+        params = (giveaway_id,)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def set_ended(giveaway_id: int) -> None:
+        """Mark a giveaway as ended."""
+        query = "UPDATE giveaway SET ended = 1 WHERE giveaway_id = %s"
+        params = (giveaway_id,)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def set_endtime(giveaway_id: int, endtime: datetime) -> None:
+        """Update the end time of a giveaway."""
+        query = "UPDATE giveaway SET endtime = %s WHERE giveaway_id = %s"
+        params = (endtime, giveaway_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def get_send_ready() -> list[int]:
+        """Get IDs of giveaways ready to be sent (started=0, starttime < now)."""
+        giveaway_ids: list[int] = []
+        async for row in execute_query_iter(
+            "SELECT giveaway_id FROM giveaway WHERE started = 0 AND starttime < NOW()"
+        ):
+            giveaway_ids.append(row[0])
+        return giveaway_ids
+
+    @staticmethod
+    async def get_end_ready() -> list[int]:
+        """Get IDs of giveaways ready to end (ended=0, endtime < now, started=1)."""
+        giveaway_ids: list[int] = []
+        async for row in execute_query_iter(
+            "SELECT giveaway_id FROM giveaway WHERE ended = 0 AND endtime < NOW() AND started = 1 AND messageId <> 'pending'"
+        ):
+            giveaway_ids.append(row[0])
+        return giveaway_ids
+
+    # ------------------------------------------------------------------ #
+    # Channel & role requirements
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def get_channel_requirements(
+        giveaway_id: int,
+    ) -> list[GiveawayChannelRequirementModel]:
+        """Get channel-specific message requirements for a giveaway."""
+        query = "SELECT channel_id, amount FROM giveaway_channelRequirement WHERE giveaway_id = %s"
+        params = (giveaway_id,)
+        rows: list[GiveawayChannelRequirementModel] = []
+        async for row in GiveawayChannelRequirementModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_role_requirements(giveaway_id: int) -> list[str]:
+        """Get role requirements (role IDs) for a giveaway."""
+        query = "SELECT role_id FROM giveawayRoleRequirement WHERE giveaway_id = %s"
+        params = (giveaway_id,)
+        role_ids: list[str] = []
+        async for row in execute_query_iter(query, params):
+            role_ids.append(row[0])
+        return role_ids
+
+    # ------------------------------------------------------------------ #
+    # Participants
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def get_participants(giveaway_id: int) -> list[str]:
+        """Get all participant user IDs for a giveaway."""
+        query = "SELECT user_id FROM giveawayParticipant WHERE giveaway_id = %s"
+        params = (giveaway_id,)
+        user_ids: list[str] = []
+        async for row in execute_query_iter(query, params):
+            user_ids.append(row[0])
+        return user_ids
+
+    @staticmethod
+    async def add_participant(giveaway_id: int, user_id: str) -> None:
+        """Add a user as a participant to a giveaway."""
+        query = "INSERT INTO giveawayParticipant (user_id, giveaway_id) VALUES (%s, %s)"
+        params = (user_id, giveaway_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def remove_participant(giveaway_id: int, user_id: str) -> None:
+        """Remove a user from a giveaway's participants."""
+        query = "DELETE FROM giveawayParticipant WHERE giveaway_id = %s AND user_id = %s"
+        params = (giveaway_id, user_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def is_participant(giveaway_id: int, user_id: str) -> bool:
+        """Check if a user is a participant in a giveaway."""
+        query = "SELECT * FROM giveawayParticipant WHERE giveaway_id = %s AND user_id = %s"
+        params = (giveaway_id, user_id)
+        result = await safe_execute_query(query, params)
+        return bool(result)
+
+    # ------------------------------------------------------------------ #
+    # Participant tracking (voice, messages)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def get_new_messages(giveaway_id: int, user_id: str) -> int | None:
+        """Get the count of new messages for a user in a giveaway."""
+        query = "SELECT messages FROM giveawayNewMessage WHERE giveaway_id = %s AND user_id = %s"
+        params = (giveaway_id, user_id)
+        result = await execute_query(query, params)
+        return result[0][0] if result else None
+
+    @staticmethod
+    async def get_new_messages_channel(
+        giveaway_id: int, channel_id: str, user_id: str
+    ) -> int | None:
+        """Get the count of new messages in a specific channel for a user in a giveaway."""
+        query = (
+            "SELECT amount FROM giveaway_channelMessages "
+            "WHERE giveaway_id = %s AND channel_id = %s AND user_id = %s"
+        )
+        params = (giveaway_id, channel_id, user_id)
+        result = await safe_execute_query(query, params)
+        return result[0][0] if result else None
+
+    @staticmethod
+    async def get_voice_time(giveaway_id: int, user_id: str) -> int | None:
+        """Get voice minutes accumulated for a user in a giveaway."""
+        query = "SELECT voiceMinutes FROM giveawayVoiceTime WHERE giveaway_id = %s AND user_id = %s"
+        params = (giveaway_id, user_id)
+        result = await safe_execute_query(query, params)
+        return result[0][0] if result else None
+
+    @staticmethod
+    async def add_voice_minutes(user_id: Any, guild_id: Any) -> None:
+        """Increment voice minutes for active giveaways in a guild."""
+        query = """
+            INSERT INTO giveawayVoiceTime (giveaway_id, user_id, voiceMinutes)
+            SELECT giveaway_id, %s, 1 FROM giveaway
+            WHERE guild_id = %s AND voiceRequirement IS NOT NULL
+            ON DUPLICATE KEY UPDATE voiceMinutes = voiceMinutes + 1
+        """
+        await execute_action(query, (user_id, guild_id))
+
+    @staticmethod
+    async def add_new_message(user_id: Any, guild_id: Any) -> None:
+        """Increment message count for active giveaways in a guild."""
+        query = """
+            INSERT INTO giveawayNewMessage (giveaway_id, user_id, messages)
+            SELECT giveaway_id, %s, 1 FROM giveaway
+            WHERE guild_id = %s AND newMessageRequirement IS NOT NULL
+            ON DUPLICATE KEY UPDATE messages = messages + 1
+        """
+        await execute_action(query, (user_id, guild_id))
+
+    @staticmethod
+    async def add_new_message_channel(
+        user_id: Any, guild_id: Any, channel_id: Any
+    ) -> None:
+        """Increment per-channel message count for active giveaways in a guild."""
+        query = """
+            INSERT INTO giveaway_channelMessages (giveaway_id, channel_id, user_id, amount)
+            SELECT giveaway_id, %s, %s, 1 FROM giveaway
+            WHERE guild_id = %s AND newMessageRequirement IS NOT NULL
+            ON DUPLICATE KEY UPDATE amount = amount + 1
+        """
+        await execute_action(query, (channel_id, user_id, guild_id))
+
+    # ------------------------------------------------------------------ #
+    # Blacklist
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def add_blacklisted_user(guild_id: str, user_id: str) -> None:
+        """Add a user to the giveaway blacklist."""
+        query = "INSERT INTO giveawayBlacklistedUser (guild_id, user_id) VALUES (%s, %s)"
+        params = (guild_id, user_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def add_blacklisted_role(guild_id: str, role_id: str) -> None:
+        """Add a role to the giveaway blacklist."""
+        query = "INSERT INTO giveawayBlacklistedRole (guild_id, role_id) VALUES (%s, %s)"
+        params = (guild_id, role_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def remove_blacklisted_user(guild_id: str, user_id: str) -> None:
+        """Remove a user from the giveaway blacklist."""
+        query = "DELETE FROM giveawayBlacklistedUser WHERE guild_id = %s AND user_id = %s"
+        params = (guild_id, user_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def remove_blacklisted_role(guild_id: str, role_id: str) -> None:
+        """Remove a role from the giveaway blacklist."""
+        query = "DELETE FROM giveawayBlacklistedRole WHERE guild_id = %s AND role_id = %s"
+        params = (guild_id, role_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def get_blacklisted_users(guild_id: str) -> list[GiveawayBlacklistEntryModel]:
+        """Get all blacklisted users for a guild."""
+        query = "SELECT user_id, reason FROM giveawayBlacklistedUser WHERE guild_id = %s"
+        params = (guild_id,)
+        rows: list[GiveawayBlacklistEntryModel] = []
+        async for row in GiveawayBlacklistEntryModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_blacklisted_roles(guild_id: str) -> list[GiveawayBlacklistEntryModel]:
+        """Get all blacklisted roles for a guild."""
+        query = "SELECT role_id, reason FROM giveawayBlacklistedRole WHERE guild_id = %s"
+        params = (guild_id,)
+        rows: list[GiveawayBlacklistEntryModel] = []
+        async for row in GiveawayBlacklistEntryModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def is_user_blacklisted(guild_id: str, user_id: str) -> bool:
+        """Check if a user is blacklisted from giveaways."""
+        query = "SELECT * FROM giveawayBlacklistedUser WHERE guild_id = %s AND user_id = %s"
+        params = (guild_id, user_id)
+        result = await execute_query(query, params)
+        return bool(result and len(result) > 0)
+
+
+# Module-level convenience instance
+giveaway_service = GiveawayService()

--- a/services/giveaway_service.py
+++ b/services/giveaway_service.py
@@ -9,7 +9,6 @@ single GiveawayService class with Pydantic-validated parameter models.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -21,7 +20,6 @@ from api import (
     transaction,
 )
 from models import GiveawayBlacklistEntryModel, GiveawayChannelRequirementModel, GiveawayModel
-
 
 # ------------------------------------------------------------------ #
 # Pydantic models
@@ -96,7 +94,7 @@ class GiveawayService:
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         """
-        params = (
+        sql_params = (
             params.guild_id,
             params.title,
             params.description,
@@ -115,7 +113,7 @@ class GiveawayService:
         )
         try:
             async with transaction() as conn, conn.cursor() as cursor:
-                await cursor.execute(query, params)
+                await cursor.execute(query, sql_params)
                 await cursor.execute("SELECT LAST_INSERT_ID()")
                 last_id = await cursor.fetchone()
                 giveaway_id = last_id[0] if last_id else None
@@ -224,6 +222,7 @@ class GiveawayService:
                     )
         except Exception as e:
             print(f"Error during giveaway update for {giveaway_id}: {e}")
+            raise
 
     @staticmethod
     async def delete(giveaway_id: int) -> None:
@@ -284,7 +283,7 @@ class GiveawayService:
     # ------------------------------------------------------------------ #
 
     @staticmethod
-    async def set_message_id(giveaway_id: int, message_id: int) -> None:
+    async def set_message_id(giveaway_id: int, message_id: int | str) -> None:
         """Set the Discord message ID for a giveaway."""
         query = "UPDATE giveaway SET messageId = %s WHERE giveaway_id = %s"
         params = (message_id, giveaway_id)
@@ -295,6 +294,13 @@ class GiveawayService:
         """Mark a giveaway as started."""
         query = "UPDATE giveaway SET started = 1 WHERE giveaway_id = %s"
         params = (giveaway_id,)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def mark_sent(giveaway_id: int, message_id: int) -> None:
+        """Atomically set both message_id and started for a giveaway."""
+        query = "UPDATE giveaway SET messageId = %s, started = 1 WHERE giveaway_id = %s"
+        params = (message_id, giveaway_id)
         await execute_action(query, params)
 
     @staticmethod
@@ -427,7 +433,7 @@ class GiveawayService:
         return result[0][0] if result else None
 
     @staticmethod
-    async def add_voice_minutes(user_id: Any, guild_id: Any) -> None:
+    async def add_voice_minutes(user_id: str, guild_id: str) -> None:
         """Increment voice minutes for active giveaways in a guild."""
         query = """
             INSERT INTO giveawayVoiceTime (giveaway_id, user_id, voiceMinutes)
@@ -438,7 +444,7 @@ class GiveawayService:
         await execute_action(query, (user_id, guild_id))
 
     @staticmethod
-    async def add_new_message(user_id: Any, guild_id: Any) -> None:
+    async def add_new_message(user_id: str, guild_id: str) -> None:
         """Increment message count for active giveaways in a guild."""
         query = """
             INSERT INTO giveawayNewMessage (giveaway_id, user_id, messages)
@@ -450,7 +456,7 @@ class GiveawayService:
 
     @staticmethod
     async def add_new_message_channel(
-        user_id: Any, guild_id: Any, channel_id: Any
+        user_id: str, guild_id: str, channel_id: str
     ) -> None:
         """Increment per-channel message count for active giveaways in a guild."""
         query = """

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -47,7 +47,6 @@ class ScheduledMessageService:
     @staticmethod
     async def schedule(params: ScheduleMessageParams) -> None:
         """Schedule a new message to be sent at the given time."""
-        import json
 
         from api import execute_action
 

--- a/utility.py
+++ b/utility.py
@@ -1,5 +1,5 @@
-import asyncio
 import ast
+import asyncio
 import bisect
 import collections
 import concurrent.futures


### PR DESCRIPTION
## Summary

Closes #1294

Encapsulates the 50+ free-floating giveaway functions in `api.py` into a single `GiveawayService` class in `services/giveaway_service.py` with Pydantic-validated parameter models.

## Changes

### New file: `services/giveaway_service.py`
- **`GiveawayCreateParams`** — Pydantic model with field validation for creating giveaways
- **`GiveawayUpdateParams`** — Pydantic model with field validation for updating giveaways
- **`GiveawayService`** class with organized static methods:
  - Giveaway CRUD: `create()`, `get()`, `update()`, `delete()`, `delete_old()`
  - State management: `set_message_id()`, `set_started()`, `set_ended()`, `set_endtime()`, `get_send_ready()`, `get_end_ready()`
  - Requirements: `get_channel_requirements()`, `get_role_requirements()`
  - Participants: `get_participants()`, `add_participant()`, `remove_participant()`, `is_participant()`
  - Tracking: `get_new_messages()`, `get_new_messages_channel()`, `get_voice_time()`, `add_voice_minutes()`, `add_new_message()`, `add_new_message_channel()`
  - Blacklist: `add/remove/get_blacklisted_user/role()`, `is_user_blacklisted()`
- Module-level `giveaway_service` convenience instance

### Updated: `api.py`
All giveaway functions now delegate to `GiveawayService` for backward compatibility.

### Updated callers
All 10+ files in `commands/giveaway/` and `loops/giveaway.py` now import directly from `services.giveaway_service`.

## Benefits
- Pydantic validation on all giveaway parameters (`winners > 0`, `title length`, etc.)
- All giveaway logic in one cohesive service class
- Cleaner, testable code
- Consistent pattern matching existing services (ReportService, AiService, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated giveaway persistence and state logic into a centralized service layer, unifying handling of creation, updates, sending, ending, participants, and blacklist management.
  * Giveaway commands and background loops now use the centralized service; user-facing commands, permissions, and embed/response flows remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->