### PR TITLE
Fix #934: Attachments not used in scheduled messages

### DIFF
--- a/api.py
+++ b/api.py
@@ -897,6 +897,7 @@ def get_table_definitions() -> dict[str, str]:
         `send_time` DATETIME NOT NULL,
         `repeatInterval` MEDIUMINT UNSIGNED,
         `repeatAmount` MEDIUMINT UNSIGNED,
+        `attachments` TEXT,
         `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         INDEX `idx_sendtime` (send_time),
         INDEX `idx_user` (user_id),
@@ -1114,6 +1115,20 @@ async def create_tables(bot=None) -> None:
         await asyncio.gather(
             *[execute_action(tables[table_name], bot=bot) for table_name in batch]
         )
+
+    # Run schema migrations for existing tables that need column additions
+    migrations = [
+        # Add attachments column to scheduledMessages for attachment support
+        """ALTER TABLE `scheduledMessages`
+         ADD COLUMN `attachments` TEXT DEFAULT NULL
+         AFTER `repeatAmount`""",
+    ]
+    for migration in migrations:
+        try:
+            await execute_action(migration, bot=bot)
+        except Exception:
+            # Column already exists or other benign error - migration is idempotent
+            pass
 
 
 async def add_warning(
@@ -2553,19 +2568,20 @@ async def add_scheduled_message(
     send_time: datetime,
     repeat_interval: int | None = None,
     repeat_amount: int | None = None,
+    attachments: str | None = None,
 ) -> None:
     query = """
     INSERT INTO scheduledMessages
-    (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount)
-    VALUES (%s, %s, %s, %s, %s, %s, %s)
+    (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
     """
-    params = (guild_id, channel_id, user_id, content, send_time, repeat_interval, repeat_amount)
+    params = (guild_id, channel_id, user_id, content, send_time, repeat_interval, repeat_amount, attachments)
     await execute_action(query, params)
 
 
 async def get_scheduled_messages(user_id: str) -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
     FROM scheduledMessages
     WHERE user_id = %s
     ORDER BY send_time ASC
@@ -2590,7 +2606,7 @@ async def get_user_scheduled_messages_in_timeframe(
     guild_id: str | None = None,
 ) -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
     FROM scheduledMessages
     WHERE user_id = %s
     AND send_time BETWEEN %s AND %s
@@ -2621,7 +2637,7 @@ async def update_scheduled_message_repeat_amount(message_id: int, repeat_amount:
 
 async def get_ready_scheduled_messages() -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
     FROM scheduledMessages WHERE send_time <= NOW()
     """
     rows: list[ScheduledMessageModel] = []

--- a/api.py
+++ b/api.py
@@ -31,6 +31,7 @@ from models import (
     LevelRolesGroupModel,
     LogEnableModel,
     ReportModel,
+    ScheduledMessageModel,
     TicketMessageModel,
     TicketModel,
     TokenOverviewModel,
@@ -1126,9 +1127,14 @@ async def create_tables(bot=None) -> None:
     for migration in migrations:
         try:
             await execute_action(migration, bot=bot)
-        except Exception:
-            # Column already exists or other benign error - migration is idempotent
-            pass
+        except Exception as exc:
+            exc_str = str(exc).lower()
+            # Only suppress "column already exists" / duplicate column errors
+            if "column already exists" in exc_str or "duplicate column" in exc_str or "duplicate column name" in exc_str:
+                logging.debug("Migration skipped (column already exists): %s", migration[:60])
+            else:
+                logging.exception("Unexpected migration error: %s", migration[:60])
+                raise
 
 
 async def add_warning(

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -1,11 +1,14 @@
+import io
 import logging
 from datetime import datetime, timedelta
 
+import aiohttp
 import discord
 
 import utility
 from localizer import tanjunLocalizer
 from services.scheduled_message_service import (
+    Attachment,
     ScheduledMessageService,
     ScheduleMessageParams,
 )
@@ -151,7 +154,6 @@ async def schedule_message(
             return
 
     # Convert Discord attachments to our Attachment model if provided
-    from services.scheduled_message_service import Attachment
     attachment_models = None
     if attachments:
         attachment_models = [
@@ -236,8 +238,33 @@ async def send_scheduled_messages(client: discord.Client) -> None:
             if isinstance(target, (discord.CategoryChannel, discord.ForumChannel)):
                 return
 
+            # Parse and send attachments if present
+            files: list[discord.File] = []
+            if msg.attachments:
+                try:
+                    attachment_data: list[dict] = json.loads(msg.attachments)
+                    for att_data in attachment_data:
+                        url = att_data.get("url", "")
+                        filename = att_data.get("filename", "file")
+
+                        async with aiohttp.ClientSession() as session:
+                            async with session.get(url) as resp:
+                                if resp.status == 200:
+                                    file_bytes = await resp.read()
+                                    files.append(
+                                        discord.File(
+                                            io.BytesIO(file_bytes),
+                                            filename=filename,
+                                        )
+                                    )
+                except (json.JSONDecodeError, Exception):
+                    logging.exception("Failed to parse attachments for scheduled message %s", message_id)
+
             embed = utility.tanjunEmbed(description=content)
-            await target.send(content=content, embed=embed)
+            send_kwargs: dict = {"content": content, "embed": embed}
+            if files:
+                send_kwargs["files"] = files
+            await target.send(**send_kwargs)
 
             if repeat_amount and repeat_amount != 0:
                 repeat_amount -= 1

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -1,4 +1,5 @@
 import io
+import json
 import logging
 from datetime import datetime, timedelta
 

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -732,6 +732,16 @@ class ScheduledMessageCommands(discord.app_commands.Group):
         channel=app_commands.locale_str("utility_schedulemessage_params_channel_description"),
         repeatinterval=app_commands.locale_str("utility_schedulemessage_params_repeat_description"),
         repeatamount=app_commands.locale_str("utility_schedulemessage_params_repeatamount_description"),
+        attachment1=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment2=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment3=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment4=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment5=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment6=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment7=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment8=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment9=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
+        attachment10=app_commands.locale_str("utility_schedulemessage_params_attachment_description"),
     )
     async def schedulemessage(  # type: ignore[no-untyped-def]
         self,
@@ -741,16 +751,16 @@ class ScheduledMessageCommands(discord.app_commands.Group):
         channel: discord.TextChannel = None,  # type: ignore[assignment]
         repeatinterval: app_commands.Range[str, 0, 15] = None,  # type: ignore[assignment]
         repeatamount: app_commands.Range[int, 0, 1000] = None,  # type: ignore[assignment]
-        # attachment1: discord.Attachment = None,
-        # attachment2: discord.Attachment = None,
-        # attachment3: discord.Attachment = None,
-        # attachment4: discord.Attachment = None,
-        # attachment5: discord.Attachment = None,
-        # attachment6: discord.Attachment = None,
-        # attachment7: discord.Attachment = None,
-        # attachment8: discord.Attachment = None,
-        # attachment9: discord.Attachment = None,
-        # attachment10: discord.Attachment = None,
+        attachment1: discord.Attachment = None,  # type: ignore[assignment]
+        attachment2: discord.Attachment = None,  # type: ignore[assignment]
+        attachment3: discord.Attachment = None,  # type: ignore[assignment]
+        attachment4: discord.Attachment = None,  # type: ignore[assignment]
+        attachment5: discord.Attachment = None,  # type: ignore[assignment]
+        attachment6: discord.Attachment = None,  # type: ignore[assignment]
+        attachment7: discord.Attachment = None,  # type: ignore[assignment]
+        attachment8: discord.Attachment = None,  # type: ignore[assignment]
+        attachment9: discord.Attachment = None,  # type: ignore[assignment]
+        attachment10: discord.Attachment = None,  # type: ignore[assignment]
     ) -> None:
         await ctx.response.defer()
         command_info = utility.CommandInfo(
@@ -765,8 +775,8 @@ class ScheduledMessageCommands(discord.app_commands.Group):
             client=ctx.client,
         )
 
-        attachments: list[Any] = []  # [a for a in [attachment1, attachment2, attachment3, attachment4, attachment5,
-        #                          attachment6, attachment7, attachment8, attachment9, attachment10] if a is not None]
+        attachments: list[discord.Attachment] = [a for a in [attachment1, attachment2, attachment3, attachment4, attachment5,
+                                        attachment6, attachment7, attachment8, attachment9, attachment10] if a is not None]
 
         await scheduleMessageCommand(
             command_info=command_info,

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -776,7 +776,7 @@ class ScheduledMessageCommands(discord.app_commands.Group):
         )
 
         attachments: list[discord.Attachment] = [a for a in [attachment1, attachment2, attachment3, attachment4, attachment5,
-                                        attachment6, attachment7, attachment8, attachment9, attachment10] if a is not None]
+                                                             attachment6, attachment7, attachment8, attachment9, attachment10] if a is not None]
 
         await scheduleMessageCommand(
             command_info=command_info,

--- a/models.py
+++ b/models.py
@@ -123,6 +123,7 @@ class ScheduledMessageModel(BaseModel):
     send_time: datetime
     repeat_interval: int | None
     repeat_amount: int | None
+    attachments: str | None = None
     created_at: datetime
 
     @classmethod

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -7,6 +7,7 @@ service with typed parameter models and clear method names.
 
 from datetime import datetime
 from typing import Annotated, Any
+import json
 
 from pydantic import BaseModel, Field, StringConstraints
 
@@ -51,17 +52,14 @@ class ScheduledMessageService:
         from api import execute_action
 
         # Serialize attachments to JSON for storage
-        # Note: The database schema currently doesn't have an attachments column.
-        # This implementation validates and normalizes attachments but cannot persist them
-        # until the schema is updated with an attachments TEXT/JSON column.
-        # attachments_json = None
-        # if params.attachments:
-        #     attachments_json = json.dumps([att.model_dump() for att in params.attachments])
+        attachments_json = None
+        if params.attachments:
+            attachments_json = json.dumps([att.model_dump() for att in params.attachments])
 
         query = """
         INSERT INTO scheduledMessages
-        (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount)
-        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        (guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """
         db_params = (
             params.guild_id,
@@ -71,10 +69,9 @@ class ScheduledMessageService:
             params.send_time,
             params.repeat_interval,
             params.repeat_amount,
+            attachments_json,
         )
         await execute_action(query, db_params)
-        # TODO: Once the database schema is updated to include an attachments column,
-        # add attachments_json to the INSERT statement and db_params tuple.
 
     @staticmethod
     async def get_user_messages(user_id: UserId) -> list[ScheduledMessageModel]:
@@ -82,7 +79,7 @@ class ScheduledMessageService:
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, created_at
+               repeatInterval, repeatAmount, attachments, created_at
         FROM scheduledMessages
         WHERE user_id = %s
         ORDER BY send_time ASC
@@ -122,7 +119,7 @@ class ScheduledMessageService:
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, created_at
+               repeatInterval, repeatAmount, attachments, created_at
         FROM scheduledMessages WHERE send_time <= NOW()
         """
         rows: list[ScheduledMessageModel] = []
@@ -141,7 +138,7 @@ class ScheduledMessageService:
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, created_at
+               repeatInterval, repeatAmount, attachments, created_at
         FROM scheduledMessages
         WHERE user_id = %s
         AND send_time BETWEEN %s AND %s


### PR DESCRIPTION
## What changed

Fixes #934 — attachments provided when scheduling a message were never persisted to the database and never sent when the scheduled message was due.

### Changes

- **Database schema**: Added `attachments` TEXT column to `scheduledMessages` table. Includes an ALTER TABLE migration for existing databases.
- **ScheduledMessageModel**: Added `attachments: str | None` field to match the new column.
- **ScheduledMessageService.schedule()**: Serializes attachment metadata to JSON and stores it in the `attachments` column.
- **send_scheduled_messages()**: Downloads and re-attaches files via aiohttp when the scheduled message is due.
- **Slash command**: Enabled the 10 attachment slots in the `/schedulemessage` command (previously commented out).

### How it works

1. User provides attachments via the slash command → serialized as JSON (filename, content_type, size, url) → stored in DB
2. When the scheduled time arrives → bot re-downloads from Discord CDN → sends as `discord.File` objects alongside the message
3. Supports up to 10 attachments per scheduled message (Discord limit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for attaching files to scheduled messages: users can add up to 10 optional attachments when scheduling a message.
  * Attachments are persisted with scheduled messages and will be fetched and delivered alongside message content and embeds when the message is sent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->