### PR TITLE
Fix #1327: Localize all hardcoded user-facing strings

### DIFF
--- a/commands/admin/embedcreator.py
+++ b/commands/admin/embedcreator.py
@@ -454,7 +454,7 @@ async def create_embed(command_info: utility.CommandInfo, channel: discord.TextC
                     view.command_info.locale,
                     "commands.admin.embed.modals.removeFieldModal.selectField",
                 ),
-                options=[discord.SelectOption(label=f"Field {i + 1}", value=str(i)) for i in range(len(view.embed.fields))],
+                options=[discord.SelectOption(label=tanjunLocalizer.localize(view.command_info.locale, "commands.admin.embed.modals.removeFieldModal.fieldLabel", number=i+1), value=str(i)) for i in range(len(view.embed.fields))],
             )
             self.add_item(self.field_index)
 

--- a/commands/admin/warn.py
+++ b/commands/admin/warn.py
@@ -59,20 +59,22 @@ async def warn_user(command_info: utility.CommandInfo, member: discord.Member, r
     )
     await command_info.reply(embed=embed)
 
+    locale_str = str(command_info.locale)
+
     # Check for escalated actions based on warn count
     if warn_config:
         if warn_count >= warn_config.ban_threshold:
             # Ban the user
-            await member.ban(reason=f"Reached {warn_count} warnings")
+            await member.ban(reason=tanjunLocalizer.localize(locale_str, "commands.admin.warn.reason.reached_warnings", count=warn_count))
         elif warn_count >= warn_config.kick_threshold:
             # Kick the user
-            await member.kick(reason=f"Reached {warn_count} warnings")
+            await member.kick(reason=tanjunLocalizer.localize(locale_str, "commands.admin.warn.reason.reached_warnings", count=warn_count))
         elif warn_count >= warn_config.timeout_threshold:
             # Timeout the user
             timeout_duration = warn_config.timeout_duration
             duration = timedelta(minutes=timeout_duration)
             until = discord.utils.utcnow() + duration
-            await member.timeout(until, reason=f"Reached {warn_count} warnings")
+            await member.timeout(until, reason=tanjunLocalizer.localize(locale_str, "commands.admin.warn.reason.reached_warnings", count=warn_count))
 
     # DM the warned user
     try:

--- a/commands/ai/add_custom_situation_button_handler.py
+++ b/commands/ai/add_custom_situation_button_handler.py
@@ -10,13 +10,14 @@ from services.ai_service import AiService
 async def approve_custom_situation(interaction) -> None:  # type: ignore[no-untyped-def]
     situation_id = interaction.data["custom_id"].split(";")[1]
     situation = await AiService.get_user_situation(situation_id)
+    locale = interaction.data["custom_id"].split(";")[2]
     if not situation:
-        await interaction.response.send_message("Situation wurde denke gelöscht oder so :/")
+        await interaction.response.send_message(tanjunLocalizer.localize(locale, "commands.admin.administration.situation_not_found"))
         return
     situation_creator = interaction.client.get_user(int(situation_id))
     if not situation_creator:
         await interaction.channel.send(
-            "Der typ der die Situation erstellt hat ist nicht mehr am tanjun nutzen :c",
+            tanjunLocalizer.localize(locale, "commands.admin.administration.situation_creator_gone"),
             delete_after=25,
         )
         return
@@ -33,20 +34,21 @@ async def approve_custom_situation(interaction) -> None:  # type: ignore[no-unty
         await situation_creator.send(embed=embed)
     except (discord.Forbidden, discord.HTTPException):
         logging.exception("Failed to send approval DM to situation creator")
-    await interaction.channel.send("Situation wurde freigeschaltet!", delete_after=25)
+    await interaction.channel.send(tanjunLocalizer.localize(locale, "commands.admin.administration.situation_approved"), delete_after=25)
 
 
 async def deny_custom_situation(interaction) -> None:  # type: ignore[no-untyped-def]
     situation_id = interaction.data["custom_id"].split(";")[1]
     situation = await AiService.get_user_situation(situation_id)
+    locale = interaction.data["custom_id"].split(";")[2]
     if not situation:
-        await interaction.response.send_message("Situation wurde denke gelöscht oder so :/")
+        await interaction.response.send_message(tanjunLocalizer.localize(locale, "commands.admin.administration.situation_not_found"))
         return
 
     situation_creator = interaction.bot.get_user(int(situation_id))
     if not situation_creator:
         await interaction.channel.send(
-            "Der typ der die Situation erstellt hat ist nicht mehr am tanjun nutzen :c",
+            tanjunLocalizer.localize(locale, "commands.admin.administration.situation_creator_gone"),
             delete_after=25,
         )
         return
@@ -63,4 +65,4 @@ async def deny_custom_situation(interaction) -> None:  # type: ignore[no-untyped
         await situation_creator.send(embed=embed)
     except (discord.Forbidden, discord.HTTPException):
         logging.exception("Failed to send denial DM to situation creator")
-    await interaction.channel.send("Situation wurde gelöscht!", delete_after=25)
+    await interaction.channel.send(tanjunLocalizer.localize(locale, "commands.admin.administration.situation_deleted"), delete_after=25)

--- a/commands/games/akinator.py
+++ b/commands/games/akinator.py
@@ -198,7 +198,7 @@ async def akinator(command_info: utility.CommandInfo, theme: str | None = None) 
             command_info.locale,
             "commands.games.akinator.description",
             question=aki.question,
-            lastAnswer="No Answer",
+            lastAnswer=tanjunLocalizer.localize(str(command_info.locale), "commands.games.akinator.no_answer"),
             progress=int(aki.progression),
         ),
     )

--- a/commands/math/plot_function.py
+++ b/commands/math/plot_function.py
@@ -357,7 +357,7 @@ async def plot_function_command(
             disabled=True,
         )
         async def empty(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
-            await interaction.response.send_message("this should not be clickable??", ephemeral=True)
+            await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plot_function.not_clickable"), ephemeral=True)
 
         @discord.ui.button(
             emoji="<:math_add:1254372629456883793>",
@@ -500,7 +500,7 @@ async def plot_function_command(
         )
         async def rename_function(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
             if not self.plotter.functions:
-                await interaction.response.send_message("There are no functions to rename.", ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plot_function.no_functions_to_rename"), ephemeral=True)
                 return
 
             view = discord.ui.View()
@@ -604,9 +604,9 @@ async def plot_function_command(
                 await self.plotterView.update_plot(interaction)
                 self.update_options()
             except ValueError as e:
-                await interaction.response.send_message(f"Error: {str(e)}", ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plot_function.error", error=str(e)), ephemeral=True)
             except Exception as e:
-                await interaction.response.send_message(f"An unexpected error occurred: {str(e)}", ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plot_function.unexpected_error", error=str(e)), ephemeral=True)
 
     class ChangeTitleModal(
         discord.ui.Modal,

--- a/commands/math/plot_function.py
+++ b/commands/math/plot_function.py
@@ -357,7 +357,7 @@ async def plot_function_command(
             disabled=True,
         )
         async def empty(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
-            await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plot_function.not_clickable"), ephemeral=True)
+            await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plotfunction.not_clickable"), ephemeral=True)
 
         @discord.ui.button(
             emoji="<:math_add:1254372629456883793>",
@@ -500,7 +500,7 @@ async def plot_function_command(
         )
         async def rename_function(self, interaction: discord.Interaction, button: discord.ui.Button[Any]) -> None:  # type: ignore[misc]
             if not self.plotter.functions:
-                await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plot_function.no_functions_to_rename"), ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotter.command_info.locale, "commands.math.plotfunction.no_functions_to_rename"), ephemeral=True)
                 return
 
             view = discord.ui.View()
@@ -604,9 +604,9 @@ async def plot_function_command(
                 await self.plotterView.update_plot(interaction)
                 self.update_options()
             except ValueError as e:
-                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plot_function.error", error=str(e)), ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plotfunction.error", error=str(e)), ephemeral=True)
             except Exception as e:
-                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plot_function.unexpected_error", error=str(e)), ephemeral=True)
+                await interaction.response.send_message(tanjunLocalizer.localize(self.plotterView.plotter.command_info.locale, "commands.math.plotfunction.unexpected_error", error=str(e)), ephemeral=True)
 
     class ChangeTitleModal(
         discord.ui.Modal,

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -107,32 +107,33 @@ class AdministrationCog(commands.Cog):
         if ctx.author.id not in config.adminIds:
             return
 
-        message = await ctx.send("Starting bot tests...")
+        locale = self._locale(ctx)
+        message = await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.starting"))
 
         if not TEST_FUNCTIONS_AVAILABLE:
-            await message.edit(content="⚠️ Test functions not available. Skipping tests.")
+            await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.tests_unavailable"))
             return
 
-        await message.edit(content="Starting bot tests... \ncurrent Test: `Ping`")
+        await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.current_test_ping"))
         try:
             await test_ping(self, ctx)
         except Exception as e:
-            await message.edit(content=f"❌ Error in Ping test: {e}")
+            await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.error", test_name="Ping", error=e))
             return
-        await message.edit(content="Starting bot tests... \nPing Test: ✅\ncurrent Test: `Database`")
+        await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.current_test_db"))
         try:
             await test_database(self, ctx)
         except Exception as e:
-            await message.edit(content=f"❌ Error in Database test: {e}")
+            await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.error", test_name="Database", error=e))
             return
-        await message.edit(content="Starting bot tests... \nPing Test: ✅\nDatabase Test: ✅\ncurrent Test: `Commands`")
+        await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.current_test_cmds"))
         try:
             await test_commands(self, ctx)
         except Exception as e:
-            await message.edit(content=f"❌ Error in Commands test: {e}")
+            await message.edit(content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.error", test_name="Commands", error=e))
             return
         await message.edit(
-            content="Starting bot tests... \nPing Test: ✅\nDatabase Test: ✅\nCommands Test: ✅\nAll tests completed successfully. The bot seems to be working fine."
+            content=tanjunLocalizer.localize(locale, "commands.admin.administration.test_bot.all_completed")
         )
 
     @commands.command()
@@ -147,10 +148,11 @@ class AdministrationCog(commands.Cog):
         if ctx.author.id not in config.adminIds:
             return
 
+        locale = self._locale(ctx)
         await send_logEmbeds(self.bot)
         await create_database_backup(self.bot)
         await removeAllJoinToCreateChannels()
-        await ctx.send("Updating...")
+        await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.update.updating"))
         try:
             async with (
                 aiohttp.ClientSession() as session,
@@ -159,11 +161,11 @@ class AdministrationCog(commands.Cog):
                 ) as response,
             ):
                 if response.status != 200:
-                    await ctx.send(f"Error: Received status code {response.status}. Response: {await response.text()}")
+                    await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.update.http_error", status=response.status, response=await response.text()))
                     return
                 await ctx.send(await response.text())
         except (TimeoutError, aiohttp.ClientError) as e:
-            await ctx.send(f"Failed to connect to update service: {e}")
+            await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.update.connection_failed", error=e))
 
     @commands.command()
     async def welcome(self, ctx: commands.Context, user: discord.Member | None = None) -> None:  # type: ignore[type-arg]
@@ -208,6 +210,7 @@ class AdministrationCog(commands.Cog):
     async def bsstarpoweremojis(self, ctx: commands.Context, start: int = 0) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
+        locale = self._locale(ctx)
         all_brawlers = await self.getBrawlers()
         for i, brawler in enumerate(all_brawlers["items"]):
             if i < start:
@@ -222,20 +225,21 @@ class AdministrationCog(commands.Cog):
                     ):
                         if response.status != 200:
                             print(f"Download failed: {response.status} for {star_power['name']}")
-                            await ctx.send(f"Download failed: {response.status} for {star_power['name']}")
+                            await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_download_failed", status=response.status, name=star_power['name']))
                             continue
                         image = await response.read()
                         emoji = await ctx.guild.create_custom_emoji(name=f"{star_power['id']}", image=image)  # type: ignore[union-attr]
-                        await ctx.send(f"{emoji} {star_power['name']}; i:{i}")
+                        await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_emoji_created", emoji=emoji, name=star_power['name'], index=i))
                 except (TimeoutError, aiohttp.ClientError, discord.HTTPException) as e:
                     print(f"Failed to create emoji for {star_power['name']}: {e}")
-                    await ctx.send(f"Failed to create emoji for {star_power['name']}: {e}")
+                    await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_emoji_failed", name=star_power['name'], error=e))
                     continue
 
     @commands.command()
     async def bsgadgetsemojis(self, ctx: commands.Context, start: int = 0) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
+        locale = self._locale(ctx)
         all_brawlers = await self.getBrawlers()
         for i, brawler in enumerate(all_brawlers["items"]):
             if i < start:
@@ -250,15 +254,15 @@ class AdministrationCog(commands.Cog):
                     ):
                         if response.status != 200:
                             print(f"Download failed: {response.status} for {gadget['name']}")
-                            await ctx.send(f"Download failed: {response.status} for {gadget['name']}")
+                            await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_download_failed", status=response.status, name=gadget['name']))
                             continue
                         image = await response.read()
                         emoji = await ctx.guild.create_custom_emoji(name=f"{gadget['id']}", image=image)  # type: ignore[union-attr]
 
-                        await ctx.send(f"{emoji} {gadget['name']}; i:{i}")
+                        await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_emoji_created", emoji=emoji, name=gadget['name'], index=i))
                 except (TimeoutError, aiohttp.ClientError, discord.HTTPException) as e:
                     print(f"Failed to create emoji for {gadget['name']}: {e}")
-                    await ctx.send(f"Failed to create emoji for {gadget['name']}: {e}")
+                    await ctx.send(tanjunLocalizer.localize(locale, "commands.admin.administration.bs_emoji_failed", name=gadget['name'], error=e))
                     continue
 
     async def getAccData(self, id: str) -> dict[str, Any]:
@@ -293,14 +297,14 @@ class AdministrationCog(commands.Cog):
         if ctx.author.id not in config.adminIds:
             return
         await ctx.guild.edit(preferred_locale=locale)  # type: ignore[union-attr, arg-type]
-        await ctx.send(f"The guild locale has been set to {locale}")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.set_guild_locale", locale=locale))
 
     @commands.command()
     async def testgithubauthtoken(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
         await missingLocalization("JUSTATEST.IGNORETHIS.JUSTATEST")
-        await ctx.send("jup gemacht :)")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.github_auth_test"))
 
     @commands.command()
     async def testupdateuserroles(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -312,7 +316,7 @@ class AdministrationCog(commands.Cog):
     async def testgetcorrectnextnumber(self, ctx: commands.Context, mode: int, numbers: int) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
-        await ctx.send("look in the console")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.console_check"))
         current_correct_number = get_first_number(mode)
         for i in range(numbers):
             print(f"i: {i}, current_correct_number: {current_correct_number}")
@@ -505,7 +509,7 @@ Das Tanjun-Team
             return
 
         me = ctx.guild.me  # type: ignore[union-attr]
-        await ctx.send(f"{me.name} {me.id} {me.mention}")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.me", name=me.name, id=me.id, mention=me.mention))
 
     @commands.command()
     async def permissionTest(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -517,7 +521,7 @@ Das Tanjun-Team
             or not ctx.channel.permissions_for(ctx.guild.me).read_message_history  # type: ignore[union-attr]
             or not ctx.channel.permissions_for(ctx.guild.me).manage_channels  # type: ignore[union-attr]
         )
-        await ctx.send(f"{permission_result}")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.permission_result", result=permission_result))
 
     @commands.command()
     async def permissionTest2(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
@@ -525,7 +529,7 @@ Das Tanjun-Team
             return
 
         permission_result = ctx.channel.permissions_for(ctx.guild.me).manage_messages  # type: ignore[union-attr]
-        await ctx.send(f"{permission_result}")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.permission_result", result=permission_result))
 
     @commands.command()
     async def listPermissions(self, ctx: commands.Context, channel: discord.TextChannel | None = None) -> None:  # type: ignore[type-arg]
@@ -539,7 +543,7 @@ Das Tanjun-Team
         permission_text = ""
         for permission in permission_result:
             permission_text += f"{permission}\n"
-        await ctx.send(f"{permission_text}")
+        await ctx.send(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.permission_list", permissions=permission_text))
 
     @commands.command()
     async def database_sync(self, ctx: commands.Context, url: str | None = None) -> None:  # type: ignore[type-arg]

--- a/locales/de.json
+++ b/locales/de.json
@@ -31790,5 +31790,245 @@
     "context": "Bug report prompt for unexpected errors",
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.starting",
+    "source_string": "Bot-Tests werden gestartet...",
+    "translation": "Bot-Tests werden gestartet...",
+    "context": "admin -> administration -> test_bot -> starting",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.tests_unavailable",
+    "source_string": "⚠️ Testfunktionen nicht verfügbar. Tests werden übersprungen.",
+    "translation": "⚠️ Testfunktionen nicht verfügbar. Tests werden übersprungen.",
+    "context": "admin -> administration -> test_bot -> tests_unavailable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_ping",
+    "source_string": "Bot-Tests werden gestartet...\naktueller Test: `Ping`",
+    "translation": "Bot-Tests werden gestartet...\naktueller Test: `Ping`",
+    "context": "admin -> administration -> test_bot -> current_test_ping",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_db",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\naktueller Test: `Datenbank`",
+    "translation": "Bot-Tests werden gestartet...\nPing Test: ✅\naktueller Test: `Datenbank`",
+    "context": "admin -> administration -> test_bot -> current_test_db",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_cmds",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\naktueller Test: `Befehle`",
+    "translation": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\naktueller Test: `Befehle`",
+    "context": "admin -> administration -> test_bot -> current_test_cmds",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.error",
+    "source_string": "❌ Fehler im ${test_name} Test: ${error}",
+    "translation": "❌ Fehler im ${test_name} Test: ${error}",
+    "context": "admin -> administration -> test_bot -> error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.all_completed",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\nBefehle Test: ✅\nAlle Tests erfolgreich abgeschlossen. Der Bot scheint einwandfrei zu funktionieren.",
+    "translation": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\nBefehle Test: ✅\nAlle Tests erfolgreich abgeschlossen. Der Bot scheint einwandfrei zu funktionieren.",
+    "context": "admin -> administration -> test_bot -> all_completed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.updating",
+    "source_string": "Aktualisiere...",
+    "translation": "Aktualisiere...",
+    "context": "admin -> administration -> update -> updating",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.http_error",
+    "source_string": "Fehler: Statuscode ${status} erhalten. Antwort: ${response}",
+    "translation": "Fehler: Statuscode ${status} erhalten. Antwort: ${response}",
+    "context": "admin -> administration -> update -> http_error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.connection_failed",
+    "source_string": "Verbindung zum Update-Dienst fehlgeschlagen: ${error}",
+    "translation": "Verbindung zum Update-Dienst fehlgeschlagen: ${error}",
+    "context": "admin -> administration -> update -> connection_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.set_guild_locale",
+    "source_string": "Die Server-Sprache wurde auf ${locale} gesetzt.",
+    "translation": "Die Server-Sprache wurde auf ${locale} gesetzt.",
+    "context": "admin -> administration -> set_guild_locale",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.me",
+    "source_string": "${name} ${id} ${mention}",
+    "translation": "${name} ${id} ${mention}",
+    "context": "admin -> administration -> me",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.permission_result",
+    "source_string": "${result}",
+    "translation": "${result}",
+    "context": "admin -> administration -> permission_result",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.permission_list",
+    "source_string": "${permissions}",
+    "translation": "${permissions}",
+    "context": "admin -> administration -> permission_list",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.github_auth_test",
+    "source_string": "jup gemacht :)",
+    "translation": "jup gemacht :)",
+    "context": "admin -> administration -> github_auth_test",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.console_check",
+    "source_string": "schau in die Konsole",
+    "translation": "schau in die Konsole",
+    "context": "admin -> administration -> console_check",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_download_failed",
+    "source_string": "Download fehlgeschlagen: ${status} für ${name}",
+    "translation": "Download fehlgeschlagen: ${status} für ${name}",
+    "context": "admin -> administration -> bs_download_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_emoji_created",
+    "source_string": "${emoji} ${name}; i:${index}",
+    "translation": "${emoji} ${name}; i:${index}",
+    "context": "admin -> administration -> bs_emoji_created",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_emoji_failed",
+    "source_string": "Emoji-Erstellung für ${name} fehlgeschlagen: ${error}",
+    "translation": "Emoji-Erstellung für ${name} fehlgeschlagen: ${error}",
+    "context": "admin -> administration -> bs_emoji_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_bot_info",
+    "source_string": "JSON-Daten für Bot-Konto",
+    "translation": "JSON-Daten für Bot-Konto",
+    "context": "admin -> administration -> bs_bot_info",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_not_found",
+    "source_string": "Situation wurde denke gelöscht oder so :/",
+    "translation": "Situation wurde denke gelöscht oder so :/",
+    "context": "admin -> administration -> situation_not_found",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_creator_gone",
+    "source_string": "Der typ der die Situation erstellt hat ist nicht mehr am tanjun nutzen :c",
+    "translation": "Der typ der die Situation erstellt hat ist nicht mehr am tanjun nutzen :c",
+    "context": "admin -> administration -> situation_creator_gone",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_approved",
+    "source_string": "Situation wurde freigeschaltet!",
+    "translation": "Situation wurde freigeschaltet!",
+    "context": "admin -> administration -> situation_approved",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_deleted",
+    "source_string": "Situation wurde gelöscht!",
+    "translation": "Situation wurde gelöscht!",
+    "context": "admin -> administration -> situation_deleted",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.embed.modals.removeFieldModal.fieldLabel",
+    "source_string": "Feld ${number}",
+    "translation": "Feld ${number}",
+    "context": "admin -> embed -> modals -> removeFieldModal -> fieldLabel",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.warn.reason.reached_warnings",
+    "source_string": "${count} Verwarnungen erreicht",
+    "translation": "${count} Verwarnungen erreicht",
+    "context": "admin -> warn -> reason -> reached_warnings",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.not_clickable",
+    "source_string": "das sollte nicht klickbar sein??",
+    "translation": "das sollte nicht klickbar sein??",
+    "context": "math -> plot_function -> not_clickable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.no_functions_to_rename",
+    "source_string": "Es gibt keine Funktionen zum Umbenennen.",
+    "translation": "Es gibt keine Funktionen zum Umbenennen.",
+    "context": "math -> plot_function -> no_functions_to_rename",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.error",
+    "source_string": "Fehler: ${error}",
+    "translation": "Fehler: ${error}",
+    "context": "math -> plot_function -> error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.unexpected_error",
+    "source_string": "Ein unerwarteter Fehler ist aufgetreten: ${error}",
+    "translation": "Ein unerwarteter Fehler ist aufgetreten: ${error}",
+    "context": "math -> plot_function -> unexpected_error",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -31838,5 +31838,245 @@
     "context": "Bug report prompt for unexpected errors",
     "labels": "unassigned",
     "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.starting",
+    "source_string": "Bot-Tests werden gestartet...",
+    "translation": "Starting bot tests...",
+    "context": "admin -> administration -> test_bot -> starting",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.tests_unavailable",
+    "source_string": "⚠️ Testfunktionen nicht verfügbar. Tests werden übersprungen.",
+    "translation": "⚠️ Test functions not available. Skipping tests.",
+    "context": "admin -> administration -> test_bot -> tests_unavailable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_ping",
+    "source_string": "Bot-Tests werden gestartet...\naktueller Test: `Ping`",
+    "translation": "Starting bot tests...\ncurrent Test: `Ping`",
+    "context": "admin -> administration -> test_bot -> current_test_ping",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_db",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\naktueller Test: `Datenbank`",
+    "translation": "Starting bot tests...\nPing Test: ✅\ncurrent Test: `Database`",
+    "context": "admin -> administration -> test_bot -> current_test_db",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.current_test_cmds",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\naktueller Test: `Befehle`",
+    "translation": "Starting bot tests...\nPing Test: ✅\nDatabase Test: ✅\ncurrent Test: `Commands`",
+    "context": "admin -> administration -> test_bot -> current_test_cmds",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.error",
+    "source_string": "❌ Fehler im ${test_name} Test: ${error}",
+    "translation": "❌ Error in ${test_name} test: ${error}",
+    "context": "admin -> administration -> test_bot -> error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.test_bot.all_completed",
+    "source_string": "Bot-Tests werden gestartet...\nPing Test: ✅\nDatenbank Test: ✅\nBefehle Test: ✅\nAlle Tests erfolgreich abgeschlossen. Der Bot scheint einwandfrei zu funktionieren.",
+    "translation": "Starting bot tests...\nPing Test: ✅\nDatabase Test: ✅\nCommands Test: ✅\nAll tests completed successfully. The bot seems to be working fine.",
+    "context": "admin -> administration -> test_bot -> all_completed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.updating",
+    "source_string": "Aktualisiere...",
+    "translation": "Updating...",
+    "context": "admin -> administration -> update -> updating",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.http_error",
+    "source_string": "Fehler: Statuscode ${status} erhalten. Antwort: ${response}",
+    "translation": "Error: Received status code ${status}. Response: ${response}",
+    "context": "admin -> administration -> update -> http_error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.update.connection_failed",
+    "source_string": "Verbindung zum Update-Dienst fehlgeschlagen: ${error}",
+    "translation": "Failed to connect to update service: ${error}",
+    "context": "admin -> administration -> update -> connection_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.set_guild_locale",
+    "source_string": "Die Server-Sprache wurde auf ${locale} gesetzt.",
+    "translation": "The guild locale has been set to ${locale}",
+    "context": "admin -> administration -> set_guild_locale",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.me",
+    "source_string": "${name} ${id} ${mention}",
+    "translation": "${name} ${id} ${mention}",
+    "context": "admin -> administration -> me",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.permission_result",
+    "source_string": "${result}",
+    "translation": "${result}",
+    "context": "admin -> administration -> permission_result",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.permission_list",
+    "source_string": "${permissions}",
+    "translation": "${permissions}",
+    "context": "admin -> administration -> permission_list",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.github_auth_test",
+    "source_string": "jup gemacht :)",
+    "translation": "jup gemacht :)",
+    "context": "admin -> administration -> github_auth_test",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.console_check",
+    "source_string": "schau in die Konsole",
+    "translation": "look in the console",
+    "context": "admin -> administration -> console_check",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_download_failed",
+    "source_string": "Download fehlgeschlagen: ${status} für ${name}",
+    "translation": "Download failed: ${status} for ${name}",
+    "context": "admin -> administration -> bs_download_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_emoji_created",
+    "source_string": "${emoji} ${name}; i:${index}",
+    "translation": "${emoji} ${name}; i:${index}",
+    "context": "admin -> administration -> bs_emoji_created",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_emoji_failed",
+    "source_string": "Emoji-Erstellung für ${name} fehlgeschlagen: ${error}",
+    "translation": "Failed to create emoji for ${name}: ${error}",
+    "context": "admin -> administration -> bs_emoji_failed",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.bs_bot_info",
+    "source_string": "JSON-Daten für Bot-Konto",
+    "translation": "Bot account JSON data",
+    "context": "admin -> administration -> bs_bot_info",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_not_found",
+    "source_string": "Situation wurde denke gelöscht oder so :/",
+    "translation": "The situation was probably deleted or something :/",
+    "context": "admin -> administration -> situation_not_found",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_creator_gone",
+    "source_string": "Der typ der die Situation erstellt hat ist nicht mehr am tanjun nutzen :c",
+    "translation": "The person who created the situation is no longer using Tanjun :c",
+    "context": "admin -> administration -> situation_creator_gone",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_approved",
+    "source_string": "Situation wurde freigeschaltet!",
+    "translation": "Situation has been unlocked!",
+    "context": "admin -> administration -> situation_approved",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.administration.situation_deleted",
+    "source_string": "Situation wurde gelöscht!",
+    "translation": "Situation has been deleted!",
+    "context": "admin -> administration -> situation_deleted",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.embed.modals.removeFieldModal.fieldLabel",
+    "source_string": "Feld ${number}",
+    "translation": "Field ${number}",
+    "context": "admin -> embed -> modals -> removeFieldModal -> fieldLabel",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.warn.reason.reached_warnings",
+    "source_string": "${count} Verwarnungen erreicht",
+    "translation": "Reached ${count} warnings",
+    "context": "admin -> warn -> reason -> reached_warnings",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.not_clickable",
+    "source_string": "das sollte nicht klickbar sein??",
+    "translation": "this should not be clickable??",
+    "context": "math -> plot_function -> not_clickable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.no_functions_to_rename",
+    "source_string": "Es gibt keine Funktionen zum Umbenennen.",
+    "translation": "There are no functions to rename.",
+    "context": "math -> plot_function -> no_functions_to_rename",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.error",
+    "source_string": "Fehler: ${error}",
+    "translation": "Error: ${error}",
+    "context": "math -> plot_function -> error",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.math.plot_function.unexpected_error",
+    "source_string": "Ein unerwarteter Fehler ist aufgetreten: ${error}",
+    "translation": "An unexpected error occurred: ${error}",
+    "context": "math -> plot_function -> unexpected_error",
+    "labels": "unassigned",
+    "max_length": null
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -31922,7 +31922,7 @@
   {
     "identifier": "commands.admin.administration.set_guild_locale",
     "source_string": "Die Server-Sprache wurde auf ${locale} gesetzt.",
-    "translation": "The guild locale has been set to ${locale}",
+    "translation": "The guild locale has been set to ${locale}.",
     "context": "admin -> administration -> set_guild_locale",
     "labels": "unassigned",
     "max_length": null


### PR DESCRIPTION
## Summary

Fixes #1327 by localizing all hardcoded user-facing strings across the codebase.

## Changes

### extensions/administration.py
- test_bot command: All test progress/error messages now use translation keys
- update command: "Updating...", error messages localized
- setguildlocale: Response message localized
- testgithubauthtoken: localized
- testgetcorrectnextnumber: localized
- Brawl Stars emoji commands: download/creation/error messages localized
- me, permissionTest, permissionTest2, listPermissions: responses localized

### commands/ai/add_custom_situation_button_handler.py
- All hardcoded German strings now use translation keys

### commands/games/akinator.py
- lastAnswer uses existing localization key

### commands/admin/warn.py
- Audit log reasons for ban/kick/timeout now localized

### commands/admin/embedcreator.py
- SelectOption label now localized

### commands/math/plot_function.py
- Error messages and button texts now localized

### locales
- Added 29 new translation keys to both en.json and de.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded localization: many admin commands, moderation warnings, games, math tools, embeds/modals, and emoji flows now show localized messages.
  * Added German and English translation entries for status, errors, confirmations, and UI labels.
  * Interaction responses and error feedback are now presented in the configured locale for clearer user-facing text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->