### PR TITLE
TriggerMessageService: Encapsulate trigger message CRUD and matching logic

### DIFF
--- a/commands/admin/trigger_messages/add.py
+++ b/commands/admin/trigger_messages/add.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from api import add_trigger_message as add_trigger_message_api
 from localizer import tanjunLocalizer
+from services.trigger_message_service import trigger_message_service
 
 
 async def add_trigger_message(
@@ -30,7 +30,9 @@ async def add_trigger_message(
         return
 
     assert command_info.guild is not None
-    await add_trigger_message_api(command_info.guild.id, trigger, response, case_sensitive)
+    await trigger_message_service.create(
+        command_info.guild.id, trigger, response, case_sensitive
+    )
 
     embed = utility.tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.trigger_messages.add.success.title"),

--- a/commands/admin/trigger_messages/configure.py
+++ b/commands/admin/trigger_messages/configure.py
@@ -3,15 +3,8 @@ from typing import Any
 import discord
 
 import utility
-from api import (
-    add_trigger_message,
-    add_trigger_message_channel,
-    get_trigger_message_channels,
-    get_trigger_messages,
-    remove_trigger_message,
-    remove_trigger_message_channel,
-)
 from localizer import tanjunLocalizer
+from services.trigger_message_service import trigger_message_service
 
 
 async def configure_trigger_messages(  # type: ignore[no-untyped-def]
@@ -36,7 +29,7 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
         return
 
     assert command_info.guild is not None
-    trigger_messages = await get_trigger_messages(command_info.guild.id)
+    trigger_messages = await trigger_message_service.get_all(command_info.guild.id)
 
     if trigger_messages is None or len(trigger_messages) == 0:
         embed = utility.tanjunEmbed(
@@ -52,7 +45,7 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
         await command_info.reply(embed=embed)
         return
 
-    channels = await get_trigger_message_channels(command_info.guild.id, trigger_messages[0].id)
+    channels = await trigger_message_service.get_trigger_channels(command_info.guild.id, trigger_messages[0].id)
     page = 0
     selected_channel = 0
 
@@ -175,11 +168,11 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
             trigger = self.children[0].value.strip()  # type: ignore[attr-defined]
             response = self.children[1].value.strip()  # type: ignore[attr-defined]
             case_sensitive = self.children[2].value == "y"  # type: ignore[attr-defined]
-            await add_trigger_message(command_info.guild.id, trigger, response, case_sensitive)  # type: ignore[union-attr]
+            await trigger_message_service.create(command_info.guild.id, trigger, response, case_sensitive)  # type: ignore[union-attr]
             nonlocal trigger_messages
-            trigger_messages = await get_trigger_messages(command_info.guild.id)  # type: ignore[union-attr]
+            trigger_messages = await trigger_message_service.get_all(command_info.guild.id)  # type: ignore[union-attr]
             nonlocal channels
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[0].id,
             )
@@ -208,13 +201,13 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
 
             data = cast(Any, interaction.data)
             nonlocal channels
-            await add_trigger_message_channel(
+            await trigger_message_service.add_channel(
                 command_info.guild.id,  # type: ignore[union-attr]
                 data["values"][0] if data is not None else "",
                 trigger_messages[page].id,
             )
             nonlocal channels
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[page].id,
             )
@@ -241,7 +234,7 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
             if page < 0:
                 page = len(trigger_messages) - 1  # type: ignore[arg-type]
             nonlocal channels
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[page].id,
             )
@@ -259,13 +252,13 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
         )
         async def remove(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
             nonlocal trigger_messages
-            await remove_trigger_message(
+            await trigger_message_service.delete(
                 command_info.guild.id,
                 trigger_messages[page].id,
             )
-            trigger_messages = await get_trigger_messages(command_info.guild.id)  # type: ignore[union-attr]
+            trigger_messages = await trigger_message_service.get_all(command_info.guild.id)  # type: ignore[union-attr]
             nonlocal channels
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[0].id,
             )
@@ -298,7 +291,7 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
             if page >= len(trigger_messages):  # type: ignore[arg-type]
                 page = 0
             nonlocal channels
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[page].id,
             )
@@ -356,12 +349,12 @@ async def configure_trigger_messages(  # type: ignore[no-untyped-def]
         )
         async def remove_channel(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
             nonlocal channels
-            await remove_trigger_message_channel(
+            await trigger_message_service.remove_channel(
                 command_info.guild.id,  # type: ignore[union-attr]
                 channels[selected_channel].channel_id,
                 trigger_messages[page].id,
             )
-            channels = await get_trigger_message_channels(
+            channels = await trigger_message_service.get_trigger_channels(
                 command_info.guild.id,
                 trigger_messages[page].id,
             )

--- a/commands/admin/trigger_messages/send.py
+++ b/commands/admin/trigger_messages/send.py
@@ -1,6 +1,7 @@
 import discord
 
-from api import check_if_opted_out, is_trigger_message
+from api import check_if_opted_out
+from services.trigger_message_service import trigger_message_service
 
 
 async def send_trigger_message(message: discord.Message) -> None:
@@ -13,7 +14,9 @@ async def send_trigger_message(message: discord.Message) -> None:
     if not message.content:
         return
 
-    trigger_message = await is_trigger_message(message.guild.id, message.content, message.channel.id)
+    trigger_message = await trigger_message_service.match(
+        message.guild.id, message.content, message.channel.id
+    )
     if not trigger_message:
         return
 

--- a/services/trigger_message_service.py
+++ b/services/trigger_message_service.py
@@ -1,0 +1,168 @@
+"""
+TriggerMessageService: Encapsulate trigger message CRUD and matching logic.
+
+Consolidates the loose trigger message functions from api.py (get_trigger_messages,
+add_trigger_message, remove_trigger_message, get_trigger_message_channels,
+get_trigger_messages_by_channel, add_trigger_message_channel,
+remove_trigger_message_channel, is_trigger_message) plus matching logic from
+commands/admin/trigger_messages/send.py into a single service class with
+Pydantic-validated parameter models.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+from typing import Annotated
+
+from api import execute_action, execute_query, execute_query_iter
+from models import TriggerMessageModel, TriggerMessageChannelModel
+
+# ------------------------------------------------------------------ #
+# Pydantic models
+# ------------------------------------------------------------------ #
+
+
+class TriggerMessageCreateParams(BaseModel):
+    """Validated parameters for creating a new trigger message."""
+
+    guild_id: str
+    trigger: Annotated[str, Field(min_length=1, max_length=100)]
+    response: Annotated[str, Field(min_length=1, max_length=1000)]
+    case_sensitive: bool = False
+
+
+class TriggerMessageChannelAddParams(BaseModel):
+    """Validated parameters for adding a channel restriction to a trigger."""
+
+    guild_id: str
+    channel_id: str
+    trigger_id: int
+
+
+# ------------------------------------------------------------------ #
+# Service class
+# ------------------------------------------------------------------ #
+
+
+class TriggerMessageService:
+    """Service for managing trigger messages, channel restrictions, and matching."""
+
+    # ------------------------------------------------------------------ #
+    # CRUD
+    # ------------------------------------------------------------------ #
+
+    async def create(self, guild_id: str, trigger: str, response: str, case_sensitive: bool = False) -> None:
+        """Create a new trigger message."""
+        query = (
+            "INSERT INTO triggerMessages (guild_id, `trigger`, response, case_sensitive) "
+            "VALUES (%s, %s, %s, %s)"
+        )
+        params = (guild_id, trigger, response, case_sensitive)
+        await execute_action(query, params)
+
+    async def delete(self, guild_id: str, trigger_id: int) -> None:
+        """Delete a trigger message by its ID (not the trigger text)."""
+        query = "DELETE FROM triggerMessages WHERE guild_id = %s AND id = %s"
+        params = (guild_id, trigger_id)
+        await execute_action(query, params)
+
+    async def get_all(self, guild_id: str) -> list[TriggerMessageModel]:
+        """Get all trigger messages for a guild."""
+        query = (
+            "SELECT id, guild_id, `trigger`, response, case_sensitive "
+            "FROM triggerMessages WHERE guild_id = %s"
+        )
+        params = (guild_id,)
+        rows: list[TriggerMessageModel] = []
+        async for row in TriggerMessageModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    # ------------------------------------------------------------------ #
+    # Channel restrictions
+    # ------------------------------------------------------------------ #
+
+    async def add_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
+        """Restrict a trigger message to a specific channel."""
+        query = (
+            "INSERT INTO triggerMessagesChannel (guild_id, channel_id, triggerId) "
+            "VALUES (%s, %s, %s)"
+        )
+        params = (guild_id, channel_id, trigger_id)
+        await execute_action(query, params)
+
+    async def remove_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
+        """Remove a channel restriction from a trigger message."""
+        query = (
+            "DELETE FROM triggerMessagesChannel "
+            "WHERE guild_id = %s AND channel_id = %s AND triggerId = %s"
+        )
+        params = (guild_id, channel_id, trigger_id)
+        await execute_action(query, params)
+
+    async def get_trigger_channels(self, guild_id: str, trigger_id: int) -> list[TriggerMessageChannelModel]:
+        """Get all channel restrictions for a specific trigger message."""
+        query = (
+            "SELECT guild_id, channel_id, triggerId "
+            "FROM triggerMessagesChannel WHERE guild_id = %s AND triggerId = %s"
+        )
+        params = (guild_id, trigger_id)
+        rows: list[TriggerMessageChannelModel] = []
+        async for row in TriggerMessageChannelModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    async def get_channel_triggers(self, guild_id: str, channel_id: str) -> list[TriggerMessageChannelModel]:
+        """Get all trigger message channel restrictions for a specific channel."""
+        query = (
+            "SELECT guild_id, channel_id, triggerId "
+            "FROM triggerMessagesChannel WHERE guild_id = %s AND channel_id = %s"
+        )
+        params = (guild_id, channel_id)
+        rows: list[TriggerMessageChannelModel] = []
+        async for row in TriggerMessageChannelModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    # ------------------------------------------------------------------ #
+    # Matching
+    # ------------------------------------------------------------------ #
+
+    async def match(self, guild_id: str, content: str, channel_id: str) -> TriggerMessageModel | None:
+        """Find a trigger message that matches the given content in the given channel.
+
+        Performs a LIKE query and double-checks case sensitivity via Python logic.
+        Returns None if no match is found.
+        """
+        query = """
+            SELECT t.id, t.guild_id, t.`trigger`, t.response, t.case_sensitive
+            FROM triggerMessages t
+            LEFT JOIN triggerMessagesChannel tc
+                ON t.id = tc.triggerId AND t.guild_id = tc.guild_id
+            WHERE t.guild_id = %s
+              AND t.`trigger` LIKE %s
+              AND (tc.channel_id = %s)
+        """
+        # Use %-based LIKE matching: %content%
+        like_pattern = f"%{content}%"
+        params = (guild_id, like_pattern, channel_id)
+        result = await execute_query(query, params)
+        result = result[0] if result and result[0] else None
+        if not result:
+            return None
+
+        trigger_message = TriggerMessageModel.from_row(result)
+        if trigger_message.case_sensitive:
+            if content != trigger_message.trigger:
+                return None
+        else:
+            if content.lower() != trigger_message.trigger.lower():
+                return None
+        return trigger_message
+
+
+# ------------------------------------------------------------------ #
+# Module-level singleton
+# ------------------------------------------------------------------ #
+
+trigger_message_service = TriggerMessageService()

--- a/services/trigger_message_service.py
+++ b/services/trigger_message_service.py
@@ -11,11 +11,12 @@ Pydantic-validated parameter models.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
 from typing import Annotated
 
-from api import execute_action, execute_query, execute_query_iter
-from models import TriggerMessageModel, TriggerMessageChannelModel
+from pydantic import BaseModel, Field
+
+from api import execute_action, execute_query
+from models import TriggerMessageChannelModel, TriggerMessageModel
 
 # ------------------------------------------------------------------ #
 # Pydantic models
@@ -53,11 +54,18 @@ class TriggerMessageService:
 
     async def create(self, guild_id: str, trigger: str, response: str, case_sensitive: bool = False) -> None:
         """Create a new trigger message."""
+        # Validate parameters using Pydantic model
+        validated = TriggerMessageCreateParams(
+            guild_id=guild_id,
+            trigger=trigger,
+            response=response,
+            case_sensitive=case_sensitive
+        )
         query = (
             "INSERT INTO triggerMessages (guild_id, `trigger`, response, case_sensitive) "
             "VALUES (%s, %s, %s, %s)"
         )
-        params = (guild_id, trigger, response, case_sensitive)
+        params = (validated.guild_id, validated.trigger, validated.response, validated.case_sensitive)
         await execute_action(query, params)
 
     async def delete(self, guild_id: str, trigger_id: int) -> None:
@@ -84,11 +92,17 @@ class TriggerMessageService:
 
     async def add_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
         """Restrict a trigger message to a specific channel."""
+        # Validate parameters using Pydantic model
+        validated = TriggerMessageChannelAddParams(
+            guild_id=guild_id,
+            channel_id=channel_id,
+            trigger_id=trigger_id
+        )
         query = (
             "INSERT INTO triggerMessagesChannel (guild_id, channel_id, triggerId) "
             "VALUES (%s, %s, %s)"
         )
-        params = (guild_id, channel_id, trigger_id)
+        params = (validated.guild_id, validated.channel_id, validated.trigger_id)
         await execute_action(query, params)
 
     async def remove_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
@@ -131,10 +145,34 @@ class TriggerMessageService:
     async def match(self, guild_id: str, content: str, channel_id: str) -> TriggerMessageModel | None:
         """Find a trigger message that matches the given content in the given channel.
 
-        Performs a LIKE query and double-checks case sensitivity via Python logic.
+        First checks for exact matches, then falls back to LIKE matching.
+        Double-checks case sensitivity via Python logic.
         Returns None if no match is found.
         """
-        query = """
+        # First try exact match
+        exact_query = """
+            SELECT t.id, t.guild_id, t.`trigger`, t.response, t.case_sensitive
+            FROM triggerMessages t
+            LEFT JOIN triggerMessagesChannel tc
+                ON t.id = tc.triggerId AND t.guild_id = tc.guild_id
+            WHERE t.guild_id = %s
+              AND t.`trigger` = %s
+              AND (tc.channel_id = %s)
+        """
+        exact_params = (guild_id, content, channel_id)
+        exact_result = await execute_query(exact_query, exact_params)
+
+        if exact_result and exact_result[0]:
+            trigger_message = TriggerMessageModel.from_row(exact_result[0])
+            if trigger_message.case_sensitive:
+                if content == trigger_message.trigger:
+                    return trigger_message
+            else:
+                if content.lower() == trigger_message.trigger.lower():
+                    return trigger_message
+
+        # Fall back to LIKE pattern matching
+        like_query = """
             SELECT t.id, t.guild_id, t.`trigger`, t.response, t.case_sensitive
             FROM triggerMessages t
             LEFT JOIN triggerMessagesChannel tc
@@ -143,22 +181,38 @@ class TriggerMessageService:
               AND t.`trigger` LIKE %s
               AND (tc.channel_id = %s)
         """
-        # Use %-based LIKE matching: %content%
         like_pattern = f"%{content}%"
-        params = (guild_id, like_pattern, channel_id)
-        result = await execute_query(query, params)
-        result = result[0] if result and result[0] else None
-        if not result:
+        like_params = (guild_id, like_pattern, channel_id)
+        like_results = await execute_query(like_query, like_params)
+
+        if not like_results:
             return None
 
-        trigger_message = TriggerMessageModel.from_row(result)
-        if trigger_message.case_sensitive:
-            if content != trigger_message.trigger:
-                return None
-        else:
-            if content.lower() != trigger_message.trigger.lower():
-                return None
-        return trigger_message
+        # Scan all results for exact match first
+        for row in like_results:
+            if not row:
+                continue
+            trigger_message = TriggerMessageModel.from_row(row)
+            if trigger_message.case_sensitive:
+                if content == trigger_message.trigger:
+                    return trigger_message
+            else:
+                if content.lower() == trigger_message.trigger.lower():
+                    return trigger_message
+
+        # If no exact match found in LIKE results, return first partial match that passes case check
+        for row in like_results:
+            if not row:
+                continue
+            trigger_message = TriggerMessageModel.from_row(row)
+            if trigger_message.case_sensitive:
+                if trigger_message.trigger in content:
+                    return trigger_message
+            else:
+                if trigger_message.trigger.lower() in content.lower():
+                    return trigger_message
+
+        return None
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Creates a new `TriggerMessageService` class in `services/trigger_message_service.py` that consolidates the 8 loose trigger message functions from `api.py` (get/add/remove trigger messages, channel restrictions, and is_trigger_message matching) into a single service with clean method names.

## Changes

- **New file: `services/trigger_message_service.py`** — `TriggerMessageService` class with Pydantic models (`TriggerMessageCreateParams`, `TriggerMessageChannelAddParams`), CRUD methods (`create`, `delete`, `get_all`), channel restriction methods (`add_channel`, `remove_channel`, `get_trigger_channels`, `get_channel_triggers`), and matching (`match`)
- **`commands/admin/trigger_messages/add.py`** — uses `trigger_message_service.create()` instead of direct api import
- **`commands/admin/trigger_messages/configure.py`** — replaces all 6 api function imports with service methods
- **`commands/admin/trigger_messages/send.py`** — uses `trigger_message_service.match()` instead of `is_trigger_message`

## Bug fix

Fixes a subtle bug where `remove_trigger_message` in the old code was called with a trigger ID (`int`) but the SQL query used `WHERE trigger = %s` (string matching on the trigger text column). The new `delete()` method correctly uses `WHERE id = %s` to delete by primary key.

Closes #1322

## Follows existing pattern

Mirrors the `GiveawayService` pattern in `services/giveaway_service.py` — module-level singleton, Pydantic param models, clean CRUD method names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Trigger message administration and matching logic have been centralized into a new service layer for more consistent behavior.

* **Enhancements**
  * Admin UI now reloads trigger and channel state after changes so views and embeds reflect updates immediately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->