### PR TITLE
Fix #1236: Enable more mypy strict checks and fix resulting type errors

### DIFF
--- a/commands/admin/boosterrole.py
+++ b/commands/admin/boosterrole.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, booster_service
 
 
 async def create_booster_role(command_info: utility.CommandInfo, role: discord.Role) -> None:

--- a/commands/utility/delete_booster_channel.py
+++ b/commands/utility/delete_booster_channel.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, booster_service
 from utility import CommandInfo, tanjunEmbed
 
 

--- a/commands/utility/delete_booster_role.py
+++ b/commands/utility/delete_booster_role.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, booster_service
 from utility import CommandInfo, tanjunEmbed
 
 

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -248,16 +248,15 @@ async def send_scheduled_messages(client: discord.Client) -> None:
                         url = att_data.get("url", "")
                         filename = att_data.get("filename", "file")
 
-                        async with aiohttp.ClientSession() as session:
-                            async with session.get(url) as resp:
-                                if resp.status == 200:
-                                    file_bytes = await resp.read()
-                                    files.append(
-                                        discord.File(
-                                            io.BytesIO(file_bytes),
-                                            filename=filename,
-                                        )
+                        async with aiohttp.ClientSession() as session, session.get(url) as resp:
+                            if resp.status == 200:
+                                file_bytes = await resp.read()
+                                files.append(
+                                    discord.File(
+                                        io.BytesIO(file_bytes),
+                                        filename=filename,
                                     )
+                                )
                 except (json.JSONDecodeError, Exception):
                     logging.exception("Failed to parse attachments for scheduled message %s", message_id)
 

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -244,19 +244,21 @@ async def send_scheduled_messages(client: discord.Client) -> None:
             if msg.attachments:
                 try:
                     attachment_data: list[dict] = json.loads(msg.attachments)
-                    for att_data in attachment_data:
-                        url = att_data.get("url", "")
-                        filename = att_data.get("filename", "file")
+                    timeout = aiohttp.ClientTimeout(total=30)
+                    async with aiohttp.ClientSession(timeout=timeout) as session:
+                        for att_data in attachment_data:
+                            url = att_data.get("url", "")
+                            filename = att_data.get("filename", "file")
 
-                        async with aiohttp.ClientSession() as session, session.get(url) as resp:
-                            if resp.status == 200:
-                                file_bytes = await resp.read()
-                                files.append(
-                                    discord.File(
-                                        io.BytesIO(file_bytes),
-                                        filename=filename,
+                            async with session.get(url) as resp:
+                                if resp.status == 200:
+                                    file_bytes = await resp.read()
+                                    files.append(
+                                        discord.File(
+                                            io.BytesIO(file_bytes),
+                                            filename=filename,
+                                        )
                                     )
-                                )
                 except (json.JSONDecodeError, Exception):
                     logging.exception("Failed to parse attachments for scheduled message %s", message_id)
 

--- a/commands/utility/setup_booster_channel.py
+++ b/commands/utility/setup_booster_channel.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, booster_service
 from utility import CommandInfo, tanjunEmbed
 
 

--- a/commands/utility/setup_booster_role.py
+++ b/commands/utility/setup_booster_role.py
@@ -1,8 +1,8 @@
 import discord
 
 import utility
-from services.booster_service import BoosterType, booster_service
 from localizer import tanjunLocalizer
+from services.booster_service import BoosterType, booster_service
 from utility import CommandInfo, tanjunEmbed
 
 

--- a/config.py
+++ b/config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import os
 import sys
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from dotenv import load_dotenv
 from pydantic import Field, SecretStr, ValidationError, computed_field
@@ -80,7 +79,7 @@ class Settings(BaseSettings, cli_parse_args=False):
 
     @computed_field  # type: ignore[prop-decorator]
     @property
-    def welcome_emoji_id(self) -> Optional[int]:
+    def welcome_emoji_id(self) -> int | None:
         raw = self.welcome_emoji_id_raw
         return int(raw) if raw.isdigit() else None
 
@@ -130,7 +129,7 @@ CALC_DIVIDE: str = settings.calc_divide
 CALC_BACKSPACE: str = settings.calc_backspace
 
 # Emoji ID for welcome command (numeric Discord emoji ID)
-WELCOME_EMOJI_ID: Optional[int] = settings.welcome_emoji_id
+WELCOME_EMOJI_ID: int | None = settings.welcome_emoji_id
 
 
 # ── Startup validation ───────────────────────────────────────────────────────

--- a/config.py
+++ b/config.py
@@ -86,7 +86,7 @@ class Settings(BaseSettings, cli_parse_args=False):
 
 
 try:
-    settings = Settings()
+    settings = Settings()  # type: ignore[call-arg]
 except ValidationError as e:
     print(f"Configuration validation error: {e}", file=sys.stderr)
     sys.exit(1)

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -14,12 +14,12 @@ from commands.utility.claim_booster_role import (
 )
 from commands.utility.schedulemessage import send_scheduled_messages
 from commands.utility.twitch.twitch_api import notify_twitch_online
-from services.twitch_service import get_twitch_service
 from loops.alivemonitor import ping_server
 from loops.create_database_backup import create_database_backup
 from loops.giveaway import checkVoiceUsers, endGiveaways, sendReadyGiveaways
 from loops.level import addXpToVoiceUsers
 from minigames.add_level_xp import clearNotifiedUsers
+from services.twitch_service import get_twitch_service
 from utility import EmbedColor
 
 embeds = {}  # type: ignore[var-annotated]

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -1,4 +1,3 @@
-from typing import Any
 
 import discord
 from discord import app_commands

--- a/health/notifier.py
+++ b/health/notifier.py
@@ -76,6 +76,16 @@ async def notify_health_failures(
         )
         return
 
+    # Narrow type to a channel that supports .send()
+    if not hasattr(channel, "send"):
+        logger.warning(
+            "Channel %s does not support sending messages, cannot notify failures",
+            channel_id,
+        )
+        return
+
+    sendable: discord.abc.Messageable = channel  # type: ignore[assignment]
+
     chunks = [failures[i : i + 25] for i in range(0, len(failures), 25)]
     for idx, chunk in enumerate(chunks, start=1):
         title = f"⚠️ Health Check Failure ({idx}/{len(chunks)})" if len(chunks) > 1 else "⚠️ Health Check Failure"
@@ -95,7 +105,7 @@ async def notify_health_failures(
 
         content = f"<@{user_id}>" if idx == 1 else None
         try:
-            await channel.send(
+            await sendable.send(
                 content=content,
                 embed=embed,
             )

--- a/locale_file_health_check.py
+++ b/locale_file_health_check.py
@@ -95,10 +95,8 @@ class LocaleFileHealthCheck(HealthCheck):
             }
             missing_from_de = en_ids - de_ids
             if missing_from_de:
-                # Filter out None values (shouldn't happen based on comprehension above, but satisfy type checker)
-                valid_missing: set[str] = {s for s in missing_from_de if s is not None}  # type: ignore[arg-type]
                 # Limit to first 20 to avoid absurdly long messages
-                sample = sorted(valid_missing)[:20]
+                sample = sorted(missing_from_de)[:20]
                 if len(missing_from_de) > 20:
                     warnings.append(
                         f"en.json has {len(missing_from_de)} entries not in de.json (showing first 20): {', '.join(sample)}"

--- a/locale_file_health_check.py
+++ b/locale_file_health_check.py
@@ -95,8 +95,10 @@ class LocaleFileHealthCheck(HealthCheck):
             }
             missing_from_de = en_ids - de_ids
             if missing_from_de:
+                # Filter out None values (shouldn't happen based on comprehension above, but satisfy type checker)
+                valid_missing: set[str] = {s for s in missing_from_de if s is not None}  # type: ignore[arg-type]
                 # Limit to first 20 to avoid absurdly long messages
-                sample = sorted(missing_from_de)[:20]
+                sample = sorted(valid_missing)[:20]
                 if len(missing_from_de) > 20:
                     warnings.append(
                         f"en.json has {len(missing_from_de)} entries not in de.json (showing first 20): {', '.join(sample)}"

--- a/main.py
+++ b/main.py
@@ -81,9 +81,11 @@ bot = commands.AutoShardedBot(prefix, intents=intents, application_id=config.app
 
 
 @bot.event
-async def on_ready():
+async def on_ready() -> None:
     Path(tempfile.gettempdir(), "bot_ready").touch()
-    print(f"Logged in as {bot.user} (ID: {bot.user.id})")
+    user = bot.user
+    if user is not None:
+        print(f"Logged in as {user} (ID: {user.id})")
     await bot.change_presence(activity=discord.Game(name=config.activity.format(version=config.version)))
 
 
@@ -114,7 +116,7 @@ async def _init_database_pool() -> asyncmy.Pool | None:
         raise
 
 
-async def main():
+async def main() -> None:
     print("starting bot...")
     print("discord.py version: ", discord.__version__)
 
@@ -144,7 +146,9 @@ async def main():
                 ptask.cancel()
             # Await pending tasks to propagate cancellations
             await asyncio.gather(*pending, return_exceptions=True)
-            raise exception_to_raise
+            if exception_to_raise is not None:
+                raise exception_to_raise
+            raise RuntimeError("A task failed with no exception information")
 
     # Both tasks completed successfully, extract pool result
     pool = pool_task.result()
@@ -175,7 +179,9 @@ async def main():
                 ptask.cancel()
             # Await pending tasks to propagate cancellations
             await asyncio.gather(*pending, return_exceptions=True)
-            raise exception_to_raise
+            if exception_to_raise is not None:
+                raise exception_to_raise
+            raise RuntimeError("A task failed with no exception information")
 
     # Step 3: Preload guild configs into cache to avoid cold-start latency.
     from api import preload_guild_configs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,11 +199,11 @@ disallow_any_decorated = false
 disallow_any_unimported = false
 disallow_any_generics = false
 disallow_subclassing_any = false
-disallow_untyped_calls = false
+disallow_untyped_calls = true
 disallow_untyped_defs = true
-disallow_incomplete_defs = false
+disallow_incomplete_defs = true
 disallow_untyped_decorators = false
-no_implicit_reexport = false
+no_implicit_reexport = true
 warn_redundant_casts = false
 warn_unused_ignores = false
 warn_return_any = true
@@ -213,15 +213,6 @@ enable_error_code = []
 disable_error_code = [
     "attr-defined",
     "name-defined",
-    "unused-ignore",
-    "no-any-unimported",
-    "assignment",
-    "var-annotated",
-    "call-overload",
-    "return-value",
-    "no-any-return",
-    "unreachable",
-    "call-arg"
 ]
 
 exclude = [
@@ -230,3 +221,12 @@ exclude = [
     '^\\.mypy_cache/',
     '^\\.github/'
 ]
+
+[[tool.mypy.overrides]]
+# Legacy files with too many type errors; fix incrementally
+module = [
+    "utility",
+    "api",
+    "models",
+]
+ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ line-length = 127
 # ANN = flake8-annotations (for type hint checking)
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "C901", "UP", "A", "B", "SIM", "TID", "N", "ANN"]
+ignore = ["UP047"]
 
 # dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ line-length = 127
 # ANN = flake8-annotations (for type hint checking)
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "C901", "UP", "A", "B", "SIM", "TID", "N", "ANN"]
-ignore = ["UP047"]
+ignore = ["UP047"]  # Preserve explicit TypeAlias for compatibility with type checkers and variance control
 
 # dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 

--- a/repositories/level_config_repository.py
+++ b/repositories/level_config_repository.py
@@ -25,7 +25,7 @@ class LevelConfigRepository:
 
         # Check cache first
         cache_entry = _guild_config_cache.get(guild_id)
-        if _is_cache_valid(cache_entry, _GUILD_CONFIG_CACHE_TTL):
+        if _is_cache_valid(cache_entry, _GUILD_CONFIG_CACHE_TTL) and cache_entry is not None:
             # Reconstruct LevelConfig from cached dict
             data = cache_entry[0]
             if data:  # Non-empty cache entry means we have config
@@ -105,7 +105,7 @@ class LevelConfigRepository:
         await execute_action(query, params)
         self._invalidate(guild_id=config.guild_id)
 
-    async def update_field(self, guild_id: str, **kwargs) -> None:
+    async def update_field(self, guild_id: str, **kwargs: object) -> None:
         """Update specific fields on an existing config row.
 
         Only the provided kwargs are written; other columns are preserved.
@@ -167,9 +167,11 @@ class LevelConfigRepository:
             params.append(value)
 
         set_str = ", ".join(set_clauses)
+        columns = [field_map[k] for k in kwargs]
+        placeholders = ["%s"] * len(kwargs)
         query = f"""
-        INSERT INTO levelConfig (guild_id, {', '.join(field_map.get(k) for k in kwargs)})
-        VALUES (%s, {', '.join(['%s'] * len(kwargs))})
+        INSERT INTO levelConfig (guild_id, {', '.join(columns)})
+        VALUES (%s, {', '.join(placeholders)})
         ON DUPLICATE KEY UPDATE {set_str}
         """
         vals = tuple([guild_id] + list(params))

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -5,9 +5,9 @@ Consolidates the loose scheduled-message functions from api.py into a single
 service with typed parameter models and clear method names.
 """
 
+import json
 from datetime import datetime
 from typing import Annotated, Any
-import json
 
 from pydantic import BaseModel, Field, StringConstraints
 

--- a/tests/test_localizer.py
+++ b/tests/test_localizer.py
@@ -1,10 +1,13 @@
 """Tests for the LocalizerService and TranslationEntry classes."""
 
 import asyncio
+import contextlib
 import json
 import os
 import time
+from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -43,10 +46,8 @@ class _Locale(_LocaleBase):
 
 
 _loc_mod.discord.Locale = _LocaleBase
-try:
+with contextlib.suppress(Exception):
     _tr_mod.discord.Locale = _LocaleBase
-except Exception:
-    pass
 
 FAKE_DE = _Locale("de")
 FAKE_EN_US = _Locale("en-US")
@@ -61,7 +62,7 @@ _tr_mod.discord.app_commands.Translator = object
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _chdir(d: Path):
+def _chdir(d: Path) -> Callable[[], None]:
     """Return a callable that restores cwd after changing to d.parent."""
     old = os.getcwd()
     os.chdir(d.parent)
@@ -198,17 +199,17 @@ class TestValidateJson:
 # ===================================================================
 
 class TestFindEntry:
-    def test_exact(self, service: LocalizerService, sample_entries):
+    def test_exact(self, service: LocalizerService, sample_entries: list[TranslationEntry]) -> None:
         r = service._find_entry(sample_entries, "test.hello")
         assert r and r.identifier == "test.hello"
 
-    def test_case_insensitive(self, service: LocalizerService, sample_entries):
+    def test_case_insensitive(self, service: LocalizerService, sample_entries: list[TranslationEntry]) -> None:
         assert service._find_entry(sample_entries, "TEST.HELLO") is not None
 
-    def test_not_found(self, service: LocalizerService, sample_entries):
+    def test_not_found(self, service: LocalizerService, sample_entries: list[TranslationEntry]) -> None:
         assert service._find_entry(sample_entries, "nope") is None
 
-    def test_empty(self, service: LocalizerService):
+    def test_empty(self, service: LocalizerService) -> None:
         assert service._find_entry([], "x") is None
 
 
@@ -217,7 +218,7 @@ class TestFindEntry:
 # ===================================================================
 
 class TestLoadSync:
-    def test_load_en(self, service: LocalizerService, locale_dir):
+    def test_load_en(self, service: LocalizerService, locale_dir: Path) -> None:
         restore = _chdir(locale_dir)
         try:
             r = service._load_sync("en")
@@ -225,7 +226,7 @@ class TestLoadSync:
         finally:
             restore()
 
-    def test_fallback_to_en(self, service: LocalizerService, locale_dir):
+    def test_fallback_to_en(self, service: LocalizerService, locale_dir: Path) -> None:
         restore = _chdir(locale_dir)
         try:
             service._load_sync("en")
@@ -234,7 +235,7 @@ class TestLoadSync:
         finally:
             restore()
 
-    def test_fallback_no_en_cache(self, service: LocalizerService, locale_dir):
+    def test_fallback_no_en_cache(self, service: LocalizerService, locale_dir: Path) -> None:
         restore = _chdir(locale_dir)
         try:
             service.reload_locales()
@@ -263,7 +264,7 @@ class TestLoadSync:
         finally:
             restore()
 
-    def test_bad_json(self, service: LocalizerService, tmp_path):
+    def test_bad_json(self, service: LocalizerService, tmp_path: Path) -> None:
         d = tmp_path / "locales"
         d.mkdir()
         (d / "en.json").write_text("{{{ bad", encoding="utf-8")
@@ -434,10 +435,10 @@ class TestReportMissing:
 
 class _FakeTranslator:
     """Mimics TanjunTranslator.translate() without inheriting from the broken mock base."""
-    def __init__(self, svc: LocalizerService):
+    def __init__(self, svc: LocalizerService) -> None:
         self._localizer = svc
 
-    async def translate(self, string, locale, context):
+    async def translate(self, string: object, locale: object, context: object) -> Optional[str]:
         from localizer import TRANSLATION_NOT_FOUND
         key_str = str(string).replace("_", ".")
         current = self._localizer.localize(locale, key_str)
@@ -513,8 +514,8 @@ class TestGlobalInstance:
         assert isinstance(tanjunLocalizer, LocalizerService)
 
     def test_singleton(self):
-        from localizer import tanjunLocalizer as r
-        assert r is tanjunLocalizer
+        from localizer import tanjunLocalizer as tanjun_localizer
+        assert tanjun_localizer is tanjunLocalizer
 
 
 # ===================================================================
@@ -539,7 +540,7 @@ class TestDeprecatedApi:
         finally:
             restore()
 
-    def test_async_matches_sync(self, service: LocalizerService, locale_dir):
+    def test_async_matches_sync(self, service: LocalizerService, locale_dir: Path) -> None:
         restore = _chdir(locale_dir)
         try:
             loop = asyncio.new_event_loop()
@@ -547,7 +548,7 @@ class TestDeprecatedApi:
             loop.close()
             s = service._load_sync("de")
             assert len(a) == len(s) and all(
-                ai.identifier == si.identifier for ai, si in zip(a, s)
+                ai.identifier == si.identifier for ai, si in zip(a, s, strict=True)
             )
         finally:
             restore()

--- a/tests/test_localizer.py
+++ b/tests/test_localizer.py
@@ -7,13 +7,19 @@ import os
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Fix the broken discord mock from conftest
+# ---------------------------------------------------------------------------
+# conftest.py replaces sys.modules["discord"] with a MagicMock, so
+# localizer.discord.Locale is a MagicMock and isinstance(x, MagicMock) fails.
+# We patch it to a real base class here so isinstance checks work.
+import localizer as _loc_mod
 import tests.mock_config  # noqa: F401 – side-effect import
-
+import translator as _tr_mod
 from localizer import (
     CACHE_TTL,
     TRANSLATION_NOT_FOUND,
@@ -22,16 +28,6 @@ from localizer import (
     tanjunLocalizer,
 )
 from translator import TanjunTranslator
-
-# ---------------------------------------------------------------------------
-# Fix the broken discord mock from conftest
-# ---------------------------------------------------------------------------
-# conftest.py replaces sys.modules["discord"] with a MagicMock, so
-# localizer.discord.Locale is a MagicMock and isinstance(x, MagicMock) fails.
-# We patch it to a real base class here so isinstance checks work.
-
-import localizer as _loc_mod
-import translator as _tr_mod
 
 
 class _LocaleBase:
@@ -438,7 +434,7 @@ class _FakeTranslator:
     def __init__(self, svc: LocalizerService) -> None:
         self._localizer = svc
 
-    async def translate(self, string: object, locale: object, context: object) -> Optional[str]:
+    async def translate(self, string: object, locale: object, context: object) -> str | None:
         from localizer import TRANSLATION_NOT_FOUND
         key_str = str(string).replace("_", ".")
         current = self._localizer.localize(locale, key_str)
@@ -514,8 +510,9 @@ class TestGlobalInstance:
         assert isinstance(tanjunLocalizer, LocalizerService)
 
     def test_singleton(self):
-        from localizer import tanjunLocalizer as tanjun_localizer
-        assert tanjun_localizer is tanjunLocalizer
+        # tanjunLocalizer is a singleton - verify two imports return the same instance
+        import localizer as _localizer_mod
+        assert tanjunLocalizer is _localizer_mod.tanjunLocalizer
 
 
 # ===================================================================

--- a/tests/test_localizer.py
+++ b/tests/test_localizer.py
@@ -1,0 +1,553 @@
+"""Tests for the LocalizerService and TranslationEntry classes."""
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tests.mock_config  # noqa: F401 – side-effect import
+
+from localizer import (
+    CACHE_TTL,
+    TRANSLATION_NOT_FOUND,
+    LocalizerService,
+    TranslationEntry,
+    tanjunLocalizer,
+)
+from translator import TanjunTranslator
+
+# ---------------------------------------------------------------------------
+# Fix the broken discord mock from conftest
+# ---------------------------------------------------------------------------
+# conftest.py replaces sys.modules["discord"] with a MagicMock, so
+# localizer.discord.Locale is a MagicMock and isinstance(x, MagicMock) fails.
+# We patch it to a real base class here so isinstance checks work.
+
+import localizer as _loc_mod
+import translator as _tr_mod
+
+
+class _LocaleBase:
+    """Stands in for discord.Locale – real type for isinstance checks."""
+    pass
+
+
+class _Locale(_LocaleBase):
+    """Locale-like object with a .value attribute (mirrors discord.Locale)."""
+    def __init__(self, v: str):
+        self.value = v
+
+
+_loc_mod.discord.Locale = _LocaleBase
+try:
+    _tr_mod.discord.Locale = _LocaleBase
+except Exception:
+    pass
+
+FAKE_DE = _Locale("de")
+FAKE_EN_US = _Locale("en-US")
+FAKE_EN_GB = _Locale("en-GB")
+
+# Also need app_commands.Translator to be a real object so TanjunTranslator()
+# can be instantiated.  We patch it at the module level.
+_tr_mod.discord.app_commands.Translator = object
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _chdir(d: Path):
+    """Return a callable that restores cwd after changing to d.parent."""
+    old = os.getcwd()
+    os.chdir(d.parent)
+    return lambda: os.chdir(old)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def service() -> LocalizerService:
+    svc = LocalizerService()
+    svc._cache.clear()
+    return svc
+
+
+@pytest.fixture
+def sample_entries() -> list[TranslationEntry]:
+    return [
+        TranslationEntry(identifier="test.hello", translation="Hello, $name!", description="Greeting"),
+        TranslationEntry(identifier="test.farewell", translation="Goodbye, $name.", description="Farewell"),
+        TranslationEntry(identifier="test.plain", translation="Just a plain string."),
+    ]
+
+
+@pytest.fixture
+def locale_dir(tmp_path: Path) -> Path:
+    lp = tmp_path / "locales"
+    lp.mkdir()
+    en = [
+        {"identifier": "common.error", "translation": "An error occurred: $detail", "description": "err"},
+        {"identifier": "common.success", "translation": "Operation successful.", "description": "ok"},
+        {"identifier": "commands.ping.name", "translation": "ping", "description": "ping"},
+    ]
+    de = [
+        {"identifier": "common.error", "translation": "Ein Fehler ist aufgetreten: $detail", "description": "err DE"},
+        {"identifier": "common.success", "translation": "Vorgang erfolgreich.", "description": "ok DE"},
+        {"identifier": "commands.ping.name", "translation": "ping", "description": "ping DE"},
+    ]
+    (lp / "en.json").write_text(json.dumps(en), encoding="utf-8")
+    (lp / "de.json").write_text(json.dumps(de), encoding="utf-8")
+    return lp
+
+
+# ===================================================================
+# TranslationEntry
+# ===================================================================
+
+class TestTranslationEntry:
+    def test_basic(self):
+        e = TranslationEntry(identifier="g.hi", translation="Hello, $name!", description="greet")
+        assert e.identifier == "g.hi"
+        assert e.translation == "Hello, $name!"
+        assert e.description == "greet"
+
+    def test_no_description(self):
+        e = TranslationEntry(identifier="g.hi", translation="Hi")
+        assert e.description is None
+
+    def test_from_dict(self):
+        e = TranslationEntry.from_dict({"identifier": "x", "translation": "Y", "description": "Z"})
+        assert e.identifier == "x" and e.translation == "Y" and e.description == "Z"
+
+    def test_from_dict_no_desc(self):
+        e = TranslationEntry.from_dict({"identifier": "x", "translation": "Y"})
+        assert e.description is None
+
+    def test_from_dict_none_desc(self):
+        e = TranslationEntry.from_dict({"identifier": "x", "translation": "Y", "description": None})
+        assert e.description is None
+
+    def test_from_dict_coercion(self):
+        e = TranslationEntry.from_dict({"identifier": 42, "translation": True, "description": None})
+        assert e.identifier == "42"
+        assert e.translation == "True"
+
+
+# ===================================================================
+# _normalize_locale
+# ===================================================================
+
+class TestNormalizeLocale:
+    def test_fake_de(self, service: LocalizerService):
+        assert service._normalize_locale(FAKE_DE) == "de"
+
+    def test_fake_en_us(self, service: LocalizerService):
+        assert service._normalize_locale(FAKE_EN_US) == "en"
+
+    def test_fake_en_gb(self, service: LocalizerService):
+        assert service._normalize_locale(FAKE_EN_GB) == "en"
+
+    def test_str_de(self, service: LocalizerService):
+        assert service._normalize_locale("de") == "de"
+
+    def test_str_en_us(self, service: LocalizerService):
+        assert service._normalize_locale("en-US") == "en"
+
+    def test_str_en_gb(self, service: LocalizerService):
+        assert service._normalize_locale("en-GB") == "en"
+
+    def test_str_en(self, service: LocalizerService):
+        assert service._normalize_locale("en") == "en"
+
+    def test_str_unknown(self, service: LocalizerService):
+        assert service._normalize_locale("fr") == "fr"
+
+
+# ===================================================================
+# _validate_json
+# ===================================================================
+
+class TestValidateJson:
+    def test_valid(self, service: LocalizerService):
+        r = service._validate_json([{"identifier": "a", "translation": "A"}])
+        assert r is not None and len(r) == 1
+
+    def test_empty(self, service: LocalizerService):
+        assert service._validate_json([]) == []
+
+    def test_not_list(self, service: LocalizerService):
+        assert service._validate_json({"k": "v"}) is None
+
+    def test_non_dict_elements(self, service: LocalizerService):
+        assert service._validate_json(["x"]) is None
+
+    def test_two_entries(self, service: LocalizerService):
+        r = service._validate_json([{"identifier": "a", "translation": "A"}, {"identifier": "b", "translation": "B"}])
+        assert r is not None and len(r) == 2
+
+
+# ===================================================================
+# _find_entry
+# ===================================================================
+
+class TestFindEntry:
+    def test_exact(self, service: LocalizerService, sample_entries):
+        r = service._find_entry(sample_entries, "test.hello")
+        assert r and r.identifier == "test.hello"
+
+    def test_case_insensitive(self, service: LocalizerService, sample_entries):
+        assert service._find_entry(sample_entries, "TEST.HELLO") is not None
+
+    def test_not_found(self, service: LocalizerService, sample_entries):
+        assert service._find_entry(sample_entries, "nope") is None
+
+    def test_empty(self, service: LocalizerService):
+        assert service._find_entry([], "x") is None
+
+
+# ===================================================================
+# _load_sync
+# ===================================================================
+
+class TestLoadSync:
+    def test_load_en(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            r = service._load_sync("en")
+            assert len(r) == 3 and r[0].identifier == "common.error"
+        finally:
+            restore()
+
+    def test_fallback_to_en(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            service._load_sync("en")
+            r = service._load_sync("fr")
+            assert len(r) == 3
+        finally:
+            restore()
+
+    def test_fallback_no_en_cache(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            service.reload_locales()
+            r = service._load_sync("fr")
+            assert len(r) == 3
+        finally:
+            restore()
+
+    def test_cache_hit(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            r1 = service._load_sync("en")
+            r2 = service._load_sync("en")
+            assert r1 is r2
+        finally:
+            restore()
+
+    def test_cache_expiry(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            r1 = service._load_sync("en")
+            entries, _ = service._cache["en"]
+            service._cache["en"] = (entries, time.time() - CACHE_TTL - 1)
+            r2 = service._load_sync("en")
+            assert r1 is not r2 and len(r1) == len(r2)
+        finally:
+            restore()
+
+    def test_bad_json(self, service: LocalizerService, tmp_path):
+        d = tmp_path / "locales"
+        d.mkdir()
+        (d / "en.json").write_text("{{{ bad", encoding="utf-8")
+        old = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            assert service._load_sync("en") == []
+        finally:
+            os.chdir(old)
+
+    def test_german(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            r = service._load_sync("de")
+            assert len(r) == 3
+            assert r[0].translation == "Ein Fehler ist aufgetreten: $detail"
+        finally:
+            restore()
+
+
+# ===================================================================
+# localize
+# ===================================================================
+
+class TestLocalize:
+    def test_placeholder(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            assert service.localize("en", "common.error", detail="timeout") == "An error occurred: timeout"
+        finally:
+            restore()
+
+    def test_no_placeholder(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            assert service.localize("en", "common.success") == "Operation successful."
+        finally:
+            restore()
+
+    def test_missing_key(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            with patch.object(service, "_report_missing"):
+                assert service.localize("en", "xyz") == TRANSLATION_NOT_FOUND
+        finally:
+            restore()
+
+    def test_safe_substitution(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            assert service.localize("en", "common.error") == "An error occurred: $detail"
+        finally:
+            restore()
+
+
+# ===================================================================
+# test_localize
+# ===================================================================
+
+class TestTestLocalize:
+    def test_found(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            assert service.test_localize("en", "common.success") == "Operation successful."
+        finally:
+            restore()
+
+    def test_returns_found_not_de(self, service: LocalizerService, locale_dir):
+        """_load_sync('fr') falls back to English, finds key → returns English, not de."""
+        restore = _chdir(locale_dir)
+        try:
+            assert service.test_localize("fr", "common.success") == "Operation successful."
+        finally:
+            restore()
+
+    def test_de_missing(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            r = service.test_localize("de", "xyz")
+            assert "No translation found" in r
+        finally:
+            restore()
+
+
+# ===================================================================
+# Async load_locale
+# ===================================================================
+
+class TestLoadLocaleAsync:
+    def test_async(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            loop = asyncio.new_event_loop()
+            r = loop.run_until_complete(service.load_locale("en"))
+            loop.close()
+            assert len(r) == 3 and r[0].identifier == "common.error"
+        finally:
+            restore()
+
+
+# ===================================================================
+# get_translation
+# ===================================================================
+
+class TestGetTranslation:
+    def test_found(self, service: LocalizerService, sample_entries):
+        assert service.get_translation(sample_entries, "test.hello") is not None
+
+    def test_not_found(self, service: LocalizerService, sample_entries):
+        assert service.get_translation(sample_entries, "x") is None
+
+    def test_case_insensitive(self, service: LocalizerService, sample_entries):
+        assert service.get_translation(sample_entries, "TEST.HELLO") is not None
+
+
+# ===================================================================
+# Cache management
+# ===================================================================
+
+class TestCacheManagement:
+    def test_reload(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            service._load_sync("en")
+            assert len(service._cache) > 0
+            service.reload_locales()
+            assert len(service._cache) == 0
+        finally:
+            restore()
+
+    def test_available(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            service._load_sync("en")
+            service._load_sync("de")
+            assert set(service.get_available_locales()) == {"en", "de"}
+        finally:
+            restore()
+
+    def test_available_empty(self, service: LocalizerService):
+        assert service.get_available_locales() == []
+
+
+# ===================================================================
+# _report_missing
+# ===================================================================
+
+class TestReportMissing:
+    def test_tracks(self, service: LocalizerService):
+        from localizer import reported_locales
+        reported_locales.clear()
+        with patch("localizer.missingLocalization", new_callable=AsyncMock):
+            service._report_missing("xx")
+            assert "xx" in reported_locales
+
+    def test_dedup(self, service: LocalizerService):
+        from localizer import reported_locales
+        reported_locales.clear()
+        with patch("localizer.missingLocalization", new_callable=AsyncMock):
+            service._report_missing("xx")
+            service._report_missing("xx")
+        assert reported_locales.count("xx") == 1
+
+
+# ===================================================================
+# TanjunTranslator
+# ===================================================================
+
+class _FakeTranslator:
+    """Mimics TanjunTranslator.translate() without inheriting from the broken mock base."""
+    def __init__(self, svc: LocalizerService):
+        self._localizer = svc
+
+    async def translate(self, string, locale, context):
+        from localizer import TRANSLATION_NOT_FOUND
+        key_str = str(string).replace("_", ".")
+        current = self._localizer.localize(locale, key_str)
+        if current == TRANSLATION_NOT_FOUND:
+            return None
+        return current
+
+
+class TestTanjunTranslator:
+    def test_found(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            t = _FakeTranslator(service)
+            s = MagicMock()
+            s.__str__ = lambda self: "common.success"
+            loop = asyncio.new_event_loop()
+            r = loop.run_until_complete(t.translate(s, MagicMock(), MagicMock()))
+            loop.close()
+            assert r == "Operation successful."
+        finally:
+            restore()
+
+    def test_not_found(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            t = _FakeTranslator(service)
+            s = MagicMock()
+            s.__str__ = lambda self: "xyz"
+            with patch.object(service, "_report_missing"):
+                loop = asyncio.new_event_loop()
+                r = loop.run_until_complete(t.translate(s, MagicMock(), MagicMock()))
+                loop.close()
+                assert r is None
+        finally:
+            restore()
+
+    def test_underscore_to_dot(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            t = _FakeTranslator(service)
+            s = MagicMock()
+            s.__str__ = lambda self: "commands_ping_name"
+            loop = asyncio.new_event_loop()
+            r = loop.run_until_complete(t.translate(s, MagicMock(), MagicMock()))
+            loop.close()
+            assert r == "ping"
+        finally:
+            restore()
+
+    def test_type_importable(self):
+        """TanjunTranslator should be importable (non-None)."""
+        assert TanjunTranslator is not None
+
+
+# ===================================================================
+# Constants
+# ===================================================================
+
+class TestConstants:
+    def test_not_found(self):
+        assert TRANSLATION_NOT_FOUND == "err: no translation found."
+
+    def test_ttl(self):
+        assert CACHE_TTL == 300.0
+
+
+# ===================================================================
+# Global instance
+# ===================================================================
+
+class TestGlobalInstance:
+    def test_exists(self):
+        assert isinstance(tanjunLocalizer, LocalizerService)
+
+    def test_singleton(self):
+        from localizer import tanjunLocalizer as r
+        assert r is tanjunLocalizer
+
+
+# ===================================================================
+# Deprecated API
+# ===================================================================
+
+class TestDeprecatedApi:
+    def test_sync(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            assert len(service.load_translations("en")) == 3
+        finally:
+            restore()
+
+    def test_async(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            loop = asyncio.new_event_loop()
+            r = loop.run_until_complete(service.load_translations_async("en"))
+            loop.close()
+            assert len(r) == 3
+        finally:
+            restore()
+
+    def test_async_matches_sync(self, service: LocalizerService, locale_dir):
+        restore = _chdir(locale_dir)
+        try:
+            loop = asyncio.new_event_loop()
+            a = loop.run_until_complete(service.load_translations_async("de"))
+            loop.close()
+            s = service._load_sync("de")
+            assert len(a) == len(s) and all(
+                ai.identifier == si.identifier for ai, si in zip(a, s)
+            )
+        finally:
+            restore()

--- a/utility.py
+++ b/utility.py
@@ -17,8 +17,6 @@ from collections.abc import Callable, Coroutine, Mapping
 from difflib import SequenceMatcher
 from typing import Annotated, Any, Self, TypeVar
 
-from pydantic import BaseModel, ConfigDict
-
 import aiohttp
 import discord
 from aiohttp import ClientTimeout

--- a/utils/async_io.py
+++ b/utils/async_io.py
@@ -1,12 +1,14 @@
 import asyncio
 import concurrent.futures
 import functools
+from collections.abc import Callable
+from typing import Any
 
 # Shared thread pool for I/O-bound blocking operations
 _io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="tanjun-io")
 
 
-async def run_blocking(func, *args, **kwargs):
+async def run_blocking(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Run a blocking function in the thread pool to avoid blocking the event loop."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_io_executor, functools.partial(func, *args, **kwargs))

--- a/utils/async_io.py
+++ b/utils/async_io.py
@@ -2,13 +2,16 @@ import asyncio
 import concurrent.futures
 import functools
 from collections.abc import Callable
-from typing import Any
+from typing import ParamSpec, TypeVar
 
 # Shared thread pool for I/O-bound blocking operations
 _io_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="tanjun-io")
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-async def run_blocking(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+
+async def run_blocking(func: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
     """Run a blocking function in the thread pool to avoid blocking the event loop."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(_io_executor, functools.partial(func, *args, **kwargs))


### PR DESCRIPTION
## Summary

Enables more mypy strict checks incrementally as recommended in #1236.

### Changes to pyproject.toml (mypy config)
- **Enabled** `disallow_incomplete_defs = true` — catches partially annotated functions
- **Enabled** `disallow_untyped_calls = true` — catches calling untyped functions from typed context
- **Enabled** `no_implicit_reexport = true` — makes re-exports explicit
- **Removed** overly broad `disable_error_code` list (was suppressing 11 error codes, now only 2 essential ones remain)
- **Added** per-module overrides for legacy files (utility, api, models) with too many type errors to fix in one pass

### Fixes in source files
- **main.py**: Added return type annotations to `on_ready` and `main`; safe exception re-raise with None guard
- **health/notifier.py**: Narrowed channel type before calling `.send()` to satisfy union-attr check
- **repositories/level_config_repository.py**: Fixed cache entry type narrowing; added `**kwargs: object` type; fixed column name generation type safety
- **locale_file_health_check.py**: Added explicit `set[str]` type for sorted operations
- **utils/async_io.py**: Added full type annotations for `run_blocking`
- **config.py**: Suppressed pydantic-settings BaseSettings false positive

### Next steps
- `disallow_any_expr`, `disallow_any_explicit`, and `strict_equality` can be tackled in subsequent PRs
- The three legacy modules (utility, api, models) should be type-annotated and the per-module overrides removed over time

Closes #1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification reliability by validating message-channel compatibility before sending.
  * Strengthened startup error handling with clearer exception propagation when initialization tasks fail.

* **Tests**
  * Added comprehensive localization test suite covering loading, lookup, caching, interpolation, fallbacks, and async behavior.

* **Chores**
  * Typing, configuration, import ordering, and async/IO/attachment download cleanups and small refactors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->