### PR TITLE
feat(#1332): Add StatusIcon enum, EMOJI_MAP, and get_icon_emoji helper

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -78,14 +78,13 @@ class StatusIcon(enum.StrEnum):
     DISABLED = "❌"
 
 
-# Map of meaningful names to custom guild emoji IDs (from issue #1248).
-# Replace the placeholder IDs below with the actual emoji IDs from your
-# Discord server once they are created.
+# Map of friendly keys to guild emoji names (from issue #1332).
+# Maps friendly keys to the actual guild emoji names used in the Discord server.
 EMOJI_MAP: dict[str, str] = {
-    "checkmark": "<:check:PLACEHOLDER_ID>",
-    "cross": "<:cross:PLACEHOLDER_ID>",
-    "loading": "<a:loading:PLACEHOLDER_ID>",
-    "info": "<:info:PLACEHOLDER_ID>",
+    "checkmark": "check",
+    "cross": "cross",
+    "loading": "loading",
+    "info": "info",
 }
 
 
@@ -95,8 +94,10 @@ async def get_icon_emoji(
     *,
     fallback: str | None = None,
 ) -> str:
-    """Get a Discord guild emoji by name, falling back to a Unicode icon.
+    """Get a Discord guild emoji by friendly key, falling back to a Unicode icon.
 
+    Looks up the friendly key in ``EMOJI_MAP`` to find the actual guild emoji name.
+    If the key is not in the map, uses the key directly as the emoji name.
     If the guild emoji is not found (or the bot object is unavailable),
     ``fallback`` is returned; if ``fallback`` is ``None``, ``StatusIcon.INFO``
     is used as the ultimate default.
@@ -106,7 +107,7 @@ async def get_icon_emoji(
     bot:
         The bot client (used to look up ``bot.emojis``).
     emoji_name:
-        The name of the guild emoji to look up (e.g. ``"checkmark"``).
+        The friendly key to look up (e.g. ``"checkmark"``), or a direct emoji name.
     fallback:
         Unicode fallback when the guild emoji isn't available.
         ``None`` means ``StatusIcon.INFO.value``.
@@ -117,7 +118,10 @@ async def get_icon_emoji(
         A string safe for use in embed titles, field values, or
         message content.
     """
-    if emoji := discord.utils.get(bot.emojis, name=emoji_name):
+    # Look up the emoji name from the map, falling back to using the key directly
+    actual_emoji_name = EMOJI_MAP.get(emoji_name, emoji_name)
+
+    if emoji := discord.utils.get(bot.emojis, name=actual_emoji_name):
         return str(emoji)
     if fallback is not None:
         return fallback

--- a/utility.py
+++ b/utility.py
@@ -58,6 +58,72 @@ class EmbedColor(enum.IntEnum):
     TIMEOUT = 0x95A5A6  # Gray: disabled/timeout
 
 
+class StatusIcon(enum.StrEnum):
+    """Standardized status icons used across all embeds and messages.
+
+    Use these instead of hardcoded Unicode emojis to keep icon usage
+    consistent.  All values are Unicode fallbacks that render in any
+    Discord client without needing Nitro or a guild emoji slot.
+    """
+
+    SUCCESS = "✅"
+    ERROR = "❌"
+    WARNING = "⚠️"
+    INFO = "ℹ️"
+    LOCK = "🔒"
+    PENDING = "⏳"
+    DENIED = "🚫"
+    CROSS = "❌"
+    ENABLED = "✅"
+    DISABLED = "❌"
+
+
+# Map of meaningful names to custom guild emoji IDs (from issue #1248).
+# Replace the placeholder IDs below with the actual emoji IDs from your
+# Discord server once they are created.
+EMOJI_MAP: dict[str, str] = {
+    "checkmark": "<:check:PLACEHOLDER_ID>",
+    "cross": "<:cross:PLACEHOLDER_ID>",
+    "loading": "<a:loading:PLACEHOLDER_ID>",
+    "info": "<:info:PLACEHOLDER_ID>",
+}
+
+
+async def get_icon_emoji(
+    bot: discord.Client | discord.ext.commands.Bot,
+    emoji_name: str,
+    *,
+    fallback: str | None = None,
+) -> str:
+    """Get a Discord guild emoji by name, falling back to a Unicode icon.
+
+    If the guild emoji is not found (or the bot object is unavailable),
+    ``fallback`` is returned; if ``fallback`` is ``None``, ``StatusIcon.INFO``
+    is used as the ultimate default.
+
+    Parameters
+    ----------
+    bot:
+        The bot client (used to look up ``bot.emojis``).
+    emoji_name:
+        The name of the guild emoji to look up (e.g. ``"checkmark"``).
+    fallback:
+        Unicode fallback when the guild emoji isn't available.
+        ``None`` means ``StatusIcon.INFO.value``.
+
+    Returns
+    -------
+    str:
+        A string safe for use in embed titles, field values, or
+        message content.
+    """
+    if emoji := discord.utils.get(bot.emojis, name=emoji_name):
+        return str(emoji)
+    if fallback is not None:
+        return fallback
+    return StatusIcon.INFO.value
+
+
 class EmbedProxy:
     def __init__(self, layer: dict[str, Any]):
         self.__dict__.update(layer)


### PR DESCRIPTION
## Summary

Adds standardized status icon strings and a guild emoji lookup helper to `utility.py` so that all embeds across the codebase can use consistent icons instead of scattered hardcoded Unicode emojis and emoji IDs.

## Changes

### `utility.py`
- **`StatusIcon(StrEnum)`** — standardized status icons (SUCCESS ✅, ERROR ❌, WARNING ⚠️, INFO ℹ️, LOCK 🔒, PENDING ⏳, DENIED 🚫, CROSS ❌, ENABLED ✅, DISABLED ❌). Unicode fallbacks that render in any Discord client.
- **`EMOJI_MAP`** — dict mapping meaningful names to custom guild emoji IDs (stub placeholders for now, to be filled with actual IDs once created).
- **`get_icon_emoji()`** — async helper that looks up a guild emoji by name via `discord.utils.get(bot.emojis, ...)`, falling back to a provided Unicode string or `StatusIcon.INFO`.

## Remaining Work (follow-up PRs)

- Migration of existing hardcoded emoji usage in `commands/`, `extensions/`, and `minigames/` to use `StatusIcon` — scoped as a separate PR to keep this one focused.

Closes #1332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved status indicator emojis with support for custom guild emojis and automatic fallback to Unicode symbols for compatibility across environments.
  * Friendly emoji names are now resolved to guild emojis when available, otherwise fall back to a configurable symbol.
  * Added standardized status icons covering success, error, warning, info, lock, pending, denied, enabled, and disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->