### PR TITLE
fix(#1300): Convert CommandInfo to Pydantic BaseModel

### DIFF
--- a/utility.py
+++ b/utility.py
@@ -866,7 +866,7 @@ class CommandInfo(BaseModel):
     client: discord.Client
 
 
-command_info = CommandInfo()
+command_info: type[CommandInfo] = CommandInfo
 
 
 def cmp(a: int, b: int) -> int:

--- a/utility.py
+++ b/utility.py
@@ -18,6 +18,8 @@ from collections.abc import Callable, Coroutine, Mapping
 from difflib import SequenceMatcher
 from typing import Any, Protocol, Self, TypeVar
 
+from pydantic import BaseModel, ConfigDict
+
 import aiohttp
 import discord
 from aiohttp import ClientTimeout
@@ -850,31 +852,21 @@ class TanjunEmbed:
         return result  # type: ignore # This payload is equivalent to the EmbedData type
 
 
-class CommandInfo:
-    def __init__(
-        self,
-        user: discord.abc.User,
-        channel: discord.abc.GuildChannel,
-        guild: discord.Guild,
-        command: discord.app_commands.Command,
-        locale: str,
-        message: discord.Message,
-        permissions: discord.Permissions,
-        reply: Callable[..., Coroutine[Any, Any, Any]],
-        client: discord.Client,
-    ):
-        self.user = user
-        self.channel = channel
-        self.guild = guild
-        self.command = command
-        self.locale = locale
-        self.message = message
-        self.permissions = permissions
-        self.reply = reply
-        self.client = client
+class CommandInfo(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    user: discord.abc.User
+    channel: discord.abc.GuildChannel
+    guild: discord.Guild
+    command: discord.app_commands.Command
+    locale: discord.Locale
+    message: discord.Message | None = None
+    permissions: discord.Permissions = discord.Permissions()
+    reply: Callable[..., Coroutine[Any, Any, Any]] | None = None
+    client: discord.Client
 
 
-command_info = CommandInfo
+command_info = CommandInfo()
 
 
 def cmp(a: int, b: int) -> int:


### PR DESCRIPTION
## Summary

Converts the `CommandInfo` class in `utility.py` from a plain Python class with `__init__` to a Pydantic `BaseModel` with proper type annotations and validation.

## Changes

- **`utility.py`**: Replaced manual `__init__` with Pydantic fields
- Added `model_config = ConfigDict(arbitrary_types_allowed=True)` for Discord library types
- Changed `locale` type from `str` to `discord.Locale`
- Made `message` optional (`discord.Message | None = None`)
- Made `reply` optional (`Callable[..., Coroutine[...]] | None = None`)
- Made `permissions` optional with default `discord.Permissions()`
- Fixed `command_info` module-level alias: now an instance (`CommandInfo()`) instead of the class reference

Closes #1300

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal command metadata handling revamped for more robust defaults and optional message/reply behavior, improving reliability.
* **Chores**
  * Under-the-hood dependency and model updates to support the new metadata handling.
* **Notes**
  * No user-facing changes; existing commands should behave the same.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->