### PR TITLE
feat: TicketService - consolidate ticket CRUD into single service (#1320)

### DIFF
--- a/api.py
+++ b/api.py
@@ -2851,19 +2851,31 @@ async def get_ticket_messages(guild_id: str) -> list[TicketMessageModel]:
 async def get_ticket_messages_by_id(ticket_message_id: str) -> TicketMessageModel | None:
     from services.ticket_service import ticket_service as _ticket_svc
 
-    return await _ticket_svc.get_config(int(ticket_message_id))  # type: ignore[arg-type]
+    try:
+        message_id = int(ticket_message_id)
+    except ValueError:
+        return None
+    return await _ticket_svc.get_config(message_id)
 
 
 async def open_ticket(guild_id: str, opener_id: str, ticket_message_id: str, channel_id: str) -> None:
     from services.ticket_service import ticket_service as _ticket_svc
 
-    await _ticket_svc.open(guild_id, opener_id, int(ticket_message_id), channel_id)
+    try:
+        message_id = int(ticket_message_id)
+    except ValueError:
+        return None
+    await _ticket_svc.open(guild_id, opener_id, message_id, channel_id)
 
 
-async def close_ticket(guild_id: str, ticket_id: str) -> None:
+async def close_ticket(guild_id: str, channel_id: str, closed_by: str) -> None:
     from services.ticket_service import ticket_service as _ticket_svc
 
-    await _ticket_svc.close(guild_id, int(ticket_id))
+    try:
+        cid = int(channel_id)
+    except ValueError:
+        return None
+    await _ticket_svc.close(guild_id, cid, closed_by)
 
 
 async def get_tickets(guild_id: str) -> list[TicketModel]:
@@ -2875,7 +2887,11 @@ async def get_tickets(guild_id: str) -> list[TicketModel]:
 async def get_ticket_by_id(guild_id: str, ticket_id: str, channel_id: str) -> TicketModel | None:
     from services.ticket_service import ticket_service as _ticket_svc
 
-    return await _ticket_svc.get_by_config_and_channel(guild_id, int(ticket_id), channel_id)
+    try:
+        tid = int(ticket_id)
+    except ValueError:
+        return None
+    return await _ticket_svc.get_by_config_and_channel(guild_id, tid, channel_id)
 
 
 async def get_ticket_by_channel_id(guild_id: str, channel_id: str) -> TicketModel | None:

--- a/api.py
+++ b/api.py
@@ -2807,6 +2807,10 @@ async def is_trigger_message(guild_id: str, trigger: str, channel_id: str) -> Tr
     return trigger_message
 
 
+# Ticket functions have been moved to TicketService in services/ticket_service.py
+# Import them from there for new code. Old aliases kept for backward compat.
+
+
 async def create_ticket_message(
     guild_id: str,
     channel_id: str,
@@ -2814,100 +2818,70 @@ async def create_ticket_message(
     ping_role: str,
     name: str,
     description: str,
-    summary_channel_id: str,
+    summary_channel_id: str | None = None,
 ) -> int | None:
-    query = "INSERT INTO ticketMessages (guild_id, channel_id, introduction, pingRole, name, description, summaryChannelId) VALUES (%s, %s, %s, %s, %s, %s, %s)"
-    params = (
-        guild_id,
-        channel_id,
-        introduction,
-        ping_role,
-        name,
-        description,
-        summary_channel_id,
+    from services.ticket_service import TicketMessageConfig
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.create_config(
+        TicketMessageConfig(
+            guild_id=guild_id,
+            channel_id=channel_id,
+            introduction=introduction,
+            ping_role=ping_role,
+            name=name,
+            description=description,
+            summary_channel_id=summary_channel_id,
+        )
     )
-    return await execute_insert_and_get_id(query, params)
 
 
-async def delete_ticket_message(guild_id: str, ticket_message_id: str) -> None:
-    query = "DELETE FROM ticketMessages WHERE guild_id = %s AND id = %s"
-    params = (guild_id, ticket_message_id)
-    await execute_action(query, params)
+async def delete_ticket_message(guild_id: str, ticket_message_id: int) -> None:
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    await _ticket_svc.delete_config(guild_id, ticket_message_id)
 
 
 async def get_ticket_messages(guild_id: str) -> list[TicketMessageModel]:
-    query = "SELECT id, guild_id, channel_id, introduction, pingRole, name, description, summaryChannelId FROM ticketMessages WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[TicketMessageModel] = []
-    async for row in TicketMessageModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.get_configs(guild_id)
 
 
 async def get_ticket_messages_by_id(ticket_message_id: str) -> TicketMessageModel | None:
-    result = await execute_query(
-        "SELECT id, guild_id, channel_id, introduction, pingRole, name, description, summaryChannelId FROM ticketMessages WHERE id = %s",
-        (ticket_message_id,),
-    )
-    return TicketMessageModel.from_row(result[0]) if result else None
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.get_config(int(ticket_message_id))  # type: ignore[arg-type]
 
 
 async def open_ticket(guild_id: str, opener_id: str, ticket_message_id: str, channel_id: str) -> None:
-    query = "INSERT INTO tickets (guild_id, openerId, ticketMessageId, channel_id) VALUES (%s, %s, %s, %s)"
-    params = (guild_id, opener_id, ticket_message_id, channel_id)
-    await execute_action(query, params)
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    await _ticket_svc.open(guild_id, opener_id, int(ticket_message_id), channel_id)
 
 
 async def close_ticket(guild_id: str, ticket_id: str) -> None:
-    query = "UPDATE tickets SET closed = 1, closedAt = NOW(), closedBy = %s WHERE guild_id = %s AND id = %s"
-    params = (guild_id, ticket_id)
-    await execute_action(query, params)
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    await _ticket_svc.close(guild_id, int(ticket_id))
 
 
 async def get_tickets(guild_id: str) -> list[TicketModel]:
-    query = """
-        SELECT guild_id, openerId,
-               UNIX_TIMESTAMP(openedAt) as openedAt,
-               closed,
-               UNIX_TIMESTAMP(closedAt) as closedAt,
-               closedBy, channel_id, ticketMessageId
-        FROM tickets WHERE guild_id = %s
-    """
-    params = (guild_id,)
-    rows: list[TicketModel] = []
-    async for row in TicketModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.get_tickets(guild_id)
 
 
 async def get_ticket_by_id(guild_id: str, ticket_id: str, channel_id: str) -> TicketModel | None:
-    query = """
-        SELECT guild_id, openerId,
-               UNIX_TIMESTAMP(openedAt) as openedAt,
-               closed,
-               UNIX_TIMESTAMP(closedAt) as closedAt,
-               closedBy, channel_id, ticketMessageId
-        FROM tickets
-        WHERE guild_id = %s AND ticketMessageId = %s AND channel_id = %s
-    """
-    params = (guild_id, ticket_id, channel_id)
-    result = await execute_query(query, params)
-    return TicketModel.from_row(result[0]) if result else None
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.get_by_config_and_channel(guild_id, int(ticket_id), channel_id)
 
 
 async def get_ticket_by_channel_id(guild_id: str, channel_id: str) -> TicketModel | None:
-    query = """
-        SELECT guild_id, openerId,
-               UNIX_TIMESTAMP(openedAt) as openedAt,
-               closed,
-               UNIX_TIMESTAMP(closedAt) as closedAt,
-               closedBy, channel_id, ticketMessageId
-        FROM tickets
-        WHERE guild_id = %s AND channel_id = %s
-    """
-    params = (guild_id, channel_id)
-    result = await execute_query(query, params)
-    return TicketModel.from_row(result[0]) if result else None
+    from services.ticket_service import ticket_service as _ticket_svc
+
+    return await _ticket_svc.get_by_channel(guild_id, channel_id)
 
 
 async def get_join_to_create_channel(channel_id: str) -> bool:

--- a/commands/admin/ticket/close_ticket.py
+++ b/commands/admin/ticket/close_ticket.py
@@ -4,7 +4,7 @@ from typing import Any
 import discord
 
 import utility
-from api import get_ticket_by_id, get_ticket_messages_by_id
+from services.ticket_service import ticket_service
 from localizer import tanjunLocalizer
 
 
@@ -24,7 +24,7 @@ async def close_ticket(interaction: discord.Interaction) -> None:
         data["custom_id"].split(";")[2],
     )
 
-    ticket_message = await get_ticket_messages_by_id(ticket_id)
+    ticket_message = await ticket_service.get_config(int(ticket_id))
     if not ticket_message:
         await interaction.followup.send(
             tanjunLocalizer.localize(
@@ -34,7 +34,9 @@ async def close_ticket(interaction: discord.Interaction) -> None:
         )
         return
 
-    ticket = await get_ticket_by_id(guild.id, ticket_id, ticket_channel_id)
+    ticket = await ticket_service.get_by_config_and_channel(
+        str(guild.id), int(ticket_id), ticket_channel_id
+    )
 
     if not ticket:
         await interaction.followup.send(

--- a/commands/admin/ticket/create_ticket.py
+++ b/commands/admin/ticket/create_ticket.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.ticket_service import TicketMessageConfig, ticket_service
 from localizer import tanjunLocalizer
+from services.ticket_service import TicketMessageConfig, ticket_service
 
 
 async def create_ticket(
@@ -58,6 +58,20 @@ async def create_ticket(
             introduction=introduction,
         )
     )
+
+    if ticket_id is None:
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                command_info.locale,
+                "commands.admin.create_ticket.error.title",
+            ),
+            description=tanjunLocalizer.localize(
+                command_info.locale,
+                "commands.admin.create_ticket.error.description",
+            ),
+        )
+        await command_info.reply(embed=embed)
+        return
 
     view = discord.ui.View()
     label = tanjunLocalizer.localize(str(command_info.locale), "commands.admin.create_ticket.button.label")

--- a/commands/admin/ticket/create_ticket.py
+++ b/commands/admin/ticket/create_ticket.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import create_ticket_message
+from services.ticket_service import TicketMessageConfig, ticket_service
 from localizer import tanjunLocalizer
 
 
@@ -47,14 +47,16 @@ async def create_ticket(
         await command_info.reply(embed=embed)
         return
 
-    ticket_id = await create_ticket_message(
-        guild_id=command_info.guild.id,
-        channel_id=channel.id,
-        name=name,
-        description=description,
-        ping_role=ping_role.id if ping_role is not None else None,  # type: ignore[arg-type]
-        summary_channel_id=summary_channel.id if summary_channel is not None else None,  # type: ignore[arg-type]
-        introduction=introduction,  # type: ignore[arg-type]
+    ticket_id = await ticket_service.create_config(
+        TicketMessageConfig(
+            guild_id=str(command_info.guild.id),
+            channel_id=str(channel.id),
+            name=name,
+            description=description,
+            ping_role=str(ping_role.id) if ping_role is not None else None,
+            summary_channel_id=str(summary_channel.id) if summary_channel is not None else None,
+            introduction=introduction,
+        )
     )
 
     view = discord.ui.View()

--- a/commands/admin/ticket/open_ticket.py
+++ b/commands/admin/ticket/open_ticket.py
@@ -3,7 +3,8 @@ from typing import Any
 import discord
 
 import utility
-from api import check_if_opted_out, get_ticket_messages_by_id, open_ticket
+from services.ticket_service import ticket_service
+from api import check_if_opted_out
 from localizer import tanjunLocalizer
 
 
@@ -64,7 +65,7 @@ async def open_ticket_2(interaction: discord.Interaction) -> None:
     data: Any = interaction.data
     ticket_id = data["custom_id"].split(";")[1]
     print("ticket_id", ticket_id)
-    ticket = await get_ticket_messages_by_id(ticket_id)
+    ticket = await ticket_service.get_config(int(ticket_id))
 
     if not ticket:
         await interaction.response.send_message(
@@ -146,9 +147,9 @@ async def open_ticket_2(interaction: discord.Interaction) -> None:
         ephemeral=True,
     )
 
-    await open_ticket(
-        guild_id=interaction.guild.id,
-        opener_id=interaction.user.id,  # type: ignore[arg-type]
-        ticket_message_id=ticket_id,
-        channel_id=thread.id,
+    await ticket_service.open(
+        guild_id=str(interaction.guild.id),
+        opener_id=str(interaction.user.id),
+        config_id=int(ticket_id),
+        channel_id=str(thread.id),
     )

--- a/commands/admin/ticket/open_ticket.py
+++ b/commands/admin/ticket/open_ticket.py
@@ -3,9 +3,9 @@ from typing import Any
 import discord
 
 import utility
-from services.ticket_service import ticket_service
 from api import check_if_opted_out
 from localizer import tanjunLocalizer
+from services.ticket_service import ticket_service
 
 
 async def openTicket(interaction: discord.Interaction) -> None:
@@ -139,17 +139,34 @@ async def open_ticket_2(interaction: discord.Interaction) -> None:
 
     await thread.send(embed=embed, view=view)
 
+    try:
+        await ticket_service.open(
+            guild_id=str(interaction.guild.id),
+            opener_id=str(interaction.user.id),
+            config_id=int(ticket_id),
+            channel_id=str(thread.id),
+        )
+    except Exception as e:
+        # Rollback: delete the created thread
+        try:
+            await thread.delete()
+        except Exception:
+            pass  # Best effort cleanup
+
+        # Notify user of failure
+        await interaction.followup.send(
+            tanjunLocalizer.localize(
+                interaction.locale,
+                "commands.admin.open_ticket.error.ticketNotCreated",
+            ),
+            ephemeral=True,
+        )
+        raise e
+
     await interaction.followup.send(
         tanjunLocalizer.localize(
             interaction.locale,
             "commands.admin.open_ticket.success.ticketCreated",
         ),
         ephemeral=True,
-    )
-
-    await ticket_service.open(
-        guild_id=str(interaction.guild.id),
-        opener_id=str(interaction.user.id),
-        config_id=int(ticket_id),
-        channel_id=str(thread.id),
     )

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -1,0 +1,180 @@
+"""
+TicketService: Encapsulate ticket CRUD and close/open logic into a single service.
+
+Consolidates the loose ticket functions from api.py (create_ticket_message,
+delete_ticket_message, get_ticket_messages, open_ticket, close_ticket, etc.) into a
+single TicketService class with Pydantic-validated parameter models.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from api import execute_action, execute_insert_and_get_id, execute_query
+from models import TicketMessageModel, TicketModel
+
+
+# ------------------------------------------------------------------ #
+# Pydantic models
+# ------------------------------------------------------------------ #
+
+
+class TicketMessageConfig(BaseModel):
+    """Validated parameters for creating a ticket message config."""
+
+    guild_id: str
+    channel_id: str
+    introduction: str | None = None
+    ping_role: str | None = None
+    name: str | None = Field(default=None, max_length=128)
+    description: str | None = Field(default=None, max_length=1024)
+    summary_channel_id: str | None = None
+
+
+# ------------------------------------------------------------------ #
+# TicketService
+# ------------------------------------------------------------------ #
+
+
+class TicketService:
+    """Service for managing ticket message configs and ticket instances."""
+
+    # ------------------------------------------------------------------ #
+    # Ticket message config
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def create_config(params: TicketMessageConfig) -> int | None:
+        """Create a new ticket message config and return its ID."""
+        query = (
+            "INSERT INTO ticketMessages "
+            "(guild_id, channel_id, introduction, pingRole, name, description, summaryChannelId) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)"
+        )
+        vals = (
+            params.guild_id,
+            params.channel_id,
+            params.introduction,
+            params.ping_role,
+            params.name,
+            params.description,
+            params.summary_channel_id,
+        )
+        return await execute_insert_and_get_id(query, vals)
+
+    @staticmethod
+    async def delete_config(guild_id: str, message_id: int) -> None:
+        """Delete a ticket message config."""
+        query = "DELETE FROM ticketMessages WHERE guild_id = %s AND id = %s"
+        await execute_action(query, (guild_id, message_id))
+
+    @staticmethod
+    async def get_configs(guild_id: str) -> list[TicketMessageModel]:
+        """Get all ticket message configs for a guild."""
+        query = (
+            "SELECT id, guild_id, channel_id, introduction, pingRole, "
+            "name, description, summaryChannelId "
+            "FROM ticketMessages WHERE guild_id = %s"
+        )
+        rows: list[TicketMessageModel] = []
+        async for row in TicketMessageModel.iter_rows(query, (guild_id,)):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_config(ticket_message_id: int) -> TicketMessageModel | None:
+        """Get a single ticket message config by ID."""
+        query = (
+            "SELECT id, guild_id, channel_id, introduction, pingRole, "
+            "name, description, summaryChannelId "
+            "FROM ticketMessages WHERE id = %s"
+        )
+        result = await execute_query(query, (ticket_message_id,))
+        return TicketMessageModel.from_row(result[0]) if result else None
+
+    # ------------------------------------------------------------------ #
+    # Ticket operations
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    async def open(
+        guild_id: str,
+        opener_id: str,
+        config_id: int,
+        channel_id: str,
+    ) -> None:
+        """Open a new ticket instance."""
+        query = (
+            "INSERT INTO tickets (guild_id, openerId, ticketMessageId, channel_id) "
+            "VALUES (%s, %s, %s, %s)"
+        )
+        await execute_action(query, (guild_id, opener_id, config_id, channel_id))
+
+    @staticmethod
+    async def close(guild_id: str, ticket_id: int) -> None:
+        """Close a ticket instance."""
+        query = (
+            "UPDATE tickets SET closed = 1, closedAt = NOW(), closedBy = %s "
+            "WHERE guild_id = %s AND id = %s"
+        )
+        await execute_action(query, (guild_id, ticket_id))
+
+    @staticmethod
+    async def get_tickets(guild_id: str) -> list[TicketModel]:
+        """Get all tickets for a guild."""
+        query = """
+            SELECT guild_id, openerId,
+                   UNIX_TIMESTAMP(openedAt) as openedAt,
+                   closed,
+                   UNIX_TIMESTAMP(closedAt) as closedAt,
+                   closedBy, channel_id, ticketMessageId
+            FROM tickets WHERE guild_id = %s
+        """
+        rows: list[TicketModel] = []
+        async for row in TicketModel.iter_rows(query, (guild_id,)):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_by_config_and_channel(
+        guild_id: str,
+        config_id: int,
+        channel_id: str,
+    ) -> TicketModel | None:
+        """Get a ticket by its config ID and channel ID."""
+        query = """
+            SELECT guild_id, openerId,
+                   UNIX_TIMESTAMP(openedAt) as openedAt,
+                   closed,
+                   UNIX_TIMESTAMP(closedAt) as closedAt,
+                   closedBy, channel_id, ticketMessageId
+            FROM tickets
+            WHERE guild_id = %s AND ticketMessageId = %s AND channel_id = %s
+        """
+        result = await execute_query(query, (guild_id, config_id, channel_id))
+        return TicketModel.from_row(result[0]) if result else None
+
+    @staticmethod
+    async def get_by_channel(
+        guild_id: str,
+        channel_id: str,
+    ) -> TicketModel | None:
+        """Get a ticket by its channel ID."""
+        query = """
+            SELECT guild_id, openerId,
+                   UNIX_TIMESTAMP(openedAt) as openedAt,
+                   closed,
+                   UNIX_TIMESTAMP(closedAt) as closedAt,
+                   closedBy, channel_id, ticketMessageId
+            FROM tickets
+            WHERE guild_id = %s AND channel_id = %s
+        """
+        result = await execute_query(query, (guild_id, channel_id))
+        return TicketModel.from_row(result[0]) if result else None
+
+
+# ------------------------------------------------------------------ #
+# Singleton instance
+# ------------------------------------------------------------------ #
+
+ticket_service = TicketService()

--- a/services/ticket_service.py
+++ b/services/ticket_service.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel, Field
 from api import execute_action, execute_insert_and_get_id, execute_query
 from models import TicketMessageModel, TicketModel
 
-
 # ------------------------------------------------------------------ #
 # Pydantic models
 # ------------------------------------------------------------------ #
@@ -111,13 +110,13 @@ class TicketService:
         await execute_action(query, (guild_id, opener_id, config_id, channel_id))
 
     @staticmethod
-    async def close(guild_id: str, ticket_id: int) -> None:
+    async def close(guild_id: str, channel_id: int, closed_by: str) -> None:
         """Close a ticket instance."""
         query = (
             "UPDATE tickets SET closed = 1, closedAt = NOW(), closedBy = %s "
-            "WHERE guild_id = %s AND id = %s"
+            "WHERE guild_id = %s AND channel_id = %s"
         )
-        await execute_action(query, (guild_id, ticket_id))
+        await execute_action(query, (closed_by, guild_id, channel_id))
 
     @staticmethod
     async def get_tickets(guild_id: str) -> list[TicketModel]:


### PR DESCRIPTION
## Summary

Consolidates the loose ticket CRUD functions from `api.py` into a single `TicketService` class with a Pydantic-validated config model, matching the pattern established by `ReportService` and `GiveawayService`.

## Changes

### New file: `services/ticket_service.py`
- `TicketMessageConfig` — Pydantic model with field constraints for ticket message config parameters
- `TicketService` class with static methods:
  - `create_config()` / `delete_config()` / `get_configs()` / `get_config()` — ticket message config CRUD
  - `open()` / `close()` — ticket instance lifecycle
  - `get_tickets()` / `get_by_config_and_channel()` / `get_by_channel()` — ticket queries
- `ticket_service` singleton instance

### Modified: `api.py`
- Replaced 9 inline ticket functions with backward-compatible aliases that delegate to `TicketService`
- Fixed `summary_channel_id` type hint to be `str | None` (was missing optional marker)
- Fixed `close_ticket` parameter types (was passing `guild_id` for `closedBy` — now uses proper signature from the service)

### Modified callers
- `commands/admin/ticket/create_ticket.py` — uses `TicketService` directly via `TicketMessageConfig`
- `commands/admin/ticket/open_ticket.py` — uses `ticket_service.get_config()` and `ticket_service.open()`
- `commands/admin/ticket/close_ticket.py` — uses `ticket_service.get_config()` and `ticket_service.get_by_config_and_channel()`

Closes #1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ticket backend consolidated into a centralized service layer for more reliable ticket creation, opening, listing, and deletion.
* **New behavior**
  * Ticket closing now records who closed the ticket and operates by channel, improving auditability.
* **Reliability**
  * Improved error handling during ticket opening to avoid orphaned threads and ensure clearer failure/success feedback.
* **UX**
  * Ticket message configs now accept an optional summary channel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->