### PR TITLE
feat(#1304): Consolidate booster channel/role CRUD into BoosterService class

### DIFF
--- a/api.py
+++ b/api.py
@@ -2331,105 +2331,95 @@ async def feedbackIsBlocked(user_id: str) -> bool:
 
 
 async def add_booster_channel(guild_id: str, channel_id: str) -> None:
-    query = "INSERT INTO booster_channel (guild_id, channel_id) VALUES (%s, %s)"
-    params = (guild_id, channel_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    await booster_service.add(BoosterType.CHANNEL, guild_id, channel_id)
 
 
 async def delete_booster_channel(guild_id: str, channel_id: str) -> None:
-    query = "DELETE FROM booster_channel WHERE guild_id = %s AND channel_id = %s"
-    params = (guild_id, channel_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    await booster_service.delete(BoosterType.CHANNEL, guild_id, entity_id=channel_id)
 
 
 async def get_booster_channel(guild_id: str) -> str | None:
-    query = "SELECT channel_id FROM booster_channel WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    return await booster_service.get(BoosterType.CHANNEL, guild_id)
 
 
 async def claim_booster_channel(user_id: str, channel_id: str, guild_id: str) -> None:
-    query = "INSERT INTO claimedBoosterChannel (user_id, channel_id, guild_id) VALUES (%s, %s, %s)"
-    params = (user_id, channel_id, guild_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
+    await booster_service.claim(ClaimedBoosterType.CHANNEL, user_id, channel_id, guild_id)
 
 
 async def remove_claimed_booster_channel(user_id: str, guild_id: str) -> None:
-    query = "DELETE FROM claimedBoosterChannel WHERE user_id = %s AND guild_id = %s"
-    params = (user_id, guild_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
+    await booster_service.unclaim(ClaimedBoosterType.CHANNEL, user_id, guild_id)
 
 
 async def get_claimed_booster_channel(
     user_id: str | None = None, guild_id: str | None = None
 ) -> str | list[ClaimedBoosterChannelModel] | None:
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
     if user_id:
-        query = (
-            "SELECT channel_id FROM claimedBoosterChannel WHERE user_id = %s AND guild_id = %s"
-            if guild_id
-            else "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel WHERE user_id = %s"
-        )
-        params = (user_id, guild_id) if guild_id else (user_id,)
-        result = await safe_execute_query(query, params)
-        if not result:
-            return None
-        return result[0][0] if guild_id else [ClaimedBoosterChannelModel.from_row(row) for row in result]
-    else:
-        query = "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel"
-        result = await safe_execute_query(query)
-        return [ClaimedBoosterChannelModel.from_row(row) for row in result]
+        return await booster_service.get_user_claims(ClaimedBoosterType.CHANNEL, user_id) or None
+    return await booster_service.get_all_claims(ClaimedBoosterType.CHANNEL) or None
 
 
 async def add_booster_role(guild_id: str, role_id: str) -> None:
-    query = "INSERT INTO boosterRole (guild_id, role_id) VALUES (%s, %s)"
-    params = (guild_id, role_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    await booster_service.add(BoosterType.ROLE, guild_id, role_id)
 
 
 async def get_booster_role(guild_id: str) -> str | None:
-    query = "SELECT role_id FROM boosterRole WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    return result[0][0] if result else None
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    return await booster_service.get(BoosterType.ROLE, guild_id)
 
 
 async def delete_booster_role(guild_id: str) -> None:
-    query = "DELETE FROM boosterRole WHERE guild_id = %s"
-    params = (guild_id,)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import BoosterType, booster_service
+
+    await booster_service.delete(BoosterType.ROLE, guild_id)
 
 
 async def add_claimed_booster_role(user_id: str, role_id: str, guild_id: str) -> None:
-    query = "INSERT INTO claimedBoosterRole (user_id, role_id, guild_id) VALUES (%s, %s, %s)"
-    params = (user_id, role_id, guild_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
+    await booster_service.claim(ClaimedBoosterType.ROLE, user_id, role_id, guild_id)
 
 
 async def remove_claimed_booster_role(user_id: str, guild_id: str) -> None:
-    query = "DELETE FROM claimedBoosterRole WHERE user_id = %s AND guild_id = %s"
-    params = (user_id, guild_id)
-    await execute_action(query, params)
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
+    await booster_service.unclaim(ClaimedBoosterType.ROLE, user_id, guild_id)
 
 
 async def get_claimed_booster_role(
     user_id: str | None = None, guild_id: str | None = None
 ) -> str | list[ClaimedBoosterRoleModel] | None:
+    """Backward-compatible wrapper around BoosterService."""
+    from services.booster_service import ClaimedBoosterType, booster_service
+
     if user_id:
-        query = (
-            "SELECT role_id FROM claimedBoosterRole WHERE user_id = %s AND guild_id = %s"
-            if guild_id
-            else "SELECT user_id, role_id, guild_id FROM claimedBoosterRole WHERE user_id = %s"
-        )
-        params = (user_id, guild_id) if guild_id else (user_id,)
-        result = await safe_execute_query(query, params)
-        if not result:
-            return None
-        return result[0][0] if guild_id else [ClaimedBoosterRoleModel.from_row(row) for row in result]
-    else:
-        query = "SELECT user_id, role_id, guild_id FROM claimedBoosterRole"
-        result = await safe_execute_query(query)
-        return [ClaimedBoosterRoleModel.from_row(row) for row in result]
+        return await booster_service.get_user_claims(ClaimedBoosterType.ROLE, user_id) or None
+    return await booster_service.get_all_claims(ClaimedBoosterType.ROLE) or None
 
 
 async def set_log_channel(guild_id: str, channel_id: str) -> None:

--- a/api.py
+++ b/api.py
@@ -2372,7 +2372,14 @@ async def get_claimed_booster_channel(
     from services.booster_service import ClaimedBoosterType, booster_service
 
     if user_id:
-        return await booster_service.get_user_claims(ClaimedBoosterType.CHANNEL, user_id) or None
+        claims = await booster_service.get_user_claims(ClaimedBoosterType.CHANNEL, user_id)
+        if guild_id:
+            # Filter to the specific guild and return the channel_id or None
+            for claim in claims:
+                if claim.guild_id == guild_id:
+                    return claim.channel_id
+            return None
+        return claims or None
     return await booster_service.get_all_claims(ClaimedBoosterType.CHANNEL) or None
 
 
@@ -2418,7 +2425,14 @@ async def get_claimed_booster_role(
     from services.booster_service import ClaimedBoosterType, booster_service
 
     if user_id:
-        return await booster_service.get_user_claims(ClaimedBoosterType.ROLE, user_id) or None
+        claims = await booster_service.get_user_claims(ClaimedBoosterType.ROLE, user_id)
+        if guild_id:
+            # Filter to the specific guild and return the role_id or None
+            for claim in claims:
+                if claim.guild_id == guild_id:
+                    return claim.role_id
+            return None
+        return claims or None
     return await booster_service.get_all_claims(ClaimedBoosterType.ROLE) or None
 
 

--- a/commands/admin/boosterrole.py
+++ b/commands/admin/boosterrole.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import add_booster_role, delete_booster_role
+from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
 
 
@@ -41,7 +41,7 @@ async def create_booster_role(command_info: utility.CommandInfo, role: discord.R
         return
 
     if role is None:
-        await delete_booster_role(command_info.guild.id)
+        await booster_service.delete(BoosterType.ROLE, str(command_info.guild.id))
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.boosterRole.roleRemoved.title"),
             description=tanjunLocalizer.localize(
@@ -80,7 +80,7 @@ async def create_booster_role(command_info: utility.CommandInfo, role: discord.R
         return
 
     try:
-        await add_booster_role(str(command_info.guild.id), str(role.id))
+        await booster_service.add(BoosterType.ROLE, str(command_info.guild.id), str(role.id))
         if role.permissions.administrator:
             embed = utility.tanjunEmbed(
                 title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.boosterRole.success.title"),

--- a/commands/utility/claim_booster_channel.py
+++ b/commands/utility/claim_booster_channel.py
@@ -1,7 +1,7 @@
 import discord
 
-from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from utility import command_info, tanjunEmbed
 
 
@@ -35,7 +35,9 @@ async def claimBoosterChannel(command_info: command_info, name: str):
         await command_info.reply(embed=embed)
         return
 
-    claimed_booster_channel = await booster_service.get_user_claims(ClaimedBoosterType.CHANNEL, str(command_info.user.id))
+    claimed_booster_channel = await booster_service.get_claim_for_user(
+        ClaimedBoosterType.CHANNEL, str(command_info.user.id), str(command_info.guild.id)
+    )
     if claimed_booster_channel:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -73,7 +75,9 @@ async def claimBoosterChannel(command_info: command_info, name: str):
     new_channel = await command_info.guild.create_voice_channel(
         name=name, reason=reason, category=channel, overwrites=overwrites
     )
-    await booster_service.claim(ClaimedBoosterType.CHANNEL, str(command_info.user.id), str(new_channel.id), str(command_info.guild.id))
+    await booster_service.claim(
+        ClaimedBoosterType.CHANNEL, str(command_info.user.id), str(new_channel.id), str(command_info.guild.id)
+    )
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(command_info.locale, "commands.utility.claimboosterchannel.success.title"),
         description=tanjunLocalizer.localize(
@@ -88,10 +92,20 @@ async def remove_claimed_booster_channels_that_are_expired(client: discord.Clien
     claimed_booster_channels = await booster_service.get_all_claims(ClaimedBoosterType.CHANNEL)
     for entry in claimed_booster_channels:
         guild = client.get_guild(int(entry.guild_id))
+        if not guild:
+            # Guild no longer exists, clean up the claim
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(entry.user_id), str(entry.guild_id))
+            continue
+
         user = guild.get_member(int(entry.user_id))
+        if not user:
+            # User no longer in guild, clean up the claim
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(entry.user_id), str(entry.guild_id))
+            continue
+
         channel = guild.get_channel(int(entry.channel_id))
         if not user.premium_since and channel:
-            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(user.id), str(entry.guild_id))
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(entry.user_id), str(entry.guild_id))
             await channel.delete(
                 reason=tanjunLocalizer.localize(
                     guild.preferred_locale if hasattr(guild, "preferred_locale") else "en_US",
@@ -99,4 +113,4 @@ async def remove_claimed_booster_channels_that_are_expired(client: discord.Clien
                 )
             )
         if not channel:
-            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(user.id), str(entry.guild_id))
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(entry.user_id), str(entry.guild_id))

--- a/commands/utility/claim_booster_channel.py
+++ b/commands/utility/claim_booster_channel.py
@@ -1,17 +1,12 @@
 import discord
 
-from api import (
-    claim_booster_channel,
-    get_booster_channel,
-    get_claimed_booster_channel,
-    remove_claimed_booster_channel,
-)
+from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import command_info, tanjunEmbed
 
 
 async def claimBoosterChannel(command_info: command_info, name: str):
-    booster_channel = await get_booster_channel(command_info.guild.id)
+    booster_channel = await booster_service.get(BoosterType.CHANNEL, str(command_info.guild.id))
     if not booster_channel:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -40,7 +35,7 @@ async def claimBoosterChannel(command_info: command_info, name: str):
         await command_info.reply(embed=embed)
         return
 
-    claimed_booster_channel = await get_claimed_booster_channel(command_info.user.id)
+    claimed_booster_channel = await booster_service.get_user_claims(ClaimedBoosterType.CHANNEL, str(command_info.user.id))
     if claimed_booster_channel:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -78,7 +73,7 @@ async def claimBoosterChannel(command_info: command_info, name: str):
     new_channel = await command_info.guild.create_voice_channel(
         name=name, reason=reason, category=channel, overwrites=overwrites
     )
-    await claim_booster_channel(command_info.user.id, new_channel.id, command_info.guild.id)
+    await booster_service.claim(ClaimedBoosterType.CHANNEL, str(command_info.user.id), str(new_channel.id), str(command_info.guild.id))
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(command_info.locale, "commands.utility.claimboosterchannel.success.title"),
         description=tanjunLocalizer.localize(
@@ -90,13 +85,13 @@ async def claimBoosterChannel(command_info: command_info, name: str):
 
 
 async def remove_claimed_booster_channels_that_are_expired(client: discord.Client):
-    claimed_booster_channels = await get_claimed_booster_channel()
+    claimed_booster_channels = await booster_service.get_all_claims(ClaimedBoosterType.CHANNEL)
     for entry in claimed_booster_channels:
         guild = client.get_guild(int(entry.guild_id))
         user = guild.get_member(int(entry.user_id))
         channel = guild.get_channel(int(entry.channel_id))
         if not user.premium_since and channel:
-            await remove_claimed_booster_channel(user.id, entry.guild_id)
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(user.id), str(entry.guild_id))
             await channel.delete(
                 reason=tanjunLocalizer.localize(
                     guild.preferred_locale if hasattr(guild, "preferred_locale") else "en_US",
@@ -104,4 +99,4 @@ async def remove_claimed_booster_channels_that_are_expired(client: discord.Clien
                 )
             )
         if not channel:
-            await remove_claimed_booster_channel(user.id, entry.guild_id)
+            await booster_service.unclaim(ClaimedBoosterType.CHANNEL, str(user.id), str(entry.guild_id))

--- a/commands/utility/claim_booster_role.py
+++ b/commands/utility/claim_booster_role.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from utility import command_info, tanjunEmbed
 
 
@@ -33,7 +33,9 @@ async def claimBoosterRole(command_info: command_info, name: str, color: discord
         await command_info.reply(embed=embed)
         return
 
-    claimed_booster_role = await booster_service.get_user_claims(ClaimedBoosterType.ROLE, str(command_info.user.id))
+    claimed_booster_role = await booster_service.get_claim_for_user(
+        ClaimedBoosterType.ROLE, str(command_info.user.id), str(command_info.guild.id)
+    )
     if claimed_booster_role:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -91,7 +93,9 @@ async def claimBoosterRole(command_info: command_info, name: str, color: discord
         reason=reason,
     )
     await new_role.edit(position=role.position + 1)
-    await booster_service.claim(ClaimedBoosterType.ROLE, str(command_info.user.id), str(new_role.id), str(command_info.guild.id))
+    await booster_service.claim(
+        ClaimedBoosterType.ROLE, str(command_info.user.id), str(new_role.id), str(command_info.guild.id)
+    )
     await command_info.user.add_roles(new_role)
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(command_info.locale, "commands.utility.claimboosterrole.success.title"),
@@ -104,16 +108,23 @@ async def remove_claimed_booster_roles_that_are_expired(client: discord.Client):
     claimed_booster_roles = await booster_service.get_all_claims(ClaimedBoosterType.ROLE)
     for entry in claimed_booster_roles:
         guild = client.get_guild(int(entry.guild_id))
+        if not guild:
+            # Guild no longer exists, clean up the claim
+            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(entry.user_id), str(entry.guild_id))
+            continue
+
         user = guild.get_member(int(entry.user_id))
         role = guild.get_role(int(entry.role_id))
-        if not user.premium_since and role:
+
+        if user and role and not user.premium_since:
             await user.remove_roles(role)
-            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(user.id), str(entry.guild_id))
+            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(entry.user_id), str(entry.guild_id))
             await role.delete(
                 reason=tanjunLocalizer.localize(
                     guild.preferred_locale if hasattr(guild, "preferred_locale") else "en_US",
                     "commands.utility.claimboosterrole.expired.reason",
                 )
             )
-        if not role:
-            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(user.id), str(entry.guild_id))
+        elif not user or not role:
+            # User or role no longer exists, clean up the claim
+            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(entry.user_id), str(entry.guild_id))

--- a/commands/utility/claim_booster_role.py
+++ b/commands/utility/claim_booster_role.py
@@ -1,18 +1,13 @@
 import discord
 
 import utility
-from api import (
-    add_claimed_booster_role,
-    get_booster_role,
-    get_claimed_booster_role,
-    remove_claimed_booster_role,
-)
+from services.booster_service import BoosterType, ClaimedBoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import command_info, tanjunEmbed
 
 
 async def claimBoosterRole(command_info: command_info, name: str, color: discord.Color, icon: discord.Attachment):
-    booster_role = await get_booster_role(command_info.guild.id)
+    booster_role = await booster_service.get(BoosterType.ROLE, str(command_info.guild.id))
     if not booster_role:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -38,7 +33,7 @@ async def claimBoosterRole(command_info: command_info, name: str, color: discord
         await command_info.reply(embed=embed)
         return
 
-    claimed_booster_role = await get_claimed_booster_role(command_info.user.id)
+    claimed_booster_role = await booster_service.get_user_claims(ClaimedBoosterType.ROLE, str(command_info.user.id))
     if claimed_booster_role:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -96,7 +91,7 @@ async def claimBoosterRole(command_info: command_info, name: str, color: discord
         reason=reason,
     )
     await new_role.edit(position=role.position + 1)
-    await add_claimed_booster_role(command_info.user.id, new_role.id, command_info.guild.id)
+    await booster_service.claim(ClaimedBoosterType.ROLE, str(command_info.user.id), str(new_role.id), str(command_info.guild.id))
     await command_info.user.add_roles(new_role)
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(command_info.locale, "commands.utility.claimboosterrole.success.title"),
@@ -106,14 +101,14 @@ async def claimBoosterRole(command_info: command_info, name: str, color: discord
 
 
 async def remove_claimed_booster_roles_that_are_expired(client: discord.Client):
-    claimed_booster_roles = await get_claimed_booster_role()
+    claimed_booster_roles = await booster_service.get_all_claims(ClaimedBoosterType.ROLE)
     for entry in claimed_booster_roles:
         guild = client.get_guild(int(entry.guild_id))
         user = guild.get_member(int(entry.user_id))
         role = guild.get_role(int(entry.role_id))
         if not user.premium_since and role:
             await user.remove_roles(role)
-            await remove_claimed_booster_role(user.id, entry.guild_id)
+            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(user.id), str(entry.guild_id))
             await role.delete(
                 reason=tanjunLocalizer.localize(
                     guild.preferred_locale if hasattr(guild, "preferred_locale") else "en_US",
@@ -121,4 +116,4 @@ async def remove_claimed_booster_roles_that_are_expired(client: discord.Client):
                 )
             )
         if not role:
-            await remove_claimed_booster_role(user.id, entry.guild_id)
+            await booster_service.unclaim(ClaimedBoosterType.ROLE, str(user.id), str(entry.guild_id))

--- a/commands/utility/delete_booster_channel.py
+++ b/commands/utility/delete_booster_channel.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import delete_booster_channel, get_booster_channel
+from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
@@ -52,7 +52,7 @@ async def deleteBoosterChannel(command_info: CommandInfo) -> None:
         await command_info.reply(embed=embed)
         return
 
-    booster_channel = await get_booster_channel(command_info.guild.id)
+    booster_channel = await booster_service.get(BoosterType.CHANNEL, str(command_info.guild.id))
     if not booster_channel:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -67,7 +67,7 @@ async def deleteBoosterChannel(command_info: CommandInfo) -> None:
         await command_info.reply(embed=embed)
         return
 
-    await delete_booster_channel(command_info.guild.id, booster_channel)
+    await booster_service.delete(BoosterType.CHANNEL, str(command_info.guild.id), entity_id=booster_channel)
 
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.deleteboosterchannel.success.title"),

--- a/commands/utility/delete_booster_role.py
+++ b/commands/utility/delete_booster_role.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import delete_booster_role, get_booster_role
+from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
@@ -52,7 +52,7 @@ async def deleteBoosterRole(command_info: CommandInfo) -> None:
         await command_info.reply(embed=embed)
         return
 
-    booster_role = await get_booster_role(command_info.guild.id)
+    booster_role = await booster_service.get(BoosterType.ROLE, str(command_info.guild.id))
     if not booster_role:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -67,7 +67,7 @@ async def deleteBoosterRole(command_info: CommandInfo) -> None:
         await command_info.reply(embed=embed)
         return
 
-    await delete_booster_role(command_info.guild.id)
+    await booster_service.delete(BoosterType.ROLE, str(command_info.guild.id))
 
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.deleteboosterrole.success.title"),

--- a/commands/utility/setup_booster_channel.py
+++ b/commands/utility/setup_booster_channel.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import add_booster_channel, get_booster_channel
+from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
@@ -35,7 +35,7 @@ async def setupBoosterChannel(command_info: CommandInfo, category: discord.Categ
         await command_info.reply(embed=embed)
         return
 
-    booster_channel = await get_booster_channel(command_info.guild.id)
+    booster_channel = await booster_service.get(BoosterType.CHANNEL, str(command_info.guild.id))
     if booster_channel:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -50,7 +50,7 @@ async def setupBoosterChannel(command_info: CommandInfo, category: discord.Categ
         await command_info.reply(embed=embed)
         return
 
-    await add_booster_channel(command_info.guild.id, category.id)
+    await booster_service.add(BoosterType.CHANNEL, str(command_info.guild.id), str(category.id))
 
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.setupboosterchannel.success.title"),

--- a/commands/utility/setup_booster_role.py
+++ b/commands/utility/setup_booster_role.py
@@ -1,7 +1,7 @@
 import discord
 
 import utility
-from api import add_booster_role, get_booster_role
+from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
 
@@ -35,7 +35,7 @@ async def setupBoosterRole(command_info: CommandInfo, role: discord.Role) -> Non
         await command_info.reply(embed=embed)
         return
 
-    booster_role = await get_booster_role(command_info.guild.id)
+    booster_role = await booster_service.get(BoosterType.ROLE, str(command_info.guild.id))
     if booster_role:
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -50,7 +50,7 @@ async def setupBoosterRole(command_info: CommandInfo, role: discord.Role) -> Non
         await command_info.reply(embed=embed)
         return
 
-    await add_booster_role(command_info.guild.id, role.id)
+    await booster_service.add(BoosterType.ROLE, str(command_info.guild.id), str(role.id))
 
     embed = tanjunEmbed(
         title=tanjunLocalizer.localize(str(command_info.locale), "commands.utility.setupboosterrole.success.title"),

--- a/services/booster_service.py
+++ b/services/booster_service.py
@@ -1,0 +1,160 @@
+"""
+BoosterService: Consolidate booster channel/role CRUD into a single service.
+
+Consolidates 10 loose functions from api.py (add_booster_channel, delete_booster_channel,
+get_booster_channel, claim_booster_channel, remove_claimed_booster_channel,
+get_claimed_booster_channel, add_booster_role, get_booster_role, delete_booster_role,
+add_claimed_booster_role, remove_claimed_booster_role, get_claimed_booster_role)
+into a single BoosterService class with Pydantic-validated parameter models.
+
+Fixes the get_claimed_* anti-pattern where the return type was str | list[Model] | None
+depending on parameters — split into typed methods.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from api import execute_action, execute_query, safe_execute_query
+from models import ClaimedBoosterChannelModel, ClaimedBoosterRoleModel
+
+
+class BoosterType(Enum):
+    """Primary booster entity tables."""
+
+    CHANNEL = "booster_channel"
+    ROLE = "boosterRole"
+
+
+class ClaimedBoosterType(Enum):
+    """Claimed booster entity tables."""
+
+    CHANNEL = "claimedBoosterChannel"
+    ROLE = "claimedBoosterRole"
+
+
+class BoosterService:
+    """Consolidated CRUD for booster channels and roles.
+
+    Usage:
+        service = BoosterService()
+        await service.add(BoosterType.CHANNEL, guild_id="123", entity_id="456")
+        channel_id = await service.get(BoosterType.CHANNEL, guild_id="123")
+        await service.claim(ClaimedBoosterType.CHANNEL, user_id="789", entity_id="456", guild_id="123")
+    """
+
+    # ------------------------------------------------------------------ #
+    # Primary entity operations (booster_channel, boosterRole)
+    # ------------------------------------------------------------------ #
+
+    async def add(self, booster_type: BoosterType, guild_id: str, entity_id: str) -> None:
+        """Insert a booster channel or role for a guild."""
+        id_column = "channel_id" if booster_type == BoosterType.CHANNEL else "role_id"
+        query = f"INSERT INTO {booster_type.value} (guild_id, {id_column}) VALUES (%s, %s)"
+        await execute_action(query, (guild_id, entity_id))
+
+    async def get(self, booster_type: BoosterType, guild_id: str) -> str | None:
+        """Get the entity_id for a booster channel or role in a guild."""
+        id_column = "channel_id" if booster_type == BoosterType.CHANNEL else "role_id"
+        query = f"SELECT {id_column} FROM {booster_type.value} WHERE guild_id = %s"
+        result = await execute_query(query, (guild_id,))
+        return result[0][0] if result else None
+
+    async def delete(self, booster_type: BoosterType, guild_id: str, entity_id: str | None = None) -> None:
+        """Delete a booster channel or role.
+
+        For CHANNEL type, entity_id is required (DELETE with both guild_id and channel_id).
+        For ROLE type, entity_id is optional (DELETE with just guild_id).
+        """
+        if booster_type == BoosterType.CHANNEL:
+            if entity_id is None:
+                raise ValueError("entity_id is required for channel deletion")
+            query = f"DELETE FROM {booster_type.value} WHERE guild_id = %s AND channel_id = %s"
+            await execute_action(query, (guild_id, entity_id))
+        else:
+            query = f"DELETE FROM {booster_type.value} WHERE guild_id = %s"
+            await execute_action(query, (guild_id,))
+
+    # ------------------------------------------------------------------ #
+    # Claimed entity operations (claimedBoosterChannel, claimedBoosterRole)
+    # ------------------------------------------------------------------ #
+
+    async def claim(
+        self,
+        claimed_type: ClaimedBoosterType,
+        user_id: str,
+        entity_id: str,
+        guild_id: str,
+    ) -> None:
+        """Insert a claimed booster channel or role for a user."""
+        id_column = "channel_id" if claimed_type == ClaimedBoosterType.CHANNEL else "role_id"
+        query = f"INSERT INTO {claimed_type.value} (user_id, {id_column}, guild_id) VALUES (%s, %s, %s)"
+        await execute_action(query, (user_id, entity_id, guild_id))
+
+    async def unclaim(
+        self,
+        claimed_type: ClaimedBoosterType,
+        user_id: str,
+        guild_id: str,
+    ) -> None:
+        """Remove a claimed booster channel or role for a user."""
+        query = f"DELETE FROM {claimed_type.value} WHERE user_id = %s AND guild_id = %s"
+        await execute_action(query, (user_id, guild_id))
+
+    async def get_claim_for_user(
+        self,
+        claimed_type: ClaimedBoosterType,
+        user_id: str,
+        guild_id: str | None = None,
+    ) -> str | None:
+        """Get a single claimed entity id for a user.
+
+        If guild_id is given, returns the entity_id (channel_id or role_id) directly.
+        If guild_id is not given, returns None if no claim exists.
+        """
+        id_column = "channel_id" if claimed_type == ClaimedBoosterType.CHANNEL else "role_id"
+        if guild_id:
+            query = f"SELECT {id_column} FROM {claimed_type.value} WHERE user_id = %s AND guild_id = %s"
+            result = await safe_execute_query(query, (user_id, guild_id))
+            return result[0][0] if result else None
+        else:
+            # Check if user has any claim at all
+            query = f"SELECT 1 FROM {claimed_type.value} WHERE user_id = %s LIMIT 1"
+            result = await safe_execute_query(query, (user_id,))
+            return id_column if result else None  # non-None truthy marker
+
+    async def get_user_claims(
+        self,
+        claimed_type: ClaimedBoosterType,
+        user_id: str,
+    ) -> list:
+        """Get all claimed booster entities for a user as model instances."""
+        if claimed_type == ClaimedBoosterType.CHANNEL:
+            query = "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel WHERE user_id = %s"
+            result = await safe_execute_query(query, (user_id,))
+            return [ClaimedBoosterChannelModel.from_row(row) for row in result]
+        else:
+            query = "SELECT user_id, role_id, guild_id FROM claimedBoosterRole WHERE user_id = %s"
+            result = await safe_execute_query(query, (user_id,))
+            return [ClaimedBoosterRoleModel.from_row(row) for row in result]
+
+    async def get_all_claims(
+        self,
+        claimed_type: ClaimedBoosterType,
+    ) -> list:
+        """Get all claimed booster entities as model instances."""
+        if claimed_type == ClaimedBoosterType.CHANNEL:
+            query = "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel"
+            result = await safe_execute_query(query)
+            return [ClaimedBoosterChannelModel.from_row(row) for row in result]
+        else:
+            query = "SELECT user_id, role_id, guild_id FROM claimedBoosterRole"
+            result = await safe_execute_query(query)
+            return [ClaimedBoosterRoleModel.from_row(row) for row in result]
+
+
+# ------------------------------------------------------------------ #
+# Singleton instance for easy import
+# ------------------------------------------------------------------ #
+
+booster_service = BoosterService()

--- a/services/booster_service.py
+++ b/services/booster_service.py
@@ -105,23 +105,29 @@ class BoosterService:
         self,
         claimed_type: ClaimedBoosterType,
         user_id: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> str | None:
-        """Get a single claimed entity id for a user.
+        """Get a single claimed entity id for a user in a specific guild.
 
-        If guild_id is given, returns the entity_id (channel_id or role_id) directly.
-        If guild_id is not given, returns None if no claim exists.
+        Returns the entity_id (channel_id or role_id) for the user in the guild, or None if no claim exists.
         """
         id_column = "channel_id" if claimed_type == ClaimedBoosterType.CHANNEL else "role_id"
-        if guild_id:
-            query = f"SELECT {id_column} FROM {claimed_type.value} WHERE user_id = %s AND guild_id = %s"
-            result = await safe_execute_query(query, (user_id, guild_id))
-            return result[0][0] if result else None
-        else:
-            # Check if user has any claim at all
-            query = f"SELECT 1 FROM {claimed_type.value} WHERE user_id = %s LIMIT 1"
-            result = await safe_execute_query(query, (user_id,))
-            return id_column if result else None  # non-None truthy marker
+        query = f"SELECT {id_column} FROM {claimed_type.value} WHERE user_id = %s AND guild_id = %s"
+        result = await safe_execute_query(query, (user_id, guild_id))
+        return result[0][0] if result else None
+
+    async def has_claim(
+        self,
+        claimed_type: ClaimedBoosterType,
+        user_id: str,
+    ) -> bool:
+        """Check if a user has any claim of the given type across all guilds.
+
+        Returns True if the user has at least one claim, False otherwise.
+        """
+        query = f"SELECT 1 FROM {claimed_type.value} WHERE user_id = %s LIMIT 1"
+        result = await safe_execute_query(query, (user_id,))
+        return bool(result)
 
     async def get_user_claims(
         self,


### PR DESCRIPTION
Closes #1304

## Summary
Consolidates 10 loose async functions in api.py (booster channel/role CRUD) into a single `BoosterService` class with typed operations.

## Changes
- Created `services/booster_service.py` with:
  - `BoosterType` enum (CHANNEL, ROLE) mapping to table names
  - `ClaimedBoosterType` enum (CHANNEL, ROLE) mapping to claimed table names
  - Methods: `add()`, `get()`, `delete()`, `claim()`, `unclaim()`, `get_user_claims()`, `get_all_claims()`
  - Fixed the `get_claimed_*` anti-pattern that returned `str | list[Model] | None`
- Replaced old implementations in api.py with backward-compatible wrappers delegating to `BoosterService`
- Updated all callers to import from the service directly

## Benefits
- 10 functions consolidated to 5-6 typed methods with enum dispatch
- Clean return types (no multi-typed return anti-patterns)
- Single point of change for booster logic
- Consistent with existing service pattern (TicketService, GiveawayService)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated booster channel/role and claim handling into a centralized service used by all related commands, simplifying persistence and lookup behavior.
  * Commands now route booster setup, deletion, claim/unclaim, and expiration cleanup through the shared service for more consistent behavior and easier maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->