### PR TITLE
feat(#1312): BrawlStarsService typed client with Pydantic response models

### DIFF
--- a/commands/admin/ticket/close_ticket.py
+++ b/commands/admin/ticket/close_ticket.py
@@ -4,8 +4,8 @@ from typing import Any
 import discord
 
 import utility
-from services.ticket_service import ticket_service
 from localizer import tanjunLocalizer
+from services.ticket_service import ticket_service
 
 
 async def close_ticket(interaction: discord.Interaction) -> None:

--- a/commands/minigames/counting/removecountingchannel.py
+++ b/commands/minigames/counting/removecountingchannel.py
@@ -1,8 +1,8 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.removecountingchannel"

--- a/commands/minigames/counting/setcountingchannel.py
+++ b/commands/minigames/counting/setcountingchannel.py
@@ -1,11 +1,11 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,
 )
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingchannel"

--- a/commands/minigames/counting/setcountingprogress.py
+++ b/commands/minigames/counting/setcountingprogress.py
@@ -1,12 +1,12 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import (
     require_counting_channel,
     require_moderate_members,
     require_valid_progress,
 )
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingprogress"

--- a/commands/minigames/counting_challenge/removecountingchannel.py
+++ b/commands/minigames/counting_challenge/removecountingchannel.py
@@ -1,8 +1,8 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.removecountingchallengechannel"

--- a/commands/minigames/counting_challenge/setcountingchannel.py
+++ b/commands/minigames/counting_challenge/setcountingchannel.py
@@ -1,11 +1,11 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,
 )
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingchannel"

--- a/commands/minigames/counting_challenge/setcountingprogress.py
+++ b/commands/minigames/counting_challenge/setcountingprogress.py
@@ -1,12 +1,12 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import (
     require_counting_channel,
     require_moderate_members,
     require_valid_progress,
 )
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingchallengeprogress"

--- a/commands/minigames/counting_modes/removecountingchannel.py
+++ b/commands/minigames/counting_modes/removecountingchannel.py
@@ -1,8 +1,8 @@
 import discord
 
-from services.counting_repository import CountingMode, CountingRepository
 from commands.minigames._counting_common import require_counting_channel, require_moderate_members
 from localizer import tanjunLocalizer
+from services.counting_repository import CountingMode, CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.removecountingmodeschannel"

--- a/commands/minigames/counting_modes/setcountingchannel.py
+++ b/commands/minigames/counting_modes/setcountingchannel.py
@@ -1,12 +1,12 @@
 import discord
 
-from services.counting_repository import CountingRepository
 from commands.minigames._counting_common import (
     require_bot_permissions,
     require_moderate_members,
 )
 from localizer import tanjunLocalizer
 from models import CountingMode
+from services.counting_repository import CountingRepository
 from utility import CommandInfo, tanjunEmbed
 
 LOCALE_KEY = "minigames.setcountingchannel"

--- a/commands/utility/brawlstars/battlelog.py
+++ b/commands/utility/brawlstars/battlelog.py
@@ -1,26 +1,9 @@
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
 
 from api import get_brawlstars_linked_account
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import command_info, date_time_to_timestamp, isoTimeToDate, tanjunEmbed
-
-
-async def getBattloeLog(player_tag: str):
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            f"https://api.brawlstars.com/v1/players/%23{player_tag[1:]}/battlelog",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        return await response.json()
 
 
 async def battlelog(command_info: command_info, player_tag: str = None):
@@ -57,8 +40,10 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                 ),
             )
         )
-    battle_log = await getBattloeLog(player_tag)
-    if not battle_log:
+
+    service = get_brawlstars_service()
+    battle_log_items = await service.get_battle_log(player_tag)
+    if not battle_log_items:
         await command_info.reply(
             embed=tanjunEmbed(
                 title=tanjunLocalizer.localize(
@@ -79,23 +64,23 @@ async def battlelog(command_info: command_info, player_tag: str = None):
     class BattleLogPaginator(discord.ui.View):
         def __init__(
             self,
-            battle_log: dict,
+            battles: list,
             command_info: command_info,
             player_tag: str,
             player_name: str,
         ):
             super().__init__(timeout=3600)
-            self.battle_log = battle_log
+            self.battles = battles
             self.command_info = command_info
             self.player_tag = player_tag
             self.player_name = player_name
             self.current_page = 0
-            self.total_pages = len(battle_log["items"])
+            self.total_pages = len(battles)
 
         def generate_page(self, page_num: int) -> discord.Embed:
-            item = self.battle_log["items"][page_num]
+            item = self.battles[page_num]
             description = ""
-            battle_time = isoTimeToDate(item["battle_time"])
+            battle_time = isoTimeToDate(item.battle_time)
             battle_time = date_time_to_timestamp(battle_time)
             description += tanjunLocalizer.localize(
                 self.command_info.locale,
@@ -103,7 +88,7 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                 timestamp=battle_time,
             )
             description += "\n"
-            game_mode = item["event"]["mode"]
+            game_mode = item.mode
             game_mode_locale = tanjunLocalizer.localize(
                 self.command_info.locale,
                 f"commands.utility.brawlstars.game_modes.{game_mode}",
@@ -114,30 +99,28 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                 game_mode=game_mode_locale,
             )
             description += "\n"
-            game_map = item["event"]["map"]
-            map_locale = tanjunLocalizer.localize(
-                self.command_info.locale,
-                f"commands.utility.brawlstars.maps.{game_map}",
-            )
-            description += tanjunLocalizer.localize(
-                self.command_info.locale,
-                "commands.utility.brawlstars.battlelog.description.game_map",
-                game_map=map_locale,
-            )
-            description += "\n"
-            battle = item["battle"]
-            trophy_change = battle["trophy_change"]
-            description += tanjunLocalizer.localize(
-                self.command_info.locale,
-                "commands.utility.brawlstars.battlelog.description.trophy_change",
-                trophy_change=trophy_change,
-            )
-            description += "\n"
-            if "result" in battle:
-                result = battle["result"]
+            if item.map:
+                map_locale = tanjunLocalizer.localize(
+                    self.command_info.locale,
+                    f"commands.utility.brawlstars.maps.{item.map}",
+                )
+                description += tanjunLocalizer.localize(
+                    self.command_info.locale,
+                    "commands.utility.brawlstars.battlelog.description.game_map",
+                    game_map=map_locale,
+                )
+                description += "\n"
+            if item.trophy_change is not None:
+                description += tanjunLocalizer.localize(
+                    self.command_info.locale,
+                    "commands.utility.brawlstars.battlelog.description.trophy_change",
+                    trophy_change=item.trophy_change,
+                )
+                description += "\n"
+            if item.result:
                 result_locale = tanjunLocalizer.localize(
                     self.command_info.locale,
-                    f"commands.utility.brawlstars.results.{result}",
+                    f"commands.utility.brawlstars.results.{item.result}",
                 )
                 description += tanjunLocalizer.localize(
                     self.command_info.locale,
@@ -145,75 +128,60 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                     result=result_locale,
                 )
                 description += "\n"
-            if "duration" in battle:
-                duration = battle["duration"]
+            if item.duration is not None:
                 description += tanjunLocalizer.localize(
                     self.command_info.locale,
                     "commands.utility.brawlstars.battlelog.description.duration",
-                    duration=duration,
+                    duration=item.duration,
                 )
                 description += "\n"
-            if "star_player" in battle:
-                star_player = battle["star_player"]
+            if item.star_player:
+                sp = item.star_player
                 description += tanjunLocalizer.localize(
                     self.command_info.locale,
                     "commands.utility.brawlstars.battlelog.description.star_player",
-                    tag=star_player["tag"],
-                    name=star_player["name"],
-                    brawler_name=star_player["brawler"]["name"],
-                    brawler_power=star_player["brawler"]["power"],
-                    brawler_trophies=star_player["brawler"]["trophies"],
+                    tag=sp.tag,
+                    name=sp.name,
+                    brawler_name=sp.brawler.name,
+                    brawler_power=sp.brawler.power,
+                    brawler_trophies=sp.brawler.trophies,
                 )
                 description += "\n"
-            if "players" in battle:
-                enemies = battle["players"]
+            if item.players:
                 description += tanjunLocalizer.localize(
                     self.command_info.locale,
                     "commands.utility.brawlstars.battlelog.description.enemies",
                 )
-                for enemie in enemies:
-                    tag = enemie["tag"]
+                for enemie in item.players:
+                    tag = enemie.tag
                     if tag.lower() == self.player_tag.lower():
-                        self.player_name = enemie["name"]
+                        self.player_name = enemie.name
                         continue
-
-                    name = enemie["name"]
-                    brawler = enemie["brawler"]
-                    brawler_name = brawler["name"]
-                    brawler_power = brawler["power"]
-                    brawler_trophies = brawler["trophies"]
-
                     description += tanjunLocalizer.localize(
                         self.command_info.locale,
                         "commands.utility.brawlstars.battlelog.description.enemy",
                         tag=tag,
-                        name=name,
-                        brawler_name=brawler_name,
-                        brawler_power=brawler_power,
-                        brawler_trophies=brawler_trophies,
+                        name=enemie.name,
+                        brawler_name=enemie.brawler.name,
+                        brawler_power=enemie.brawler.power,
+                        brawler_trophies=enemie.brawler.trophies,
                     )
                     description += "\n"
-            elif "teams" in battle:
-                teams = battle["teams"]
+            elif item.teams:
+                teams = item.teams
                 description += tanjunLocalizer.localize(
                     self.command_info.locale,
                     "commands.utility.brawlstars.battlelog.description.team1",
                 )
                 for player in teams[0]:
-                    tag = player["tag"]
-                    name = player["name"]
-                    brawler = player["brawler"]
-                    brawler_name = brawler["name"]
-                    brawler_power = brawler["power"]
-                    brawler_trophies = brawler["trophies"]
                     description += tanjunLocalizer.localize(
                         self.command_info.locale,
                         "commands.utility.brawlstars.battlelog.description.teamPlayer",
-                        tag=tag,
-                        name=name,
-                        brawler_name=brawler_name,
-                        brawler_power=brawler_power,
-                        brawler_trophies=brawler_trophies,
+                        tag=player.tag,
+                        name=player.name,
+                        brawler_name=player.brawler.name,
+                        brawler_power=player.brawler.power,
+                        brawler_trophies=player.brawler.trophies,
                     )
                     description += "\n"
                 description += tanjunLocalizer.localize(
@@ -221,20 +189,14 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                     "commands.utility.brawlstars.battlelog.description.team2",
                 )
                 for player in teams[1]:
-                    tag = player["tag"]
-                    name = player["name"]
-                    brawler = player["brawler"]
-                    brawler_name = brawler["name"]
-                    brawler_power = brawler["power"]
-                    brawler_trophies = brawler["trophies"]
                     description += tanjunLocalizer.localize(
                         self.command_info.locale,
                         "commands.utility.brawlstars.battlelog.description.teamPlayer",
-                        tag=tag,
-                        name=name,
-                        brawler_name=brawler_name,
-                        brawler_power=brawler_power,
-                        brawler_trophies=brawler_trophies,
+                        tag=player.tag,
+                        name=player.name,
+                        brawler_name=player.brawler.name,
+                        brawler_power=player.brawler.power,
+                        brawler_trophies=player.brawler.trophies,
                     )
                     description += "\n"
             return tanjunEmbed(
@@ -283,8 +245,8 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                 self.current_page += 1
             await interaction.response.edit_message(view=self, embed=self.generate_page(self.current_page))
 
-    if len(battle_log["items"]) > 1:
-        view = BattleLogPaginator(battle_log, command_info, player_tag, player_name)
+    if len(battle_log_items) > 1:
+        view = BattleLogPaginator(battle_log_items, command_info, player_tag, player_name)
         await command_info.reply(embed=view.generate_page(0), view=view)
     else:
         embed = tanjunEmbed(
@@ -295,7 +257,9 @@ async def battlelog(command_info: command_info, player_tag: str = None):
                 tag=player_tag,
             ),
             description=""
-            if not battle_log["items"]
-            else BattleLogPaginator(battle_log, command_info, player_tag, player_name).generate_page(0).description,
+            if not battle_log_items
+            else BattleLogPaginator(battle_log_items, command_info, player_tag, player_name)
+            .generate_page(0)
+            .description,
         )
         await command_info.reply(embed=embed)

--- a/commands/utility/brawlstars/brawlers.py
+++ b/commands/utility/brawlstars/brawlers.py
@@ -1,8 +1,6 @@
 import json
 
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
 
 from api import get_brawlstars_linked_account
 from commands.utility.brawlstars.bshelper import (
@@ -12,24 +10,9 @@ from commands.utility.brawlstars.bshelper import (
     getStarPowerEmoji,
     parseName,
 )
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import command_info, similar, tanjunEmbed
-
-
-async def getPlayerInfo(player_tag: str):
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            f"https://api.brawlstars.com/v1/players/%23{player_tag[1:]}",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        return await response.json()
 
 
 async def brawlers(command_info: command_info, player_tag: str = None):
@@ -66,7 +49,9 @@ async def brawlers(command_info: command_info, player_tag: str = None):
                 ),
             )
         )
-    player_info = await getPlayerInfo(player_tag)
+
+    service = get_brawlstars_service()
+    player_info = await service.get_player(player_tag)
     if not player_info:
         return await command_info.reply(
             tanjunLocalizer.localize(
@@ -75,20 +60,20 @@ async def brawlers(command_info: command_info, player_tag: str = None):
             )
         )
 
-    player_name = player_info["name"]
-    total_brawlers = len(player_info["brawlers"])
+    player_name = player_info.name
+    total_brawlers = len(player_info.brawlers)
 
     async def generate_page(page_number: int) -> discord.Embed:
-        brawler = player_info["brawlers"][page_number]
-        id = brawler["id"]
-        name = parseName(brawler["name"])
-        power = brawler["power"]
-        rank = brawler["rank"]
-        trophies = brawler["trophies"]
-        highest_trophies = brawler["highest_trophies"]
-        gears = brawler["gears"]
-        gadgets = brawler["gadgets"]
-        star_powers = brawler["star_powers"]
+        brawler = player_info.brawlers[page_number]
+        id = brawler.id
+        name = parseName(brawler.name)
+        power = brawler.power
+        rank = brawler.rank
+        trophies = brawler.trophies
+        highest_trophies = brawler.highest_trophies
+        gears = brawler.gears
+        gadgets = brawler.gadgets
+        star_powers = brawler.star_powers
         level_emoji = getLevelEmoji(rank)
 
         if rank <= 50:
@@ -124,7 +109,7 @@ async def brawlers(command_info: command_info, player_tag: str = None):
             description += "\n"
 
             for star_power in star_powers:
-                name = f" {getStarPowerEmoji(star_power['id'])} {parseName(star_power['name'])}"
+                name = f" {getStarPowerEmoji(star_power.id)} {parseName(star_power.name)}"
                 description += tanjunLocalizer.localize(
                     command_info.locale,
                     "commands.utility.brawlstars.brawlers.description.star_power",
@@ -142,7 +127,7 @@ async def brawlers(command_info: command_info, player_tag: str = None):
             description += "\n"
 
             for gadget in gadgets:
-                name = f" {getGadgetEmoji(gadget['id'])} {parseName(gadget['name'])}"
+                name = f" {getGadgetEmoji(gadget.id)} {parseName(gadget.name)}"
                 description += tanjunLocalizer.localize(
                     command_info.locale,
                     "commands.utility.brawlstars.brawlers.description.gadget",
@@ -159,7 +144,7 @@ async def brawlers(command_info: command_info, player_tag: str = None):
             description += "\n"
 
             for gear in gears:
-                name = f" {getGearEmoji(gear['id'])} {parseName(gear['name'])}"
+                name = f" {getGearEmoji(gear.id)} {parseName(gear.name)}"
                 description += tanjunLocalizer.localize(
                     command_info.locale,
                     "commands.utility.brawlstars.brawlers.description.gear",
@@ -171,7 +156,7 @@ async def brawlers(command_info: command_info, player_tag: str = None):
 
         if command_info.user.id == 1295625022454370346 and command_info.guild.id == 947219439764521060:
             description += "\n"
-            description += f"raw: \n```json\n{json.dumps(brawler, indent=4)}\n```"
+            description += f"raw: \n```json\n{json.dumps(brawler.model_dump(), indent=4)}\n```"
 
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -274,8 +259,8 @@ async def brawlers(command_info: command_info, player_tag: str = None):
 
                 desired_page = 0
                 best_similarity = -100
-                for i, brawler in enumerate(player_info["brawlers"]):
-                    similarity = similar(brawler["name"].lower(), brawler_name.lower())
+                for i, brawler in enumerate(player_info.brawlers):
+                    similarity = similar(brawler.name.lower(), brawler_name.lower())
                     if similarity > best_similarity:
                         best_similarity = similarity
                         desired_page = i

--- a/commands/utility/brawlstars/club.py
+++ b/commands/utility/brawlstars/club.py
@@ -1,31 +1,16 @@
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
 
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import addThousandsSeparator, command_info, similar, tanjunEmbed
-
-
-async def getClubInfo(club_tag: str):
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            f"https://api.brawlstars.com/v1/clubs/%23{club_tag[1:]}",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        return await response.json()
 
 
 async def club(command_info: command_info, club_tag: str):
     if not club_tag.startswith("#"):
         club_tag = f"#{club_tag}"
-    club_info = await getClubInfo(club_tag)
+
+    service = get_brawlstars_service()
+    club_info = await service.get_club(club_tag)
     if not club_info:
         return await command_info.reply(
             tanjunLocalizer.localize(
@@ -34,13 +19,13 @@ async def club(command_info: command_info, club_tag: str):
             )
         )
 
-    club_name = club_info["name"]
-    club_description = club_info["description"]
-    required_trophies = club_info["required_trophies"]
-    trophies = club_info["trophies"]
-    members = club_info["members"]
+    club_name = club_info.name
+    club_description = club_info.description or ""
+    required_trophies = club_info.required_trophies
+    trophies = club_info.trophies or 0
+    members = club_info.members
     role_order = {"president": 4, "vicePresident": 3, "senior": 2, "member": 1}
-    members = sorted(members, key=lambda x: (role_order[x["role"]], x["trophies"]), reverse=True)
+    members = sorted(members, key=lambda x: (role_order.get(x.role, 0), x.trophies), reverse=True)
 
     base_description = ""
     base_description += tanjunLocalizer.localize(
@@ -58,10 +43,10 @@ async def club(command_info: command_info, club_tag: str):
         description += tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.club.description.member",
-            name=member["name"],
-            tag=member["tag"],
-            trophies=addThousandsSeparator(member["trophies"]),
-            role=member["role"],
+            name=member.name,
+            tag=member.tag,
+            trophies=addThousandsSeparator(member.trophies),
+            role=member.role,
         )
         embed = tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -69,7 +54,7 @@ async def club(command_info: command_info, club_tag: str):
                 "commands.utility.brawlstars.club.title",
                 name=club_name,
                 tag=club_tag,
-                role=member["role"],
+                role=member.role,
                 current_page=i + 1,
                 total_pages=len(members),
             ),
@@ -157,11 +142,11 @@ async def club(command_info: command_info, club_tag: str):
                 desired_page = 0
                 best_similarity = -100
                 for i, member in enumerate(members):
-                    similarity = similar(member["name"].lower(), member_name.lower())
+                    similarity = similar(member.name.lower(), member_name.lower())
                     if similarity > best_similarity:
                         best_similarity = similarity
                         desired_page = i
-                    similarity = similar(member["tag"].lower(), member_name.lower())
+                    similarity = similar(member.tag.lower(), member_name.lower())
                     if similarity > best_similarity:
                         best_similarity = similarity
                         desired_page = i

--- a/commands/utility/brawlstars/events.py
+++ b/commands/utility/brawlstars/events.py
@@ -1,9 +1,7 @@
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
 
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import (
     command_info,
     date_time_to_timestamp,
@@ -12,23 +10,9 @@ from utility import (
 )
 
 
-async def getEventRotation():
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            "https://api.brawlstars.com/v1/events/rotation",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        return await response.json()
-
-
 async def events(command_info: command_info):
-    event_rotation = await getEventRotation()
+    service = get_brawlstars_service()
+    event_rotation = await service.get_events()
     if not event_rotation:
         return await command_info.reply(
             tanjunLocalizer.localize(

--- a/commands/utility/brawlstars/events.py
+++ b/commands/utility/brawlstars/events.py
@@ -23,16 +23,16 @@ async def events(command_info: command_info):
 
     async def generate_page(page_num: int) -> discord.Embed:
         event = event_rotation[page_num]
-        start_time = event["start_time"]
+        start_time = event.start_time
         start_timestamp = date_time_to_timestamp(isoTimeToDate(start_time))
-        end_time = event["end_time"]
+        end_time = event.end_time
         end_timestamp = date_time_to_timestamp(isoTimeToDate(end_time))
-        map_ = event["event"]["map"]
+        map_ = event.event.map
         map_locale = tanjunLocalizer.localize(
             command_info.locale,
             f"commands.utility.brawlstars.maps.{map_}",
         )
-        mode = event["event"]["mode"]
+        mode = event.event.mode
         mode_locale = tanjunLocalizer.localize(
             command_info.locale,
             f"commands.utility.brawlstars.game_modes.{mode}",

--- a/commands/utility/brawlstars/link.py
+++ b/commands/utility/brawlstars/link.py
@@ -1,37 +1,17 @@
-from typing import Any
-
-import aiohttp
-from aiohttp import ClientTimeout
+from __future__ import annotations
 
 from api import add_brawlstars_linked_account, get_brawlstars_linked_account
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import CommandInfo, tanjunEmbed
-
-
-async def getPlayerInfo(player_tag: str) -> dict[str, str] | None:
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            f"https://api.brawlstars.com/v1/players/%23{player_tag[1:]}",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        json_data: Any = await response.json()
-        if isinstance(json_data, dict):
-            return json_data
-        else:
-            return None
 
 
 async def link(command_info: CommandInfo, player_tag: str) -> None:
     if not player_tag.startswith("#"):
         player_tag = f"#{player_tag}"
-    player_info = await getPlayerInfo(player_tag)
+
+    service = get_brawlstars_service()
+    player_info = await service.get_player(player_tag)
     if not player_info:
         await command_info.reply(
             embed=tanjunEmbed(

--- a/commands/utility/brawlstars/playerinfo.py
+++ b/commands/utility/brawlstars/playerinfo.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from services.brawlstars import get_brawlstars_service
 from api import get_brawlstars_linked_account
 from localizer import tanjunLocalizer
+from services.brawlstars import get_brawlstars_service
 from utility import CommandInfo, tanjunEmbed
 
 

--- a/commands/utility/brawlstars/playerinfo.py
+++ b/commands/utility/brawlstars/playerinfo.py
@@ -1,44 +1,11 @@
+from __future__ import annotations
+
 from typing import Any
 
-import aiohttp
-from aiohttp import ClientTimeout
-
+from services.brawlstars import get_brawlstars_service
 from api import get_brawlstars_linked_account
-from config import brawlstarsToken
 from localizer import tanjunLocalizer
 from utility import CommandInfo, tanjunEmbed
-
-
-async def fetch_player_data(player_tag: str) -> dict[str, Any] | None:
-    """Fetch player data directly from Brawl Stars API."""
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    url = "https://api.brawlstars.com/v1/players"
-    params = {"tag": player_tag}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, headers=headers, params=params, timeout=ClientTimeout(total=10)) as response,
-    ):
-        if response.status != 200:
-            return None
-        return await response.json()
-
-
-async def getAllBrawlers() -> dict[str, Any] | None:
-    headers = {"Authorization": f"Bearer {brawlstarsToken}"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(
-            "https://api.brawlstars.com/v1/brawlers",
-            headers=headers,
-            timeout=ClientTimeout(total=10),
-        ) as response,
-    ):
-        if response.status != 200:
-            return None
-        json_data: Any = await response.json()
-        if isinstance(json_data, dict):
-            return json_data
-        return None
 
 
 async def player_info(command_info: CommandInfo, player_tag: str | None = None) -> None:
@@ -79,8 +46,9 @@ async def player_info(command_info: CommandInfo, player_tag: str | None = None) 
         )
         return
 
-    player_data = await fetch_player_data(player_tag)
-    if not player_data or "items" not in player_data or not player_data["items"]:
+    service = get_brawlstars_service()
+    player = await service.get_player(player_tag)
+    if not player:
         await command_info.reply(
             tanjunLocalizer.localize(
                 command_info.locale,
@@ -89,68 +57,59 @@ async def player_info(command_info: CommandInfo, player_tag: str | None = None) 
         )
         return
 
-    player = player_data["items"][0]
-
     description = ""
     description += tanjunLocalizer.localize(
         command_info.locale,
         "commands.utility.brawlstars.playerinfo.description.trophies",
-        trophies=player.get("trophies", 0),
+        trophies=player.trophies,
     )
     description += "\n"
     description += tanjunLocalizer.localize(
         command_info.locale,
         "commands.utility.brawlstars.playerinfo.description.highest_trophies",
-        highest_trophies=player.get("highest_trophies", 0),
+        highest_trophies=player.highest_trophies,
     )
     description += "\n"
     description += tanjunLocalizer.localize(
         command_info.locale,
         "commands.utility.brawlstars.playerinfo.description.expLevel",
-        expLevel=player.get("expLevel", 0),
+        expLevel=player.exp_level,
     )
 
-    club = player.get("club", {})
-    if club:
+    if player.club:
         description += "\n"
         description += tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.playerinfo.description.club",
-            tag=club.get("tag", "N/A"),
-            name=club.get("name", "N/A"),
+            tag=player.club.tag,
+            name=player.club.name,
         )
     description += "\n"
-    victories_3v3 = player.get("x3vs3_victories", 0)
-    if victories_3v3 != 0:
+    if player.x3vs3_victories != 0:
         description += tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.playerinfo.description.3v3Victories",
-            victories=victories_3v3,
+            victories=player.x3vs3_victories,
         )
     description += "\n"
-    solo_victories = player.get("solo_victories", 0)
-    if solo_victories != 0:
+    if player.solo_victories != 0:
         description += tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.playerinfo.description.soloVictories",
-            victories=solo_victories,
+            victories=player.solo_victories,
         )
     description += "\n"
-    duo_victories = player.get("duo_victories", 0)
-    if duo_victories != 0:
+    if player.duo_victories != 0:
         description += tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.playerinfo.description.duoVictories",
-            victories=duo_victories,
+            victories=player.duo_victories,
         )
     description += "\n"
     description += "\n"
-    all_brawlers = await getAllBrawlers()
-    brawlers_count = 0
-    if all_brawlers and "items" in all_brawlers:
-        brawlers_count = len(all_brawlers["items"])
-
-    owned_count = len(player.get("brawlers", []))
+    all_brawlers = await service.get_brawler_list()
+    brawlers_count = len(all_brawlers)
+    owned_count = len(player.brawlers)
     description += tanjunLocalizer.localize(
         command_info.locale,
         "commands.utility.brawlstars.playerinfo.description.brawlers",
@@ -161,10 +120,10 @@ async def player_info(command_info: CommandInfo, player_tag: str | None = None) 
         title=tanjunLocalizer.localize(
             command_info.locale,
             "commands.utility.brawlstars.playerinfo.title",
-            player_name=player.get("name", "Unknown"),
+            player_name=player.name,
             tag=player_tag,
         ),
         description=description,
-        color=player.get("nameColor", 0xFFFFFF),
+        color=player.name_color or 0xFFFFFF,
     )
     await command_info.reply(embed=embed)

--- a/commands/utility/brawlstars/playerinfo.py
+++ b/commands/utility/brawlstars/playerinfo.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from services.brawlstars import get_brawlstars_service
 from api import get_brawlstars_linked_account
 from localizer import tanjunLocalizer

--- a/minigames/_xp_core.py
+++ b/minigames/_xp_core.py
@@ -7,8 +7,8 @@ Delegates to XpCalculator service for the actual boost formula.
 The XpCalculator service class is also exported for direct use.
 """
 
-from services.xp_calculator import XpCalculator, xp_calculator
 from api import _get_cached_blacklist
+from services.xp_calculator import XpCalculator, xp_calculator
 
 # Re-export for callers that want to use the service directly
 __all__ = ["XpCalculator", "xp_calculator", "calculate_xp", "is_entity_blacklisted"]

--- a/minigames/counting_modes.py
+++ b/minigames/counting_modes.py
@@ -3,10 +3,11 @@ from math import sqrt
 
 import discord
 
-from services.counting_repository import CountingMode as _CountingDBMode, CountingRepository
 from api import check_if_opted_out
 from localizer import tanjunLocalizer
 from models import CountingMode
+from services.counting_repository import CountingMode as _CountingDBMode
+from services.counting_repository import CountingRepository
 from utility import DiscordSafe, EmbedColor, tanjunEmbed
 
 repo = CountingRepository

--- a/repositories/level_config_repository.py
+++ b/repositories/level_config_repository.py
@@ -19,8 +19,9 @@ class LevelConfigRepository:
 
     async def get_config(self, guild_id: str) -> LevelConfig:
         """Load the full LevelConfig for a guild, returning defaults if none exists."""
-        from api import _guild_config_cache, _is_cache_valid, _GUILD_CONFIG_CACHE_TTL, execute_query
         import time
+
+        from api import _GUILD_CONFIG_CACHE_TTL, _guild_config_cache, _is_cache_valid, execute_query
 
         # Check cache first
         cache_entry = _guild_config_cache.get(guild_id)

--- a/services/brawlstars.py
+++ b/services/brawlstars.py
@@ -14,22 +14,39 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import Any
 
 import aiohttp
-from pydantic import BaseModel, Field
+from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
 
 # ── Pydantic Models ──────────────────────────────────────────────────────────
 
 
-class BrawlStarsIcon(BaseModel):
+def to_camel_case(snake_str: str) -> str:
+    """Convert snake_case to camelCase."""
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+class BrawlStarsBaseModel(BaseModel):
+    """Base model with camelCase alias support for all Brawl Stars models."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel_case,
+        populate_by_name=True,
+    )
+
+
+class BrawlStarsIcon(BrawlStarsBaseModel):
     """Represents an icon/avatar in Brawl Stars API responses."""
 
     id: int | None = None
 
 
-class BrawlStarsClub(BaseModel):
+class BrawlStarsClub(BrawlStarsBaseModel):
     """Represents a club associated with a player or queried directly."""
 
     tag: str = ""
@@ -42,7 +59,7 @@ class BrawlStarsClub(BaseModel):
     members: list["BrawlStarsClubMember"] = Field(default_factory=list)
 
 
-class BrawlStarsClubMember(BaseModel):
+class BrawlStarsClubMember(BrawlStarsBaseModel):
     """Represents a single member within a club."""
 
     tag: str
@@ -55,7 +72,7 @@ class BrawlStarsClubMember(BaseModel):
     club_rank: int | None = None
 
 
-class BrawlerGear(BaseModel):
+class BrawlerGear(BrawlStarsBaseModel):
     """A gear equipped on a brawler."""
 
     id: int
@@ -63,21 +80,21 @@ class BrawlerGear(BaseModel):
     level: int
 
 
-class BrawlerGadget(BaseModel):
+class BrawlerGadget(BrawlStarsBaseModel):
     """A gadget equipped on a brawler."""
 
     id: int
     name: str
 
 
-class BrawlerStarPower(BaseModel):
+class BrawlerStarPower(BrawlStarsBaseModel):
     """A star power equipped on a brawler."""
 
     id: int
     name: str
 
 
-class BrawlerInfo(BaseModel):
+class BrawlerInfo(BrawlStarsBaseModel):
     """Detailed info for a single brawler a player owns."""
 
     id: int
@@ -91,7 +108,7 @@ class BrawlerInfo(BaseModel):
     star_powers: list[BrawlerStarPower] = Field(default_factory=list)
 
 
-class BrawlStarsPlayer(BaseModel):
+class BrawlStarsPlayer(BrawlStarsBaseModel):
     """Full player model returned by the Brawl Stars API."""
 
     tag: str
@@ -112,20 +129,20 @@ class BrawlStarsPlayer(BaseModel):
     icon: BrawlStarsIcon | None = None
 
 
-class BrawlStarPlayerBrawler(BaseModel):
+class BrawlStarPlayerBrawler(BrawlStarsBaseModel):
     """Minimal brawler data from the /v1/brawlers endpoint."""
 
     id: int
     name: str
 
 
-class BrawlStarsBrawlerList(BaseModel):
+class BrawlStarsBrawlerList(BrawlStarsBaseModel):
     """Response from the /v1/brawlers list endpoint."""
 
     items: list[BrawlStarPlayerBrawler] = Field(default_factory=list)
 
 
-class BrawlStarsEvent(BaseModel):
+class BrawlStarsEvent(BrawlStarsBaseModel):
     """A single event in the current rotation."""
 
     start_time: str
@@ -133,7 +150,7 @@ class BrawlStarsEvent(BaseModel):
     event: "BrawlStarsEventDetail"
 
 
-class BrawlStarsEventDetail(BaseModel):
+class BrawlStarsEventDetail(BrawlStarsBaseModel):
     """Details of a single event slot."""
 
     id: int
@@ -141,13 +158,13 @@ class BrawlStarsEventDetail(BaseModel):
     map: str
 
 
-class BrawlStarsEventRotation(BaseModel):
+class BrawlStarsEventRotation(BrawlStarsBaseModel):
     """Wrapper for the event rotation endpoint (list in response)."""
 
     items: list[BrawlStarsEvent] = Field(default_factory=list)
 
 
-class BattlePlayer(BaseModel):
+class BattlePlayer(BrawlStarsBaseModel):
     """Player info within a battle."""
 
     tag: str
@@ -155,22 +172,22 @@ class BattlePlayer(BaseModel):
     brawler: BrawlerInfo | None = None
 
 
-class BrawlStarsBattle(BaseModel):
+class BrawlStarsBattle(BrawlStarsBaseModel):
     """A single battle entry from the battle log."""
 
-    battle_time: str
-    mode: str
-    type: str
-    result: str | None = None
-    duration: int | None = None
-    trophy_change: int | None = None
-    star_player: BattlePlayer | None = None
-    teams: list[list[BattlePlayer]] | None = None
-    players: list[BattlePlayer] | None = None
-    map: str | None = None
+    battle_time: str = Field(validation_alias="battleTime")
+    mode: str = Field(validation_alias=AliasPath("event", "mode"))
+    type: str = Field(validation_alias=AliasPath("battle", "type"))
+    result: str | None = Field(default=None, validation_alias=AliasPath("battle", "result"))
+    duration: int | None = Field(default=None, validation_alias=AliasPath("battle", "duration"))
+    trophy_change: int | None = Field(default=None, validation_alias=AliasPath("battle", "trophyChange"))
+    star_player: BattlePlayer | None = Field(default=None, validation_alias=AliasPath("battle", "starPlayer"))
+    teams: list[list[BattlePlayer]] | None = Field(default=None, validation_alias=AliasPath("battle", "teams"))
+    players: list[BattlePlayer] | None = Field(default=None, validation_alias=AliasPath("battle", "players"))
+    map: str | None = Field(default=None, validation_alias=AliasPath("event", "map"))
 
 
-class BrawlStarsBattleLog(BaseModel):
+class BrawlStarsBattleLog(BrawlStarsBaseModel):
     """Response from the battle log endpoint."""
 
     items: list[BrawlStarsBattle] = Field(default_factory=list)
@@ -199,17 +216,19 @@ class BrawlStarsService:
 
         self._token: str = token or brawlstarsToken
         self._session: aiohttp.ClientSession | None = session
+        self._owns_session: bool = session is None
 
     # ── Session management ──────────────────────────────────────────────────
 
     async def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None or self._session.closed:
             self._session = aiohttp.ClientSession()
+            self._owns_session = True
         return self._session
 
     async def close(self) -> None:
         """Close the underlying session if owned by this service."""
-        if self._session is not None and not self._session.closed:
+        if self._session is not None and not self._session.closed and self._owns_session:
             await self._session.close()
 
     async def __aenter__(self) -> BrawlStarsService:
@@ -224,34 +243,43 @@ class BrawlStarsService:
         """Perform a GET request to the Brawl Stars API.
 
         Returns the parsed JSON dict on success (HTTP 200), or ``None`` on
-        any non-200 status.
+        any non-200 status, network errors, timeouts, or JSON parsing errors.
         """
-        session = await self._get_session()
-        async with session.get(
-            f"{self.BASE_URL}{path}",
-            headers={"Authorization": f"Bearer {self._token}"},
-            timeout=aiohttp.ClientTimeout(total=10),
-        ) as response:
-            if response.status != 200:
+        try:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.BASE_URL}{path}",
+                headers={"Authorization": f"Bearer {self._token}"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status != 200:
+                    return None
+                data: Any = await response.json()
+                if isinstance(data, dict):
+                    return data
                 return None
-            data: Any = await response.json()
-            if isinstance(data, dict):
-                return data
+        except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, ValueError):
             return None
 
     async def _get_list(self, path: str) -> list[dict[str, Any]]:
-        """Perform a GET request that returns a list (e.g. event rotation)."""
-        session = await self._get_session()
-        async with session.get(
-            f"{self.BASE_URL}{path}",
-            headers={"Authorization": f"Bearer {self._token}"},
-            timeout=aiohttp.ClientTimeout(total=10),
-        ) as response:
-            if response.status != 200:
+        """Perform a GET request that returns a list (e.g. event rotation).
+
+        Returns an empty list on network errors, timeouts, or JSON parsing errors.
+        """
+        try:
+            session = await self._get_session()
+            async with session.get(
+                f"{self.BASE_URL}{path}",
+                headers={"Authorization": f"Bearer {self._token}"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status != 200:
+                    return []
+                data: Any = await response.json()
+                if isinstance(data, list):
+                    return data
                 return []
-            data: Any = await response.json()
-            if isinstance(data, list):
-                return data
+        except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, ValueError):
             return []
 
     # ── Player endpoints ────────────────────────────────────────────────────
@@ -296,13 +324,13 @@ class BrawlStarsService:
 
     # ── Events endpoints ────────────────────────────────────────────────────
 
-    async def get_events(self) -> list[dict[str, Any]]:
+    async def get_events(self) -> list[BrawlStarsEvent]:
         """Fetch the current event rotation.
 
-        Returns raw dicts because the event rotation schema is a list at the
-        top level. Callers can access ``event["event"]["map"]`` etc.
+        Returns parsed BrawlStarsEvent model instances.
         """
-        return await self._get_list("/events/rotation")
+        data = await self._get_list("/events/rotation")
+        return [BrawlStarsEvent.model_validate(event) for event in data]
 
 
 # Module-level singleton for convenient import

--- a/services/brawlstars.py
+++ b/services/brawlstars.py
@@ -14,13 +14,11 @@ Usage:
 
 from __future__ import annotations
 
-import asyncio
 import json
 from typing import Any
 
 import aiohttp
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
-
 
 # ── Pydantic Models ──────────────────────────────────────────────────────────
 
@@ -56,7 +54,7 @@ class BrawlStarsClub(BrawlStarsBaseModel):
     badge_id: int | None = None
     required_trophies: int = 0
     trophies: int | None = None
-    members: list["BrawlStarsClubMember"] = Field(default_factory=list)
+    members: list[BrawlStarsClubMember] = Field(default_factory=list)
 
 
 class BrawlStarsClubMember(BrawlStarsBaseModel):
@@ -108,6 +106,15 @@ class BrawlerInfo(BrawlStarsBaseModel):
     star_powers: list[BrawlerStarPower] = Field(default_factory=list)
 
 
+class BattleBrawler(BrawlStarsBaseModel):
+    """Minimal brawler data from battle log payloads."""
+
+    id: int
+    name: str
+    power: int
+    trophies: int
+
+
 class BrawlStarsPlayer(BrawlStarsBaseModel):
     """Full player model returned by the Brawl Stars API."""
 
@@ -147,7 +154,7 @@ class BrawlStarsEvent(BrawlStarsBaseModel):
 
     start_time: str
     end_time: str
-    event: "BrawlStarsEventDetail"
+    event: BrawlStarsEventDetail
 
 
 class BrawlStarsEventDetail(BrawlStarsBaseModel):
@@ -169,7 +176,7 @@ class BattlePlayer(BrawlStarsBaseModel):
 
     tag: str
     name: str
-    brawler: BrawlerInfo | None = None
+    brawler: BattleBrawler | None = None
 
 
 class BrawlStarsBattle(BrawlStarsBaseModel):
@@ -258,7 +265,7 @@ class BrawlStarsService:
                 if isinstance(data, dict):
                     return data
                 return None
-        except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, ValueError):
+        except (TimeoutError, aiohttp.ClientError, json.JSONDecodeError, ValueError):
             return None
 
     async def _get_list(self, path: str) -> list[dict[str, Any]]:
@@ -279,7 +286,7 @@ class BrawlStarsService:
                 if isinstance(data, list):
                     return data
                 return []
-        except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, ValueError):
+        except (TimeoutError, aiohttp.ClientError, json.JSONDecodeError, ValueError):
             return []
 
     # ── Player endpoints ────────────────────────────────────────────────────

--- a/services/brawlstars.py
+++ b/services/brawlstars.py
@@ -1,0 +1,320 @@
+"""
+BrawlStarsService: Typed client for the Brawl Stars API with Pydantic response models.
+
+Consolidates all raw API calls scattered across commands/utility/brawlstars/* into a single
+service with proper response validation, centralized rate-limit handling, and shared session
+management.
+
+Usage:
+    from services.brawlstars import BrawlStarsService
+
+    service = BrawlStarsService()
+    player = await service.get_player("#ABC123")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+from pydantic import BaseModel, Field
+
+
+# ── Pydantic Models ──────────────────────────────────────────────────────────
+
+
+class BrawlStarsIcon(BaseModel):
+    """Represents an icon/avatar in Brawl Stars API responses."""
+
+    id: int | None = None
+
+
+class BrawlStarsClub(BaseModel):
+    """Represents a club associated with a player or queried directly."""
+
+    tag: str = ""
+    name: str = ""
+    description: str | None = None
+    type: str | None = None
+    badge_id: int | None = None
+    required_trophies: int = 0
+    trophies: int | None = None
+    members: list["BrawlStarsClubMember"] = Field(default_factory=list)
+
+
+class BrawlStarsClubMember(BaseModel):
+    """Represents a single member within a club."""
+
+    tag: str
+    name: str
+    role: str
+    trophies: int
+    name_color: str | None = None
+    icon: BrawlStarsIcon | None = None
+    # Optional fields from get_player context
+    club_rank: int | None = None
+
+
+class BrawlerGear(BaseModel):
+    """A gear equipped on a brawler."""
+
+    id: int
+    name: str
+    level: int
+
+
+class BrawlerGadget(BaseModel):
+    """A gadget equipped on a brawler."""
+
+    id: int
+    name: str
+
+
+class BrawlerStarPower(BaseModel):
+    """A star power equipped on a brawler."""
+
+    id: int
+    name: str
+
+
+class BrawlerInfo(BaseModel):
+    """Detailed info for a single brawler a player owns."""
+
+    id: int
+    name: str
+    power: int
+    rank: int
+    trophies: int
+    highest_trophies: int
+    gears: list[BrawlerGear] = Field(default_factory=list)
+    gadgets: list[BrawlerGadget] = Field(default_factory=list)
+    star_powers: list[BrawlerStarPower] = Field(default_factory=list)
+
+
+class BrawlStarsPlayer(BaseModel):
+    """Full player model returned by the Brawl Stars API."""
+
+    tag: str
+    name: str
+    trophies: int = 0
+    highest_trophies: int = 0
+    exp_level: int = 0
+    exp_points: int = 0
+    is_qualified_from_championship: bool = False
+    duo_wins: int = 0
+    solo_wins: int = 0
+    x3vs3_victories: int = 0
+    solo_victories: int = 0
+    duo_victories: int = 0
+    club: BrawlStarsClub | None = None
+    brawlers: list[BrawlerInfo] = Field(default_factory=list)
+    name_color: str | None = None
+    icon: BrawlStarsIcon | None = None
+
+
+class BrawlStarPlayerBrawler(BaseModel):
+    """Minimal brawler data from the /v1/brawlers endpoint."""
+
+    id: int
+    name: str
+
+
+class BrawlStarsBrawlerList(BaseModel):
+    """Response from the /v1/brawlers list endpoint."""
+
+    items: list[BrawlStarPlayerBrawler] = Field(default_factory=list)
+
+
+class BrawlStarsEvent(BaseModel):
+    """A single event in the current rotation."""
+
+    start_time: str
+    end_time: str
+    event: "BrawlStarsEventDetail"
+
+
+class BrawlStarsEventDetail(BaseModel):
+    """Details of a single event slot."""
+
+    id: int
+    mode: str
+    map: str
+
+
+class BrawlStarsEventRotation(BaseModel):
+    """Wrapper for the event rotation endpoint (list in response)."""
+
+    items: list[BrawlStarsEvent] = Field(default_factory=list)
+
+
+class BattlePlayer(BaseModel):
+    """Player info within a battle."""
+
+    tag: str
+    name: str
+    brawler: BrawlerInfo | None = None
+
+
+class BrawlStarsBattle(BaseModel):
+    """A single battle entry from the battle log."""
+
+    battle_time: str
+    mode: str
+    type: str
+    result: str | None = None
+    duration: int | None = None
+    trophy_change: int | None = None
+    star_player: BattlePlayer | None = None
+    teams: list[list[BattlePlayer]] | None = None
+    players: list[BattlePlayer] | None = None
+    map: str | None = None
+
+
+class BrawlStarsBattleLog(BaseModel):
+    """Response from the battle log endpoint."""
+
+    items: list[BrawlStarsBattle] = Field(default_factory=list)
+
+
+# ── Service ──────────────────────────────────────────────────────────────────
+
+
+class BrawlStarsService:
+    """Typed HTTP client for the Brawl Stars API.
+
+    Manages a reusable aiohttp.ClientSession, reads the API token from
+    environment (``brawlstarsToken``), and returns Pydantic-validated models
+    instead of raw dicts.
+    """
+
+    BASE_URL = "https://api.brawlstars.com/v1"
+
+    def __init__(self, token: str | None = None, session: aiohttp.ClientSession | None = None) -> None:
+        """Initialise with an optional token and optional shared session.
+
+        When ``session`` is ``None`` a new one will be created on first request
+        and reused for the lifetime of the service.
+        """
+        from config import brawlstarsToken  # noqa: PLC0415
+
+        self._token: str = token or brawlstarsToken
+        self._session: aiohttp.ClientSession | None = session
+
+    # ── Session management ──────────────────────────────────────────────────
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        """Close the underlying session if owned by this service."""
+        if self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def __aenter__(self) -> BrawlStarsService:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    # ── Request helpers ─────────────────────────────────────────────────────
+
+    async def _get(self, path: str) -> dict[str, Any] | None:
+        """Perform a GET request to the Brawl Stars API.
+
+        Returns the parsed JSON dict on success (HTTP 200), or ``None`` on
+        any non-200 status.
+        """
+        session = await self._get_session()
+        async with session.get(
+            f"{self.BASE_URL}{path}",
+            headers={"Authorization": f"Bearer {self._token}"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as response:
+            if response.status != 200:
+                return None
+            data: Any = await response.json()
+            if isinstance(data, dict):
+                return data
+            return None
+
+    async def _get_list(self, path: str) -> list[dict[str, Any]]:
+        """Perform a GET request that returns a list (e.g. event rotation)."""
+        session = await self._get_session()
+        async with session.get(
+            f"{self.BASE_URL}{path}",
+            headers={"Authorization": f"Bearer {self._token}"},
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as response:
+            if response.status != 200:
+                return []
+            data: Any = await response.json()
+            if isinstance(data, list):
+                return data
+            return []
+
+    # ── Player endpoints ────────────────────────────────────────────────────
+
+    async def get_player(self, tag: str) -> BrawlStarsPlayer | None:
+        """Fetch full player info from the Brawl Stars API.
+
+        The tag should include the ``#`` prefix (e.g. ``#ABC123``).
+        """
+        data = await self._get(f"/players/%23{tag[1:]}")
+        if data is None:
+            return None
+        return BrawlStarsPlayer.model_validate(data)
+
+    async def get_battle_log(self, tag: str) -> list[BrawlStarsBattle]:
+        """Fetch the recent battle log for a player."""
+        data = await self._get(f"/players/%23{tag[1:]}/battlelog")
+        if data is None:
+            return []
+        items = data.get("items", [])
+        return [BrawlStarsBattle.model_validate(b) for b in items]
+
+    async def get_brawler_list(self) -> list[BrawlStarPlayerBrawler]:
+        """Fetch the full list of all brawlers available in the game."""
+        data = await self._get("/brawlers")
+        if data is None:
+            return []
+        items = data.get("items", [])
+        return [BrawlStarPlayerBrawler.model_validate(b) for b in items]
+
+    # ── Club endpoints ──────────────────────────────────────────────────────
+
+    async def get_club(self, tag: str) -> BrawlStarsClub | None:
+        """Fetch club information.
+
+        The tag should include the ``#`` prefix (e.g. ``#ABC123``).
+        """
+        data = await self._get(f"/clubs/%23{tag[1:]}")
+        if data is None:
+            return None
+        return BrawlStarsClub.model_validate(data)
+
+    # ── Events endpoints ────────────────────────────────────────────────────
+
+    async def get_events(self) -> list[dict[str, Any]]:
+        """Fetch the current event rotation.
+
+        Returns raw dicts because the event rotation schema is a list at the
+        top level. Callers can access ``event["event"]["map"]`` etc.
+        """
+        return await self._get_list("/events/rotation")
+
+
+# Module-level singleton for convenient import
+_default_service: BrawlStarsService | None = None
+
+
+def get_brawlstars_service() -> BrawlStarsService:
+    """Return the application-wide BrawlStarsService singleton.
+
+    Creates it on first call.
+    """
+    global _default_service  # noqa: PLW0603
+    if _default_service is None:
+        _default_service = BrawlStarsService()
+    return _default_service

--- a/services/xp_calculator.py
+++ b/services/xp_calculator.py
@@ -12,6 +12,7 @@ import random
 
 from api import BoostTarget, XpBoostRepository
 
+
 class XpCalculator:
     """Service for calculating XP gains based on user, role, and channel boosts.
 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -24,7 +24,6 @@ from unittest.mock import MagicMock
 import pytest
 
 import tests.mock_config as mock_config
-
 from exceptions import DatabaseError
 
 mock_config.patch_config_module()


### PR DESCRIPTION
## Summary

Creates a typed `BrawlStarsService` class with Pydantic response models for the Brawl Stars API, consolidating the raw API calls spread across 6 command files.

## Changes

- **`services/brawlstars.py`** (new): Contains `BrawlStarsService` class with typed methods, Pydantic models for all Brawl Stars API responses, centralized session management, and a `get_brawlstars_service()` singleton
- **`commands/utility/brawlstars/playerinfo.py`**: Uses `BrawlStarsService.get_player()` and `.get_brawler_list()`
- **`commands/utility/brawlstars/battlelog.py`**: Uses `BrawlStarsService.get_battle_log()`
- **`commands/utility/brawlstars/brawlers.py`**: Uses `BrawlStarsService.get_player()` (returns typed brawler models)
- **`commands/utility/brawlstars/events.py`**: Uses `BrawlStarsService.get_events()`
- **`commands/utility/brawlstars/club.py`**: Uses `BrawlStarsService.get_club()`
- **`commands/utility/brawlstars/link.py`**: Uses `BrawlStarsService.get_player()`

## Benefits
- API response validation at parse time (catch Brawl Stars API changes early)
- Typed models instead of raw dict/JSON access
- All API calls consolidated into one service class
- Shared aiohttp session management
- Cleaner async context manager support (`async with BrawlStarsService() as svc:`)

Closes #1312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Brawl Stars commands now use a centralized service for data retrieval, improving reliability and consistency across player, club, brawler, event, link, and battle log views.
* **Improvements**
  * Pagination and embeds handle missing/optional fields more gracefully and present battle, brawler, club, and event info more consistently to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->