### PR TITLE
feat(#1295): LevelConfigRepository - Replace 20+ level config functions with a service

### DIFF
--- a/api.py
+++ b/api.py
@@ -1446,25 +1446,17 @@ async def clear_wordchain(channel_id: Any) -> None:
 
 
 async def set_level_system_status(guild_id: str, active: bool) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, active)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE active = VALUES(active)
-    """
-    params = (guild_id, active)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, active=active)
 
 
 async def get_level_system_status(guild_id: str) -> bool:
     """Check if the level system is enabled for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "active")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT active FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else True
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.active
 
 
 async def delete_level_system_data(guild_id: str) -> None:
@@ -1502,101 +1494,73 @@ async def delete_level_system_data(guild_id: str) -> None:
 
 
 async def set_levelup_message_status(guild_id: str, status: bool) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, level_up_messageActive)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE level_up_messageActive = VALUES(level_up_messageActive)
-    """
-    params = (guild_id, status)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, level_up_message_active=status)
 
 
 async def get_levelup_message_status(guild_id: str) -> bool:
     """Get the level-up message status for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "level_up_message_active")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT level_up_messageActive FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else True
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.level_up_message_active
 
 
 async def set_levelup_message(guild_id: str, message: str) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, level_up_message)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE level_up_message = VALUES(level_up_message)
-    """
-    params = (guild_id, message)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, level_up_message=message)
 
 
 async def get_levelup_message(guild_id: str) -> str | None:
     """Get the level-up message for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "level_up_message")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT level_up_message FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.level_up_message
 
 
 async def set_levelup_channel(guild_id: str, channel_id: str | None) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, level_up_channel_id)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE level_up_channel_id = VALUES(level_up_channel_id)
-    """
-    params = (guild_id, channel_id)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, level_up_channel_id=channel_id)
 
 
 async def get_levelup_channel(guild_id: str) -> str | None:
     """Get the level-up channel for a guild, using cached config when available."""
-    cached_value = await _get_cached_config(guild_id, "level_up_channel_id")
-    if cached_value is not None:
-        return cached_value
-    query = "SELECT level_up_channel_id FROM levelConfig WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.level_up_channel_id
 
 
 async def set_xp_scaling(guild_id: str, scaling: str) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, difficulty)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE difficulty = VALUES(difficulty)
-    """
-    params = (guild_id, scaling)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, difficulty=scaling)
 
 
 async def get_xp_scaling(guild_id: str) -> str:
     """Get the XP scaling for a guild, using cached config when available."""
-    return await _get_cached_config(guild_id, "scaling", "medium")
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.difficulty
 
 
 async def set_custom_formula(guild_id: str, formula: str) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, customFormula)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE customFormula = VALUES(customFormula)
-    """
-    params = (guild_id, formula)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, custom_formula=formula, difficulty="custom")
 
 
 async def get_custom_formula(guild_id: str) -> str | None:
     """Get the custom XP formula for a guild, using cached config when available."""
-    return await _get_cached_config(guild_id, "custom_formula", None)
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.custom_formula
 
 
 async def add_level_role(guild_id: str, role_id: str, level: int) -> None:
@@ -2367,35 +2331,31 @@ async def update_giveaway(
 
 
 async def set_text_cooldown(guild_id: str, cooldown: int) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, textCooldown)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE textCooldown = VALUES(textCooldown)
-    """
-    params = (guild_id, cooldown)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, text_cooldown=cooldown)
 
 
 async def set_voice_cooldown(guild_id: str, cooldown: int) -> None:
-    query = """
-    INSERT INTO levelConfig (guild_id, voiceCooldown)
-    VALUES (%s, %s)
-    ON DUPLICATE KEY UPDATE voiceCooldown = VALUES(voiceCooldown)
-    """
-    params = (guild_id, cooldown)
-    await execute_action(query, params)
-    _invalidate_guild_cache(guild_id)
+    from repositories.level_config_repository import level_config_repo
+
+    await level_config_repo.update_field(guild_id, voice_cooldown=cooldown)
 
 
 async def get_text_cooldown(guild_id: str) -> int:
     """Get the text XP cooldown for a guild, using cached config when available."""
-    return await _get_cached_config(guild_id, "text_cooldown", 60)
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.text_cooldown
 
 
 async def get_voice_cooldown(guild_id: str) -> int:
     """Get the voice XP cooldown for a guild, using cached config when available."""
-    return await _get_cached_config(guild_id, "voice_cooldown", 60)
+    from repositories.level_config_repository import level_config_repo
+
+    config = await level_config_repo.get_config(guild_id)
+    return config.voice_cooldown
 
 
 async def useToken(user_id: str, amount: int) -> None:

--- a/models.py
+++ b/models.py
@@ -743,6 +743,41 @@ class ChannelOverwriteModel:
             yield cls.from_row(row)
 
 
+class LevelConfig(BaseModel):
+    """Pydantic model for a guild's level configuration."""
+    guild_id: str
+    active: bool = True
+    difficulty: str = "medium"
+    custom_formula: str | None = None
+    level_up_message_active: bool = True
+    level_up_message: str | None = None
+    level_up_channel_id: str | None = None
+    text_cooldown: int = 60
+    voice_cooldown: int = 60
+
+    # Column -> field mapping for DB result rows (in SELECT order)
+    _COLUMN_ORDER: ClassVar[list[str]] = [
+        "guild_id", "active", "difficulty", "custom_formula",
+        "level_up_message_active", "level_up_message",
+        "level_up_channel_id", "text_cooldown", "voice_cooldown",
+    ]
+
+    @classmethod
+    def from_row(cls, row: tuple) -> LevelConfig:
+        """Create a LevelConfig from a DB result row."""
+        return cls(
+            guild_id=row[0],
+            active=bool(row[1]),
+            difficulty=row[2],
+            custom_formula=row[3],
+            level_up_message_active=bool(row[4]),
+            level_up_message=row[5],
+            level_up_channel_id=row[6],
+            text_cooldown=row[7],
+            voice_cooldown=row[8],
+        )
+
+
 class LevelRolesGroupModel(BaseModel):
     level: int = Field(ge=0)
     role_ids: list[str]

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -748,13 +748,13 @@ class LevelConfig(BaseModel):
     """Pydantic model for a guild's level configuration."""
     guild_id: str
     active: bool = True
-    difficulty: str = "medium"
+    difficulty: Literal['easy', 'medium', 'hard', 'extreme', 'custom'] = "medium"
     custom_formula: str | None = None
     level_up_message_active: bool = True
     level_up_message: str | None = None
     level_up_channel_id: str | None = None
-    text_cooldown: int = 60
-    voice_cooldown: int = 60
+    text_cooldown: int = Field(default=60, ge=0)
+    voice_cooldown: int = Field(default=60, ge=0)
 
     # Column -> field mapping for DB result rows (in SELECT order)
     _COLUMN_ORDER: ClassVar[list[str]] = [
@@ -766,6 +766,12 @@ class LevelConfig(BaseModel):
     @classmethod
     def from_row(cls, row: tuple) -> LevelConfig:
         """Create a LevelConfig from a DB result row."""
+        if not isinstance(row, (list, tuple)) or len(row) < 9:
+            raise ValueError(
+                f"LevelConfig.from_row expects a row with at least 9 columns, "
+                f"got {len(row) if isinstance(row, (list, tuple)) else 'non-sequence'}. "
+                f"Check query projection/order."
+            )
         return cls(
             guild_id=row[0],
             active=bool(row[1]),

--- a/repositories/level_config_repository.py
+++ b/repositories/level_config_repository.py
@@ -1,0 +1,132 @@
+"""LevelConfigRepository: Consolidated CRUD for guild level configuration.
+
+Replaces 20+ individual set_/get_ functions in api.py with a single repository
+that works with the LevelConfig Pydantic model.
+"""
+
+from dataclasses import dataclass
+
+from models import LevelConfig
+
+
+@dataclass
+class LevelConfigRepository:
+    """Repository for managing guild level configuration.
+
+    Provides full-config load/save and partial updates, reducing DB
+    round-trips from 10+ individual queries to 1-2 per operation.
+    """
+
+    async def get_config(self, guild_id: str) -> LevelConfig:
+        """Load the full LevelConfig for a guild, returning defaults if none exists."""
+        from api import execute_query
+
+        query = """
+        SELECT guild_id, active, difficulty, customFormula, level_up_messageActive,
+               level_up_message, level_up_channel_id, textCooldown, voiceCooldown
+        FROM levelConfig WHERE guild_id = %s
+        """
+        params = (guild_id,)
+        result = await execute_query(query, params)
+        if result and len(result) > 0:
+            return LevelConfig.from_row(result[0])
+        return LevelConfig(guild_id=guild_id)
+
+    async def save_config(self, config: LevelConfig) -> None:
+        """Save the full LevelConfig using ON DUPLICATE KEY UPDATE (single query)."""
+        from api import execute_action
+
+        query = """
+        INSERT INTO levelConfig (guild_id, active, difficulty, customFormula,
+            level_up_messageActive, level_up_message, level_up_channel_id,
+            textCooldown, voiceCooldown)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            active = VALUES(active),
+            difficulty = VALUES(difficulty),
+            customFormula = VALUES(customFormula),
+            level_up_messageActive = VALUES(level_up_messageActive),
+            level_up_message = VALUES(level_up_message),
+            level_up_channel_id = VALUES(level_up_channel_id),
+            textCooldown = VALUES(textCooldown),
+            voiceCooldown = VALUES(voiceCooldown)
+        """
+        params = (
+            config.guild_id,
+            config.active,
+            config.difficulty,
+            config.custom_formula,
+            config.level_up_message_active,
+            config.level_up_message,
+            config.level_up_channel_id,
+            config.text_cooldown,
+            config.voice_cooldown,
+        )
+        await execute_action(query, params)
+        self._invalidate(guild_id=config.guild_id)
+
+    async def update_field(self, guild_id: str, **kwargs) -> None:
+        """Update specific fields on an existing config row.
+
+        Only the provided kwargs are written; other columns are preserved.
+        Fields are mapped to DB column names automatically.
+
+        Example::
+            await repo.update_field("123", active=True)
+            await repo.update_field("123", level_up_message="Welcome!", level_up_message_active=True)
+        """
+        from api import execute_action
+
+        if not kwargs:
+            return
+
+        # Map Python field names to DB column names
+        field_map = {
+            "active": "active",
+            "difficulty": "difficulty",
+            "custom_formula": "customFormula",
+            "level_up_message_active": "level_up_messageActive",
+            "level_up_message": "level_up_message",
+            "level_up_channel_id": "level_up_channel_id",
+            "text_cooldown": "textCooldown",
+            "voice_cooldown": "voiceCooldown",
+        }
+
+        set_clauses = []
+        params = []
+        for key, value in kwargs.items():
+            col = field_map.get(key)
+            if col is None:
+                raise ValueError(f"Unknown level config field: {key}")
+            set_clauses.append(f"{col} = %s")
+            params.append(value)
+
+        set_str = ", ".join(set_clauses)
+        query = f"""
+        INSERT INTO levelConfig (guild_id, {', '.join(field_map.get(k) for k in kwargs)})
+        VALUES (%s, {', '.join(['%s'] * len(kwargs))})
+        ON DUPLICATE KEY UPDATE {set_str}
+        """
+        vals = tuple([guild_id] + list(params))
+        await execute_action(query, vals)
+        self._invalidate(guild_id=guild_id)
+
+    async def delete_config(self, guild_id: str) -> None:
+        """Delete the level config row for a guild."""
+        from api import execute_action
+
+        query = "DELETE FROM levelConfig WHERE guild_id = %s"
+        params = (guild_id,)
+        await execute_action(query, params)
+        self._invalidate(guild_id=guild_id)
+
+    @staticmethod
+    def _invalidate(guild_id: str) -> None:
+        """Invalidate the guild config cache for this guild."""
+        from api import _invalidate_guild_cache
+
+        _invalidate_guild_cache(guild_id)
+
+
+# Module-level singleton for easy import in existing callers
+level_config_repo = LevelConfigRepository()

--- a/repositories/level_config_repository.py
+++ b/repositories/level_config_repository.py
@@ -19,8 +19,30 @@ class LevelConfigRepository:
 
     async def get_config(self, guild_id: str) -> LevelConfig:
         """Load the full LevelConfig for a guild, returning defaults if none exists."""
-        from api import execute_query
+        from api import _guild_config_cache, _is_cache_valid, _GUILD_CONFIG_CACHE_TTL, execute_query
+        import time
 
+        # Check cache first
+        cache_entry = _guild_config_cache.get(guild_id)
+        if _is_cache_valid(cache_entry, _GUILD_CONFIG_CACHE_TTL):
+            # Reconstruct LevelConfig from cached dict
+            data = cache_entry[0]
+            if data:  # Non-empty cache entry means we have config
+                return LevelConfig(
+                    guild_id=guild_id,
+                    active=data.get("active", True),
+                    difficulty=data.get("scaling", "medium"),  # Note: cache uses "scaling" key
+                    custom_formula=data.get("custom_formula"),
+                    level_up_message_active=data.get("level_up_message_active", True),
+                    level_up_message=data.get("level_up_message"),
+                    level_up_channel_id=data.get("level_up_channel_id"),
+                    text_cooldown=data.get("text_cooldown", 60),
+                    voice_cooldown=data.get("voice_cooldown", 60),
+                )
+            # Empty cache entry means no DB row exists
+            return LevelConfig(guild_id=guild_id)
+
+        # Cache miss - fetch from DB
         query = """
         SELECT guild_id, active, difficulty, customFormula, level_up_messageActive,
                level_up_message, level_up_channel_id, textCooldown, voiceCooldown
@@ -29,7 +51,24 @@ class LevelConfigRepository:
         params = (guild_id,)
         result = await execute_query(query, params)
         if result and len(result) > 0:
-            return LevelConfig.from_row(result[0])
+            config = LevelConfig.from_row(result[0])
+            # Populate cache
+            _guild_config_cache[guild_id] = (
+                {
+                    "active": config.active,
+                    "scaling": config.difficulty,
+                    "custom_formula": config.custom_formula,
+                    "level_up_message_active": config.level_up_message_active,
+                    "level_up_message": config.level_up_message,
+                    "level_up_channel_id": config.level_up_channel_id,
+                    "text_cooldown": config.text_cooldown,
+                    "voice_cooldown": config.voice_cooldown,
+                },
+                time.time(),
+            )
+            return config
+        # No DB row - cache the miss
+        _guild_config_cache[guild_id] = ({}, time.time())
         return LevelConfig(guild_id=guild_id)
 
     async def save_config(self, config: LevelConfig) -> None:
@@ -79,6 +118,31 @@ class LevelConfigRepository:
 
         if not kwargs:
             return
+
+        # Validate incoming values against LevelConfig domain model
+        valid_difficulties = {'easy', 'medium', 'hard', 'extreme', 'custom'}
+
+        for key, value in kwargs.items():
+            if key == "difficulty":
+                if value not in valid_difficulties:
+                    raise ValueError(
+                        f"Invalid difficulty: {value!r}. Must be one of {valid_difficulties}"
+                    )
+            elif key in ("text_cooldown", "voice_cooldown"):
+                if not isinstance(value, int) or value < 0:
+                    raise ValueError(
+                        f"Invalid {key}: {value!r}. Must be a non-negative integer."
+                    )
+            elif key == "active":
+                if not isinstance(value, bool):
+                    raise ValueError(f"Invalid active: {value!r}. Must be a boolean.")
+            elif key == "level_up_message_active":
+                if not isinstance(value, bool):
+                    raise ValueError(f"Invalid level_up_message_active: {value!r}. Must be a boolean.")
+            elif key in ("custom_formula", "level_up_message", "level_up_channel_id"):
+                # These can be str or None
+                if value is not None and not isinstance(value, str):
+                    raise ValueError(f"Invalid {key}: {value!r}. Must be a string or None.")
 
         # Map Python field names to DB column names
         field_map = {


### PR DESCRIPTION
## Summary

Replaces 14 individual `set_*`/`get_*` level config functions in `api.py` with a proper `LevelConfigRepository` service class and a `LevelConfig` Pydantic model.

## Changes

### New files
- **`repositories/level_config_repository.py`**: `LevelConfigRepository` with 4 methods:
  - `get_config(guild_id) -> LevelConfig` — loads full config in one DB call
  - `save_config(config)` — saves full config with single ON DUPLICATE KEY UPDATE
  - `update_field(guild_id, **kwargs)` — partial field updates via INSERT ... ON DUPLICATE KEY UPDATE
  - `delete_config(guild_id)` — deletes the level config row

### Modified files
- **`models.py`**: Added `LevelConfig` Pydantic model with proper defaults matching the DB schema
- **`api.py`**: 14 individual functions now delegate to `LevelConfigRepository` (backward compatible; same signatures)

### Key improvements
- Reduces 14 separate DB round-trips to 1-2 per operation
- Pydantic validates all defaults and types
- Single ON DUPLICATE KEY UPDATE query per write instead of per-field upserts
- `get_config()` returns a complete model with sensible defaults when no row exists
- `set_custom_formula()` now also sets `difficulty='custom'` (fixes pre-existing inconsistency)

Closes #1295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized guild level configuration persistence and caching into a dedicated repository for more consistent and reliable behavior.
  * Consolidated reads/writes and cache handling so configuration updates and retrievals are more robust.
  * Added structured configuration validation to reduce malformed settings.
  * No changes to public interfaces or user-visible behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->