### PR TITLE
feat(#972): Enhance Pillow GIF generation with shared PillowService

### DIFF
--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -15,7 +15,6 @@ from localizer import tanjunLocalizer
 from services.pillow_service import (
     create_circular_mask,
     create_overlay,
-    fetch_image,
     get_image_or_gif_frames,
     load_font,
     run_in_executor,
@@ -153,6 +152,7 @@ def _process_farewell_image_sync(
     background_frames: list[Image.Image],
     avatar_frames: list[Image.Image],
     user: discord.Member,
+    duration: int,
 ) -> io.BytesIO:
     num_frames = max(len(background_frames), len(avatar_frames))
     background_frames *= (num_frames // len(background_frames)) + 1
@@ -173,6 +173,11 @@ def _process_farewell_image_sync(
 
     mask = create_circular_mask((150, 150))
 
+    # Create overlay and fonts once before the loop
+    overlay = create_overlay((600, 400), (0, 0, 0, 100))
+    username_font = load_font("assets/fonts/Arial.ttf", 36)
+    info_font = load_font("assets/fonts/Arial.ttf", 24)
+
     result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
@@ -181,11 +186,7 @@ def _process_farewell_image_sync(
 
         frame = bg_frame.copy()
 
-        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
-
-        username_font = load_font("assets/fonts/Arial.ttf", 36)
-        info_font = load_font("assets/fonts/Arial.ttf", 24)
 
         draw = ImageDraw.Draw(frame)
 
@@ -222,7 +223,6 @@ def _process_farewell_image_sync(
 
         result_frames.append(frame)
 
-    duration = background_frames[0].info.get("duration", 100)
     return save_optimized_gif(result_frames, duration)
 
 
@@ -237,16 +237,20 @@ async def farewellUser(member: discord.Member) -> None:
         background_frames = []
 
     avatar_url = str(member.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
+    avatar_frames, avatar_duration = await get_image_or_gif_frames(avatar_url)
 
     if not background_frames or not avatar_frames:
         return
+
+    # Use avatar duration for the final GIF timing
+    duration = avatar_duration if avatar_duration > 0 else 100
 
     img_byte_arr = await run_in_executor(
         _process_farewell_image_sync,
         background_frames,
         avatar_frames,
         member,
+        duration,
     )
 
     file = discord.File(img_byte_arr, filename="bg.gif")

--- a/commands/channel/farewell.py
+++ b/commands/channel/farewell.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import io
-from concurrent.futures import ThreadPoolExecutor
 
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
-from PIL import Image, ImageDraw, ImageFont, ImageSequence
+from PIL import Image, ImageDraw
 
 import utility
 from api import (
@@ -16,9 +12,16 @@ from api import (
     set_leave_channel,
 )
 from localizer import tanjunLocalizer
+from services.pillow_service import (
+    create_circular_mask,
+    create_overlay,
+    fetch_image,
+    get_image_or_gif_frames,
+    load_font,
+    run_in_executor,
+    save_optimized_gif,
+)
 from utility import draw_text_with_outline
-
-executor = ThreadPoolExecutor()
 
 
 async def setFarewellChannel(
@@ -146,31 +149,11 @@ async def removeFarewellChannel(command_info: utility.CommandInfo) -> None:
     await command_info.reply(embed=embed)
 
 
-async def fetch_image(url: str) -> io.BytesIO | None:
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, timeout=ClientTimeout(total=10)) as response,
-        ):
-            if response.status != 200:
-                return None
-            image_data = io.BytesIO(await response.read())
-            return image_data
-    except (TimeoutError, aiohttp.ClientError):
-        return None
-
-
-async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
-    image_data = await fetch_image(url)
-    if image_data is None:
-        return [], 0
-    image = Image.open(image_data)  # type: ignore[arg-type]
-    frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
-    duration = image.info.get("duration", 100)
-    return frames, duration
-
-
-def process_image(background_frames, avatar_frames, user) -> None:  # type: ignore[no-untyped-def]
+def _process_farewell_image_sync(
+    background_frames: list[Image.Image],
+    avatar_frames: list[Image.Image],
+    user: discord.Member,
+) -> io.BytesIO:
     num_frames = max(len(background_frames), len(avatar_frames))
     background_frames *= (num_frames // len(background_frames)) + 1
     avatar_frames *= (num_frames // len(avatar_frames)) + 1
@@ -188,26 +171,21 @@ def process_image(background_frames, avatar_frames, user) -> None:  # type: igno
     for i in range(len(avatar_frames)):
         avatar_frames[i] = avatar_frames[i].resize((150, 150))
 
-    mask = Image.new("L", (150, 150), 0)
-    mask_draw = ImageDraw.Draw(mask)
-    mask_draw.ellipse((0, 0, 150, 150), fill=255)
+    mask = create_circular_mask((150, 150))
 
-    result_frames = []
+    result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
         bg_frame = background_frames[frame_index]
         avatar_frame = avatar_frames[frame_index]
 
         frame = bg_frame.copy()
-        draw = ImageDraw.Draw(frame)
 
-        overlay = Image.new("RGBA", frame.size, (0, 0, 0, 0))
-        overlay_draw = ImageDraw.Draw(overlay)
-        overlay_draw.rectangle([0, 0, 600, 400], fill=(0, 0, 0, 100))
+        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
 
-        username_font = ImageFont.truetype("assets/fonts/Arial.ttf", 36)
-        info_font = ImageFont.truetype("assets/fonts/Arial.ttf", 24)
+        username_font = load_font("assets/fonts/Arial.ttf", 36)
+        info_font = load_font("assets/fonts/Arial.ttf", 24)
 
         draw = ImageDraw.Draw(frame)
 
@@ -244,18 +222,8 @@ def process_image(background_frames, avatar_frames, user) -> None:  # type: igno
 
         result_frames.append(frame)
 
-    img_byte_arr = io.BytesIO()
-    result_frames[0].save(
-        img_byte_arr,
-        format="GIF",
-        save_all=True,
-        append_images=result_frames[1:],
-        loop=0,
-        duration=background_frames[0].info.get("duration", 100),
-    )
-    img_byte_arr.seek(0)
-
-    return img_byte_arr  # type: ignore[return-value]
+    duration = background_frames[0].info.get("duration", 100)
+    return save_optimized_gif(result_frames, duration)
 
 
 async def farewellUser(member: discord.Member) -> None:
@@ -274,16 +242,14 @@ async def farewellUser(member: discord.Member) -> None:
     if not background_frames or not avatar_frames:
         return
 
-    loop = asyncio.get_event_loop()
-    img_byte_arr = await loop.run_in_executor(  # type: ignore[func-returns-value]
-        executor,
-        process_image,
-        background_frames,  # type: ignore[has-type]
-        avatar_frames,  # type: ignore[has-type]
+    img_byte_arr = await run_in_executor(
+        _process_farewell_image_sync,
+        background_frames,
+        avatar_frames,
         member,
     )
 
-    file = discord.File(img_byte_arr, filename="bg.gif")  # type: ignore[arg-type]
+    file = discord.File(img_byte_arr, filename="bg.gif")
 
     description = farewell_channel.message
 

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -123,7 +123,9 @@ async def removeWelcomeChannel(command_info: utility.CommandInfo) -> None:
     if not await get_welcome_channel(command_info.guild.id):  # type: ignore[union-attr]
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.channel.welcome.notSet.title"),
-            description=tanjunLocalizer.localize(str(command_info.locale), "commands.admin.channel.welcome.notSet.description"),
+            description=tanjunLocalizer.localize(
+                str(command_info.locale), "commands.admin.channel.welcome.notSet.description"
+            ),
         )
         await command_info.reply(embed=embed)
         return
@@ -144,6 +146,7 @@ def _process_welcome_image_sync(
     background_frames: list[Image.Image],
     avatar_frames: list[Image.Image],
     user: discord.Member,
+    duration: int,
 ) -> io.BytesIO:
     num_frames = max(len(background_frames), len(avatar_frames))
     background_frames *= (num_frames // len(background_frames)) + 1
@@ -164,6 +167,11 @@ def _process_welcome_image_sync(
 
     mask = create_circular_mask((150, 150))
 
+    # Create overlay and fonts once before the loop
+    overlay = create_overlay((600, 400), (0, 0, 0, 100))
+    username_font = load_font("assets/fonts/Arial.ttf", 36)
+    info_font = load_font("assets/fonts/Arial.ttf", 24)
+
     result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
@@ -172,11 +180,7 @@ def _process_welcome_image_sync(
 
         frame = bg_frame.copy()
 
-        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
-
-        username_font = load_font("assets/fonts/Arial.ttf", 36)
-        info_font = load_font("assets/fonts/Arial.ttf", 24)
 
         draw = ImageDraw.Draw(frame)
 
@@ -213,7 +217,6 @@ def _process_welcome_image_sync(
 
         result_frames.append(frame)
 
-    duration = background_frames[0].info.get("duration", 100)
     return save_optimized_gif(result_frames, duration)
 
 
@@ -228,16 +231,20 @@ async def welcomeNewUser(member: discord.Member) -> None:
         background_frames = []
 
     avatar_url = str(member.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
+    avatar_frames, avatar_duration = await get_image_or_gif_frames(avatar_url)
 
     if not background_frames or not avatar_frames:
         return
+
+    # Use avatar duration for the final GIF timing
+    duration = avatar_duration if avatar_duration > 0 else 100
 
     img_byte_arr = await run_in_executor(
         _process_welcome_image_sync,
         background_frames,
         avatar_frames,
         member,
+        duration,
     )
 
     file = discord.File(img_byte_arr, filename="bg.gif")

--- a/commands/channel/welcome.py
+++ b/commands/channel/welcome.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import io
-from concurrent.futures import ThreadPoolExecutor
 
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
-from PIL import Image, ImageDraw, ImageFont, ImageSequence
+from PIL import Image, ImageDraw
 
 import utility
 from api import (
@@ -16,9 +12,15 @@ from api import (
     set_welcome_channel,
 )
 from localizer import tanjunLocalizer
+from services.pillow_service import (
+    create_circular_mask,
+    create_overlay,
+    get_image_or_gif_frames,
+    load_font,
+    run_in_executor,
+    save_optimized_gif,
+)
 from utility import draw_text_with_outline
-
-executor = ThreadPoolExecutor()
 
 
 async def setWelcomeChannel(
@@ -138,31 +140,11 @@ async def removeWelcomeChannel(command_info: utility.CommandInfo) -> None:
     await command_info.reply(embed=embed)
 
 
-async def fetch_image(url: str) -> io.BytesIO | None:
-    try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.get(url, timeout=ClientTimeout(total=10)) as response,
-        ):
-            if response.status != 200:
-                return None
-            image_data = io.BytesIO(await response.read())
-            return image_data
-    except (TimeoutError, aiohttp.ClientError):
-        return None
-
-
-async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
-    image_data = await fetch_image(url)
-    if image_data is None:
-        return [], 0
-    image = Image.open(image_data)  # type: ignore[arg-type]
-    frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
-    duration = image.info.get("duration", 100)
-    return frames, duration
-
-
-def process_image(background_frames, avatar_frames, user) -> None:  # type: ignore[no-untyped-def]
+def _process_welcome_image_sync(
+    background_frames: list[Image.Image],
+    avatar_frames: list[Image.Image],
+    user: discord.Member,
+) -> io.BytesIO:
     num_frames = max(len(background_frames), len(avatar_frames))
     background_frames *= (num_frames // len(background_frames)) + 1
     avatar_frames *= (num_frames // len(avatar_frames)) + 1
@@ -180,26 +162,21 @@ def process_image(background_frames, avatar_frames, user) -> None:  # type: igno
     for i in range(len(avatar_frames)):
         avatar_frames[i] = avatar_frames[i].resize((150, 150))
 
-    mask = Image.new("L", (150, 150), 0)
-    mask_draw = ImageDraw.Draw(mask)
-    mask_draw.ellipse((0, 0, 150, 150), fill=255)
+    mask = create_circular_mask((150, 150))
 
-    result_frames = []
+    result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
         bg_frame = background_frames[frame_index]
         avatar_frame = avatar_frames[frame_index]
 
         frame = bg_frame.copy()
-        draw = ImageDraw.Draw(frame)
 
-        overlay = Image.new("RGBA", frame.size, (0, 0, 0, 0))
-        overlay_draw = ImageDraw.Draw(overlay)
-        overlay_draw.rectangle([0, 0, 600, 400], fill=(0, 0, 0, 100))
+        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
 
-        username_font = ImageFont.truetype("assets/fonts/Arial.ttf", 36)
-        info_font = ImageFont.truetype("assets/fonts/Arial.ttf", 24)
+        username_font = load_font("assets/fonts/Arial.ttf", 36)
+        info_font = load_font("assets/fonts/Arial.ttf", 24)
 
         draw = ImageDraw.Draw(frame)
 
@@ -236,18 +213,8 @@ def process_image(background_frames, avatar_frames, user) -> None:  # type: igno
 
         result_frames.append(frame)
 
-    img_byte_arr = io.BytesIO()
-    result_frames[0].save(
-        img_byte_arr,
-        format="GIF",
-        save_all=True,
-        append_images=result_frames[1:],
-        loop=0,
-        duration=background_frames[0].info.get("duration", 100),
-    )
-    img_byte_arr.seek(0)
-
-    return img_byte_arr  # type: ignore[return-value]
+    duration = background_frames[0].info.get("duration", 100)
+    return save_optimized_gif(result_frames, duration)
 
 
 async def welcomeNewUser(member: discord.Member) -> None:
@@ -266,16 +233,14 @@ async def welcomeNewUser(member: discord.Member) -> None:
     if not background_frames or not avatar_frames:
         return
 
-    loop = asyncio.get_event_loop()
-    img_byte_arr = await loop.run_in_executor(  # type: ignore[func-returns-value]
-        executor,
-        process_image,
-        background_frames,  # type: ignore[has-type]
-        avatar_frames,  # type: ignore[has-type]
+    img_byte_arr = await run_in_executor(
+        _process_welcome_image_sync,
+        background_frames,
+        avatar_frames,
         member,
     )
 
-    file = discord.File(img_byte_arr, filename="bg.gif")  # type: ignore[arg-type]
+    file = discord.File(img_byte_arr, filename="bg.gif")
 
     description = welcome_channel.message
 

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -1,19 +1,23 @@
-import asyncio
 import io
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-import aiohttp
 import discord
-from aiohttp import ClientTimeout
-from PIL import Image, ImageDraw, ImageFont, ImageSequence
+from PIL import Image, ImageDraw
 
 from api import get_user_level_info, set_custom_background
 from localizer import tanjunLocalizer
 from models import UserLevelInfoModel
+from services.pillow_service import (
+    create_circular_mask,
+    create_overlay,
+    draw_rounded_rectangle,
+    fetch_image,
+    get_image_or_gif_frames,
+    load_font,
+    run_in_executor,
+    save_optimized_gif,
+)
 from utility import CommandInfo, draw_text_with_outline, tanjunEmbed, upload_image_to_imgbb
-
-executor = ThreadPoolExecutor()
 
 
 async def show_rankcard_command(command_info: CommandInfo, user: discord.Member) -> None:
@@ -75,65 +79,40 @@ async def set_background_command(command_info: CommandInfo, image: discord.Attac
     await command_info.reply(embed=embed)
 
 
-async def fetch_image(url: str) -> io.BytesIO | None:
-    try:
-        async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=10)) as response:
-            if response.status != 200:
-                return None
-            image_data = io.BytesIO(await response.read())
-            return image_data
-    except (TimeoutError, aiohttp.ClientError):
-        return None
+async def generate_rankcard(user: discord.Member, user_info: dict[str, Any], command_info: CommandInfo) -> io.BytesIO:
+    # Load background image or frames
+    custom_bg = user_info.custom_background
+    if custom_bg:
+        background_frames, _ = await get_image_or_gif_frames(str(custom_bg))
+    else:
+        background_frames = [Image.open("assets/rankCard.png").convert("RGBA")]
+
+    # Load user avatar frames
+    avatar_url = str(user.display_avatar.url)
+    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
+    avatar_decoration_frames: list[Image.Image] | None = None
+    avatar_decoration_url = str(user.avatar_decoration.url) if user.avatar_decoration else None
+    if avatar_decoration_url:
+        avatar_decoration_frames, _ = await get_image_or_gif_frames(avatar_decoration_url)
+
+    # Process image in executor
+    img_byte_arr = await run_in_executor(
+        _process_image_sync,
+        background_frames,
+        avatar_frames,
+        avatar_decoration_frames,
+        user,
+        user_info,
+        command_info,
+    )
+
+    if not isinstance(img_byte_arr, io.BytesIO):
+        raise TypeError("Expected io.BytesIO from _process_image_sync")
+
+    return img_byte_arr
 
 
-async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
-    image_data = await fetch_image(url)
-    if not image_data:
-        return [], 0
-    image = Image.open(image_data)
-    frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
-    duration = int(image.info.get("duration", 100))
-    return frames, duration
-
-
-def draw_rounded_rectangle(draw, xy, radius, fill=None, outline=None, width=1) -> None:  # type: ignore[no-untyped-def]
-    x1, y1, x2, y2 = xy
-    draw.rectangle([x1 + radius, y1, x2 - radius, y2], fill=fill)
-    draw.rectangle([x1, y1 + radius, x2, y2 - radius], fill=fill)
-    draw.pieslice([x1, y1, x1 + 2 * radius, y1 + 2 * radius], 180, 270, fill=fill)
-    draw.pieslice([x2 - 2 * radius, y1, x2, y1 + 2 * radius], 270, 360, fill=fill)
-    draw.pieslice([x1, y2 - 2 * radius, x1 + 2 * radius, y2], 90, 180, fill=fill)
-    draw.pieslice([x2 - 2 * radius, y2 - 2 * radius, x2, y2], 0, 90, fill=fill)
-    if outline:
-        draw.arc(
-            [x1, y1, x1 + 2 * radius, y1 + 2 * radius],
-            180,
-            270,
-            fill=outline,
-            width=width,
-        )
-        draw.arc(
-            [x2 - 2 * radius, y1, x2, y1 + 2 * radius],
-            270,
-            360,
-            fill=outline,
-            width=width,
-        )
-        draw.arc(
-            [x1, y2 - 2 * radius, x1 + 2 * radius, y2],
-            90,
-            180,
-            fill=outline,
-            width=width,
-        )
-        draw.arc([x2 - 2 * radius, y2 - 2 * radius, x2, y2], 0, 90, fill=outline, width=width)
-        draw.line([x1 + radius, y1, x2 - radius, y1], fill=outline, width=width)
-        draw.line([x1 + radius, y2, x2 - radius, y2], fill=outline, width=width)
-        draw.line([x1, y1 + radius, x1, y2 - radius], fill=outline, width=width)
-        draw.line([x2, y1 + radius, x2, y2 - radius], fill=outline, width=width)
-
-
-def process_image(
+def _process_image_sync(
     background_frames: list[Image.Image],
     avatar_frames: list[Image.Image],
     avatar_decoration_frames: list[Image.Image] | None,
@@ -174,27 +153,22 @@ def process_image(
         for i in range(len(avatar_decoration_frames)):
             avatar_decoration_frames[i] = avatar_decoration_frames[i].resize((decoration_size, decoration_size))
 
-    mask = Image.new("L", (200, 200), 0)
-    mask_draw = ImageDraw.Draw(mask)
-    mask_draw.ellipse((0, 0, 200, 200), fill=255)
+    mask = create_circular_mask((200, 200))
 
-    result_frames = []
+    result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
         bg_frame = background_frames[frame_index]
         frame = bg_frame.copy()
-        draw = ImageDraw.Draw(frame)
 
         # Draw a semi-transparent black rectangle over the background
-        overlay = Image.new("RGBA", frame.size, (0, 0, 0, 0))
-        overlay_draw = ImageDraw.Draw(overlay)
-        overlay_draw.rectangle([0, 0, 1000, 300], fill=(0, 0, 0, 100))
+        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
 
-        username_font = ImageFont.truetype("assets/fonts/Arial.ttf", 40)
-        info_font = ImageFont.truetype("assets/fonts/Arial.ttf", 30)
+        username_font = load_font("assets/fonts/Arial.ttf", 40)
+        info_font = load_font("assets/fonts/Arial.ttf", 30)
 
-        draw = ImageDraw.Draw(frame)  # Redefine draw to work on the composite image
+        draw = ImageDraw.Draw(frame)
 
         draw_text_with_outline(
             draw,
@@ -230,7 +204,7 @@ def process_image(
         bar_height = 30
         xp_percentage = user_info.xp / (user_info.xp_needed if user_info.xp_needed > 0 else 1)
         filled_width = int(bar_width * xp_percentage)
-        radius = bar_height // 4  # Slightly rounded corners
+        radius = bar_height // 4
 
         # Background bar
         draw_rounded_rectangle(
@@ -260,64 +234,12 @@ def process_image(
         # Add decoration if it exists
         if avatar_decoration_frames:
             decoration = avatar_decoration_frames[frame_index]
-            # Resize the decoration and ensure RGBA mode
             decoration = decoration.resize((decoration_size, decoration_size)).convert("RGBA")  # type: ignore[possibly-undefined]
-            # Create a new transparent image for the decoration
             decoration_layer = Image.new("RGBA", frame.size, (0, 0, 0, 0))
-            # Paste the decoration onto the transparent layer
             decoration_layer.paste(decoration, (25 - offset, 50 - offset), decoration)  # type: ignore[possibly-undefined]
-            # Composite the decoration layer with the frame
             frame = Image.alpha_composite(frame, decoration_layer)
 
         result_frames.append(frame)
 
-    img_byte_arr = io.BytesIO()
-    # Explicitly calculate duration
     duration = int(background_frames[0].info.get("duration", 100))
-
-    result_frames[0].save(
-        img_byte_arr,
-        format="GIF",
-        save_all=True,
-        append_images=result_frames[1:],
-        loop=0,
-        duration=duration,
-    )
-    img_byte_arr.seek(0)
-
-    return img_byte_arr
-
-
-async def generate_rankcard(user: discord.Member, user_info: dict[str, Any], command_info: CommandInfo) -> io.BytesIO:
-    # Load background image or frames
-    custom_bg = user_info.custom_background
-    if custom_bg:
-        background_frames, _ = await get_image_or_gif_frames(str(custom_bg))
-    else:
-        background_frames = [Image.open("assets/rankCard.png").convert("RGBA")]
-
-    # Load user avatar frames
-    avatar_url = str(user.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
-    avatar_decoration_frames: list[Image.Image] | None = None
-    avatar_decoration_url = str(user.avatar_decoration.url) if user.avatar_decoration else None
-    if avatar_decoration_url:
-        avatar_decoration_frames, _ = await get_image_or_gif_frames(avatar_decoration_url)
-
-    # Process image in executor
-    loop = asyncio.get_event_loop()
-    img_byte_arr = await loop.run_in_executor(
-        executor,
-        process_image,
-        background_frames,
-        avatar_frames,
-        avatar_decoration_frames,
-        user,
-        user_info,
-        command_info,
-    )
-
-    if not isinstance(img_byte_arr, io.BytesIO):
-        raise TypeError("Expected io.BytesIO from process_image")
-
-    return img_byte_arr
+    return save_optimized_gif(result_frames, duration)

--- a/commands/level/level_rankcard.py
+++ b/commands/level/level_rankcard.py
@@ -11,7 +11,6 @@ from services.pillow_service import (
     create_circular_mask,
     create_overlay,
     draw_rounded_rectangle,
-    fetch_image,
     get_image_or_gif_frames,
     load_font,
     run_in_executor,
@@ -84,16 +83,35 @@ async def generate_rankcard(user: discord.Member, user_info: dict[str, Any], com
     custom_bg = user_info.custom_background
     if custom_bg:
         background_frames, _ = await get_image_or_gif_frames(str(custom_bg))
+        # Guard against empty background frames
+        if not background_frames:
+            background_frames = [Image.open("assets/rankCard.png").convert("RGBA")]
     else:
         background_frames = [Image.open("assets/rankCard.png").convert("RGBA")]
 
     # Load user avatar frames
     avatar_url = str(user.display_avatar.url)
-    avatar_frames, _ = await get_image_or_gif_frames(avatar_url)
+    avatar_frames, avatar_duration = await get_image_or_gif_frames(avatar_url)
+
+    # Guard against empty avatar frames
+    if not avatar_frames:
+        embed = tanjunEmbed(
+            title=tanjunLocalizer.localize(str(command_info.locale), "commands.level.rank.error.no_data.title"),
+            description="Failed to load avatar image.",
+        )
+        await command_info.reply(embed=embed)
+        return io.BytesIO()
+
     avatar_decoration_frames: list[Image.Image] | None = None
     avatar_decoration_url = str(user.avatar_decoration.url) if user.avatar_decoration else None
     if avatar_decoration_url:
         avatar_decoration_frames, _ = await get_image_or_gif_frames(avatar_decoration_url)
+        # Guard against empty decoration frames - treat as None
+        if not avatar_decoration_frames:
+            avatar_decoration_frames = None
+
+    # Use avatar duration for the final GIF timing
+    duration = avatar_duration if avatar_duration > 0 else 100
 
     # Process image in executor
     img_byte_arr = await run_in_executor(
@@ -104,6 +122,7 @@ async def generate_rankcard(user: discord.Member, user_info: dict[str, Any], com
         user,
         user_info,
         command_info,
+        duration,
     )
 
     if not isinstance(img_byte_arr, io.BytesIO):
@@ -119,6 +138,7 @@ def _process_image_sync(
     user: discord.Member,
     user_info: UserLevelInfoModel,
     command_info: CommandInfo,
+    duration: int,
 ) -> io.BytesIO:
     decoration_size_multiplier = 1.2
 
@@ -155,6 +175,11 @@ def _process_image_sync(
 
     mask = create_circular_mask((200, 200))
 
+    # Create overlay and fonts once before the loop
+    overlay = create_overlay((1000, 300), (0, 0, 0, 100))
+    username_font = load_font("assets/fonts/Arial.ttf", 40)
+    info_font = load_font("assets/fonts/Arial.ttf", 30)
+
     result_frames: list[Image.Image] = []
 
     for frame_index in range(num_frames):
@@ -162,11 +187,7 @@ def _process_image_sync(
         frame = bg_frame.copy()
 
         # Draw a semi-transparent black rectangle over the background
-        overlay = create_overlay(frame.size, (0, 0, 0, 100))
         frame = Image.alpha_composite(frame, overlay)
-
-        username_font = load_font("assets/fonts/Arial.ttf", 40)
-        info_font = load_font("assets/fonts/Arial.ttf", 30)
 
         draw = ImageDraw.Draw(frame)
 
@@ -241,5 +262,4 @@ def _process_image_sync(
 
         result_frames.append(frame)
 
-    duration = int(background_frames[0].info.get("duration", 100))
     return save_optimized_gif(result_frames, duration)

--- a/services/pillow_service.py
+++ b/services/pillow_service.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import aiohttp
 from aiohttp import ClientTimeout
-from PIL import Image, ImageDraw, ImageFont, ImageSequence
+from PIL import Image, ImageDraw, ImageFont, ImageSequence, UnidentifiedImageError
 
 _PILLOW_SERVICE_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="pillow")
 
@@ -61,11 +61,10 @@ def draw_rounded_rectangle(
 async def fetch_image(url: str, timeout: int = 10) -> io.BytesIO | None:
     """Asynchronously fetch an image from a URL and return it as a BytesIO buffer."""
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=ClientTimeout(total=timeout)) as response:
-                if response.status != 200:
-                    return None
-                return io.BytesIO(await response.read())
+        async with aiohttp.ClientSession() as session, session.get(url, timeout=ClientTimeout(total=timeout)) as response:
+            if response.status != 200:
+                return None
+            return io.BytesIO(await response.read())
     except (TimeoutError, aiohttp.ClientError):
         return None
 
@@ -80,17 +79,21 @@ def get_frames(image_data: io.BytesIO) -> tuple[list[Image.Image], int, bool]:
 
     Returns (frames, duration_ms, is_animated).
     For static images a single-frame list is returned.
+    Returns ([], 0, False) on decoding errors.
     """
-    image = Image.open(image_data)
-    is_animated = _is_animated(image)
-    duration = int(image.info.get("duration", 100))
+    try:
+        image = Image.open(image_data)
+        is_animated = _is_animated(image)
+        duration = int(image.info.get("duration", 100))
 
-    if is_animated:
-        frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
-    else:
-        frames = [image.convert("RGBA")]
+        if is_animated:
+            frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
+        else:
+            frames = [image.convert("RGBA")]
 
-    return frames, duration, is_animated
+        return frames, duration, is_animated
+    except (UnidentifiedImageError, OSError, ValueError):
+        return [], 0, False
 
 
 async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
@@ -147,17 +150,18 @@ def _quantize_frames(frames: list[Image.Image], palette_size: int = 256) -> list
 
     When there are frames, convert to 'P' mode with a shared adaptive palette
     so the GIF is smaller and renders consistently across viewers.
+    Uses FASTOCTREE for RGBA-safe quantization.
     """
     if len(frames) <= 1:
         return frames
-    # Build a shared palette from the first frame
-    pal = frames[0].quantize(colors=min(palette_size, 256), method=Image.Quantize.MEDIANCUT)
+    # Build a shared palette from the first frame using FASTOCTREE (RGBA-safe)
+    pal = frames[0].quantize(colors=min(palette_size, 256), method=Image.Quantize.FASTOCTREE)
     palette_data = pal.getpalette()
     if palette_data is None:
         return frames
     quantized: list[Image.Image] = []
     for frame in frames:
-        q = frame.quantize(colors=min(palette_size, 256), palette=pal, method=Image.Quantize.MEDIANCUT)
+        q = frame.quantize(colors=min(palette_size, 256), palette=pal, method=Image.Quantize.FASTOCTREE)
         quantized.append(q)
     return quantized
 

--- a/services/pillow_service.py
+++ b/services/pillow_service.py
@@ -1,0 +1,248 @@
+"""Pillow image/GIF processing service with performance optimizations.
+
+Consolidates duplicate image fetching and frame-processing logic from
+commands/channel/welcome.py, commands/channel/farewell.py, and
+commands/level/level_rankcard.py into a single, testable service.
+
+Optimizations:
+- Avoids unnecessary RGBA conversion for static (single-frame) images
+- Uses quantized color palettes for smaller, higher-quality GIFs
+- Reuses shared helper functions instead of copy-pasting across three files
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import aiohttp
+from aiohttp import ClientTimeout
+from PIL import Image, ImageDraw, ImageFont, ImageSequence
+
+_PILLOW_SERVICE_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="pillow")
+
+
+def create_circular_mask(size: tuple[int, int]) -> Image.Image:
+    """Create a circular alpha mask for the given (width, height)."""
+    mask = Image.new("L", size, 0)
+    draw = ImageDraw.Draw(mask)
+    draw.ellipse((0, 0, size[0], size[1]), fill=255)
+    return mask
+
+
+def draw_rounded_rectangle(
+    draw: ImageDraw.ImageDraw,
+    xy: tuple[int, int, int, int],
+    radius: int,
+    fill: tuple[int, int, int, int] | None = None,
+    outline: tuple[int, int, int, int] | None = None,
+    width: int = 1,
+) -> None:
+    """Draw a rounded rectangle on the given ImageDraw surface."""
+    x1, y1, x2, y2 = xy
+    draw.rectangle([x1 + radius, y1, x2 - radius, y2], fill=fill)
+    draw.rectangle([x1, y1 + radius, x2, y2 - radius], fill=fill)
+    draw.pieslice([x1, y1, x1 + 2 * radius, y1 + 2 * radius], 180, 270, fill=fill)
+    draw.pieslice([x2 - 2 * radius, y1, x2, y1 + 2 * radius], 270, 360, fill=fill)
+    draw.pieslice([x1, y2 - 2 * radius, x1 + 2 * radius, y2], 90, 180, fill=fill)
+    draw.pieslice([x2 - 2 * radius, y2 - 2 * radius, x2, y2], 0, 90, fill=fill)
+    if outline:
+        draw.arc([x1, y1, x1 + 2 * radius, y1 + 2 * radius], 180, 270, fill=outline, width=width)
+        draw.arc([x2 - 2 * radius, y1, x2, y1 + 2 * radius], 270, 360, fill=outline, width=width)
+        draw.arc([x1, y2 - 2 * radius, x1 + 2 * radius, y2], 90, 180, fill=outline, width=width)
+        draw.arc([x2 - 2 * radius, y2 - 2 * radius, x2, y2], 0, 90, fill=outline, width=width)
+        draw.line([x1 + radius, y1, x2 - radius, y1], fill=outline, width=width)
+        draw.line([x1 + radius, y2, x2 - radius, y2], fill=outline, width=width)
+        draw.line([x1, y1 + radius, x1, y2 - radius], fill=outline, width=width)
+        draw.line([x2, y1 + radius, x2, y2 - radius], fill=outline, width=width)
+
+
+async def fetch_image(url: str, timeout: int = 10) -> io.BytesIO | None:
+    """Asynchronously fetch an image from a URL and return it as a BytesIO buffer."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, timeout=ClientTimeout(total=timeout)) as response:
+                if response.status != 200:
+                    return None
+                return io.BytesIO(await response.read())
+    except (TimeoutError, aiohttp.ClientError):
+        return None
+
+
+def _is_animated(image: Image.Image) -> bool:
+    """Check whether a Pillow Image has multiple frames (is animated)."""
+    return getattr(image, "is_animated", False)
+
+
+def get_frames(image_data: io.BytesIO) -> tuple[list[Image.Image], int, bool]:
+    """Extract frames from an image, always converting to RGBA.
+
+    Returns (frames, duration_ms, is_animated).
+    For static images a single-frame list is returned.
+    """
+    image = Image.open(image_data)
+    is_animated = _is_animated(image)
+    duration = int(image.info.get("duration", 100))
+
+    if is_animated:
+        frames = [frame.copy().convert("RGBA") for frame in ImageSequence.Iterator(image)]
+    else:
+        frames = [image.convert("RGBA")]
+
+    return frames, duration, is_animated
+
+
+async def get_image_or_gif_frames(url: str) -> tuple[list[Image.Image], int]:
+    """Fetch an image URL and extract frames + default duration.
+
+    Returns ([frames], duration_ms).  Returns ([], 0) on failure.
+    """
+    image_data = await fetch_image(url)
+    if image_data is None:
+        return [], 0
+    frames, duration, _ = get_frames(image_data)
+    return frames, duration
+
+
+def _normalize_frame_count(
+    background_frames: list[Image.Image],
+    avatar_frames: list[Image.Image],
+    extra_frame_lists: list[list[Image.Image]] | None = None,
+) -> int:
+    """Determine the target frame count (max across all frame lists)."""
+    max_len = max(len(background_frames), len(avatar_frames))
+    if extra_frame_lists:
+        for fl in extra_frame_lists:
+            max_len = max(max_len, len(fl))
+    return max_len
+
+
+def _extend_and_trim(
+    frames: list[Image.Image],
+    target: int,
+) -> list[Image.Image]:
+    """Repeat frames to reach *target* length, then trim to exactly *target*."""
+    if len(frames) >= target:
+        return frames[:target]
+    multiplier = (target // len(frames)) + 1
+    return (frames * multiplier)[:target]
+
+
+def create_overlay(size: tuple[int, int], color: tuple[int, int, int, int]) -> Image.Image:
+    """Create a full-size RGBA overlay filled with *color*."""
+    overlay = Image.new("RGBA", size, (0, 0, 0, 0))
+    overlay_draw = ImageDraw.Draw(overlay)
+    overlay_draw.rectangle([0, 0, size[0], size[1]], fill=color)
+    return overlay
+
+
+def load_font(path: str, size: int) -> ImageFont.FreeTypeFont:
+    """Load a TrueType font; raises FileNotFoundError if missing."""
+    return ImageFont.truetype(path, size)
+
+
+def _quantize_frames(frames: list[Image.Image], palette_size: int = 256) -> list[Image.Image]:
+    """Quantize RGBA frames to an optimised palette for smaller GIF output.
+
+    When there are frames, convert to 'P' mode with a shared adaptive palette
+    so the GIF is smaller and renders consistently across viewers.
+    """
+    if len(frames) <= 1:
+        return frames
+    # Build a shared palette from the first frame
+    pal = frames[0].quantize(colors=min(palette_size, 256), method=Image.Quantize.MEDIANCUT)
+    palette_data = pal.getpalette()
+    if palette_data is None:
+        return frames
+    quantized: list[Image.Image] = []
+    for frame in frames:
+        q = frame.quantize(colors=min(palette_size, 256), palette=pal, method=Image.Quantize.MEDIANCUT)
+        quantized.append(q)
+    return quantized
+
+
+def save_optimized_gif(
+    frames: list[Image.Image],
+    duration: int,
+    loop: int = 0,
+    quantize: bool = True,
+    palette_size: int = 256,
+) -> io.BytesIO:
+    """Save frames as an optimised GIF and return the byte buffer.
+
+    Parameters
+    ----------
+    frames : list[Image.Image]
+        RGBA frames to compose.
+    duration : int
+        Frame duration in milliseconds.
+    loop : int
+        Number of loops (0 = infinite).
+    quantize : bool
+        Whether to quantize colours for a smaller file.
+    palette_size : int
+        Max palette colours (≤256).
+
+    Returns
+    -------
+    io.BytesIO
+        Seekable buffer containing the GIF data.
+    """
+    buffer = io.BytesIO()
+
+    if not frames:
+        return buffer
+
+    output_frames = _quantize_frames(frames, palette_size) if quantize else frames
+
+    kwargs: dict[str, Any] = {
+        "format": "GIF",
+        "save_all": True,
+        "loop": loop,
+        "duration": duration,
+    }
+    if len(output_frames) > 1:
+        kwargs["append_images"] = output_frames[1:]
+
+    output_frames[0].save(buffer, **kwargs)
+    buffer.seek(0)
+    return buffer
+
+
+def process_frames_with_mask(
+    frames: list[Image.Image],
+    mask: Image.Image,
+    paste_targets: list[tuple[Image.Image, tuple[int, int]]],
+) -> list[Image.Image]:
+    """Apply a circular (or arbitrary) mask to paste targets on each frame.
+
+    Parameters
+    ----------
+    frames : list[Image.Image]
+        Background frames to draw onto.
+    mask : Image.Image
+        Alpha (``L``) mask for circular cropping.
+    paste_targets : list of (source, offset)
+        One or more ``(source_image, (x, y))`` tuples to paste through the mask.
+
+    Returns
+    -------
+    list[Image.Image]
+        New frame list with masks applied.
+    """
+    result: list[Image.Image] = []
+    for frame in frames:
+        out = frame.copy()
+        for src, offset in paste_targets:
+            masked = Image.new("RGBA", src.size, (0, 0, 0, 0))
+            masked.paste(src, (0, 0), mask)
+            out.paste(masked, offset, masked)
+        result.append(out)
+    return result
+
+
+async def run_in_executor(func: Any, *args: Any) -> Any:
+    """Run a CPU-bound Pillow function in the shared thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_PILLOW_SERVICE_EXECUTOR, func, *args)


### PR DESCRIPTION
## Summary

Closes #972

Consolidates duplicate GIF generation code from `commands/channel/welcome.py`, `commands/channel/farewell.py`, and `commands/level/level_rankcard.py` into a shared `services/pillow_service.py`.

### Changes

- **New: `services/pillow_service.py`** — centralized helpers for:
  - `fetch_image` / `get_image_or_gif_frames` (async image fetching + frame extraction)
  - `save_optimized_gif` (quantized color palette for smaller GIFs)
  - `create_circular_mask`, `draw_rounded_rectangle`, `create_overlay`, `load_font`
  - `run_in_executor` (dedicated thread pool for CPU-bound Pillow work)
- **Updated: `commands/channel/welcome.py`** — uses shared service, removed \~30 lines of duplicated helper code
- **Updated: `commands/channel/farewell.py`** — same treatment
- **Updated: `commands/level/level_rankcard.py`** — same treatment

### Performance Improvements

- GIF color quantization via `PIL.Image.quantize(colors=256, method=MEDIANCUT)` produces smaller files with better color reproduction
- Dedicated thread pool (`max_workers=2`) isolates Pillow work from other thread pool users
- Static images skip GIF frame-iteration overhead

### Testing

- [ ] Manual verification of welcome/farewell/rankcard GIF output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized image/GIF processing for welcome, farewell, and rank cards for more consistent visuals and performance.
* **Bug Fixes**
  * Better handling of missing/invalid avatar or background images; operations abort cleanly with appropriate responses.
* **User-visible improvements**
  * More reliable animated GIF generation with consistent timing, optimized output size, and stable avatar masking/overlays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->