### PR TITLE
fix: Audit log incorrectly attributing actions to wrong users (#1103)

### DIFF
--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -512,9 +512,10 @@ class LogsCog(commands.Cog):
 
         updater = None
 
-        async for entry in rule.guild.audit_logs(action=discord.AuditLogAction.automod_rule_update):
-            updater = entry.user.mention  # type: ignore[union-attr]
-            break
+        async for entry in rule.guild.audit_logs(limit=5, action=discord.AuditLogAction.automod_rule_update):
+            if entry.target.id == rule.id:  # type: ignore[union-attr]
+                updater = entry.user.mention  # type: ignore[union-attr]
+                break
 
         # Basic info
         if updater:
@@ -680,9 +681,10 @@ class LogsCog(commands.Cog):
 
         updater = None
 
-        async for entry in rule.guild.audit_logs(action=discord.AuditLogAction.automod_rule_delete):
-            updater = entry.user.mention  # type: ignore[union-attr]
-            break
+        async for entry in rule.guild.audit_logs(limit=5, action=discord.AuditLogAction.automod_rule_delete):
+            if entry.target.id == rule.id:  # type: ignore[union-attr]
+                updater = entry.user.mention  # type: ignore[union-attr]
+                break
 
         # Basic info
         if updater:
@@ -930,9 +932,10 @@ class LogsCog(commands.Cog):
         description_parts = []
 
         deleter = None
-        async for entry in channel.guild.audit_logs(action=discord.AuditLogAction.channel_delete):
-            deleter = entry.user.mention  # type: ignore[union-attr]
-            break
+        async for entry in channel.guild.audit_logs(limit=5, action=discord.AuditLogAction.channel_delete):
+            if entry.target.id == channel.id:  # type: ignore[union-attr]
+                deleter = entry.user.mention  # type: ignore[union-attr]
+                break
 
         if deleter:
             description_parts.append(tanjunLocalizer.localize(locale, "logs.guild_channelDelete.deleted_by", deleter=deleter))
@@ -1023,9 +1026,10 @@ class LogsCog(commands.Cog):
         locale = channel.guild.preferred_locale if hasattr(channel.guild, "preferred_locale") else "en_US"
         description_parts = []
         creator = None
-        async for entry in channel.guild.audit_logs(action=discord.AuditLogAction.channel_create):
-            creator = entry.user.mention  # type: ignore[union-attr]
-            break
+        async for entry in channel.guild.audit_logs(limit=5, action=discord.AuditLogAction.channel_create):
+            if entry.target.id == channel.id:  # type: ignore[union-attr]
+                creator = entry.user.mention  # type: ignore[union-attr]
+                break
 
         if creator:
             description_parts.append(tanjunLocalizer.localize(locale, "logs.guild_channelCreate.created_by", creator=creator))
@@ -1099,9 +1103,10 @@ class LogsCog(commands.Cog):
         description_parts = []
 
         updater = None
-        async for entry in after.guild.audit_logs(action=discord.AuditLogAction.channel_update):
-            updater = entry.user.mention  # type: ignore[union-attr]
-            break
+        async for entry in after.guild.audit_logs(limit=5, action=discord.AuditLogAction.channel_update):
+            if entry.target.id == after.id:  # type: ignore[union-attr]
+                updater = entry.user.mention  # type: ignore[union-attr]
+                break
 
         if updater:
             description_parts.append(tanjunLocalizer.localize(locale, "logs.guild_channelUpdate.updated_by", updater=updater))
@@ -2273,8 +2278,10 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.memberBan.name", user=user.mention))
 
         banner = None
-        async for log in user.guild.audit_logs(limit=1, user=user):
-            banner = log.banner
+        async for log in user.guild.audit_logs(limit=1, action=discord.AuditLogAction.ban):
+            if log.target == user:
+                banner = log.user
+                break
 
         if banner:
             description_parts.append(tanjunLocalizer.localize(locale, "logs.memberBan.banned_by", banner=banner.mention))
@@ -2304,8 +2311,10 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.memberUnban.name", user=user.mention))
 
         unbanned_by = None
-        async for log in guild.audit_logs(limit=1, user=user):
-            unbanned_by = log.user
+        async for log in guild.audit_logs(limit=1, action=discord.AuditLogAction.unban):
+            if log.target == user:
+                unbanned_by = log.user
+                break
 
         if unbanned_by:
             description_parts.append(
@@ -2552,8 +2561,10 @@ class LogsCog(commands.Cog):
 
         send_log = False
 
-        async for log in message.guild.audit_logs(limit=1, action=discord.AuditLogAction.message_delete):  # type: ignore[union-attr]
-            deleted_by = log.user
+        async for log in message.guild.audit_logs(limit=5, action=discord.AuditLogAction.message_delete):  # type: ignore[union-attr]
+            if log.target.id == message.author.id and log.extra.channel.id == message.channel.id:  # type: ignore[union-attr]
+                deleted_by = log.user
+                break
         if deleted_by:
             description_parts.append(
                 tanjunLocalizer.localize(
@@ -2702,8 +2713,10 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleCreate.name", role=role.mention))
 
         created_by = None
-        async for log in role.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_create):
-            created_by = log.user
+        async for log in role.guild.audit_logs(limit=5, action=discord.AuditLogAction.role_create):
+            if log.target.id == role.id:  # type: ignore[union-attr]
+                created_by = log.user
+                break
         if created_by:
             description_parts.append(
                 tanjunLocalizer.localize(
@@ -2780,8 +2793,10 @@ class LogsCog(commands.Cog):
         description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleDelete.name", role=role.name))
 
         deleted_by = None
-        async for log in role.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_delete):
-            deleted_by = log.user
+        async for log in role.guild.audit_logs(limit=5, action=discord.AuditLogAction.role_delete):
+            if log.target.id == role.id:  # type: ignore[union-attr]
+                deleted_by = log.user
+                break
         if deleted_by:
             description_parts.append(
                 tanjunLocalizer.localize(
@@ -2861,8 +2876,10 @@ class LogsCog(commands.Cog):
             description_parts.append(tanjunLocalizer.localize(locale, "logs.guildRoleUpdate.name", role=after.name))
 
         updated_by = None
-        async for log in after.guild.audit_logs(limit=1, action=discord.AuditLogAction.role_update):
-            updated_by = log.user
+        async for log in after.guild.audit_logs(limit=5, action=discord.AuditLogAction.role_update):
+            if log.target.id == after.id:  # type: ignore[union-attr]
+                updated_by = log.user
+                break
         if updated_by:
             description_parts.append(
                 tanjunLocalizer.localize(


### PR DESCRIPTION
## Description

Fixes #1103 — the audit log has been attributing actions to the wrong users in several places.

### Root Issues

The primary bugs were in `on_member_ban` and `on_member_unban` which used `audit_logs(user=user)` — this filters by the user **performing** the action, NOT the target (affected person). Since the banned/unbanned user never performs the ban on themselves, the query would return unrelated audit log entries (or no match at all).

### Changes

1. **on_member_ban**: Changed from `audit_logs(limit=1, user=user)` → `audit_logs(limit=1, action=AuditLogAction.ban)` + `log.target == user` check
2. **on_member_unban**: Same fix with `AuditLogAction.unban`

Additionally hardened **all other audit log lookups** to verify the target:
3. **channel_delete/create/update**: Added `entry.target.id` check with `limit=5`
4. **role_create/delete/update**: Added `entry.target.id` check with `limit=5`
5. **message_delete**: Added both target (author ID) and channel match verification
6. **automod_rule_update/delete**: Added `entry.target.id` check with `limit=5`

Previously, many handlers just took the first audit log entry for a given action type without checking if it matched the specific entity, which could lead to wrong attributions in busy servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Improved audit log attribution accuracy** – Fixed issue where log entries could incorrectly attribute actions to the wrong user. The system now properly matches audit log records to events for AutoMod rules, channels, member bans, message deletions, and roles, ensuring accurate responsibility tracking across all logged actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->