### PR TITLE
feat(#1326): Add ErrorEmbedCategory enum and embed factory functions

### DIFF
--- a/commands/level/disable_level_system.py
+++ b/commands/level/disable_level_system.py
@@ -6,7 +6,7 @@ from api import (
     set_level_system_status,
 )
 from localizer import tanjunLocalizer
-from utility import command_info, tanjunEmbed
+from utility import command_info, error_embed, success_embed, tanjunEmbed, ErrorEmbedCategory
 
 
 async def disable_level_system(command_info: command_info):
@@ -33,7 +33,8 @@ async def disable_level_system(command_info: command_info):
             self.stop()
 
     if not command_info.user.guild_permissions.administrator:
-        embed = tanjunEmbed(
+        embed = error_embed(
+            ErrorEmbedCategory.PERMISSION,
             title=tanjunLocalizer.localize(
                 command_info.locale,
                 "commands.level.disablelevelsystem.error.no_permission.title",
@@ -49,7 +50,8 @@ async def disable_level_system(command_info: command_info):
     current_status = await get_level_system_status(str(command_info.guild.id))
 
     if not current_status:
-        embed = tanjunEmbed(
+        embed = error_embed(
+            ErrorEmbedCategory.NOT_FOUND,
             title=tanjunLocalizer.localize(
                 command_info.locale,
                 "commands.level.disablelevelsystem.error.already_disabled.title",
@@ -81,14 +83,14 @@ async def disable_level_system(command_info: command_info):
         await delete_level_system_data(str(command_info.guild.id))
         await set_level_system_status(str(command_info.guild.id), False)
 
-        success_embed = tanjunEmbed(
+        embed = success_embed(
             title=tanjunLocalizer.localize(command_info.locale, "commands.level.disablelevelsystem.success.title"),
             description=tanjunLocalizer.localize(
                 command_info.locale,
                 "commands.level.disablelevelsystem.success.description",
             ),
         )
-        await message.edit(embed=success_embed, view=None)
+        await message.edit(embed=embed, view=None)
     else:
         cancel_embed = tanjunEmbed(
             title=tanjunLocalizer.localize(command_info.locale, "commands.level.disablelevelsystem.cancel.title"),

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -13,6 +13,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from localizer import tanjunLocalizer
+from utility import ErrorEmbedCategory
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,8 @@ class ErrorHandlerCog(commands.Cog):
     async def _build_error_embed(
         self,
         interaction: discord.Interaction,
-        locale_key: str,
+        category: ErrorEmbedCategory = ErrorEmbedCategory.UNEXPECTED,
+        locale_key: str = "errors.unexpected_error",
         **kwargs: Any,
     ) -> discord.Embed:
         """Build a localized error embed for the given translation key.
@@ -62,6 +64,8 @@ class ErrorHandlerCog(commands.Cog):
         ----------
         interaction:
             The interaction to derive the locale and guild from.
+        category:
+            The error category to determine embed colour.
         locale_key:
             The dot-notation localizer key (e.g. ``"errors.cooldown"``).
         **kwargs:
@@ -78,7 +82,7 @@ class ErrorHandlerCog(commands.Cog):
         embed = discord.Embed(
             title=title if "no translation found" not in title.lower() else "Error",
             description=description if "no translation found" not in description.lower() else "An unexpected error occurred.",
-            colour=0xFF6B6B,  # Soft red for errors
+            colour=category.value,
         )
         return embed
 
@@ -96,6 +100,7 @@ class ErrorHandlerCog(commands.Cog):
         if isinstance(original, app_commands.CommandOnCooldown):
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.RATE_LIMIT,
                 "errors.cooldown",
                 retry_after=round(original.retry_after, 1),
             )
@@ -111,6 +116,7 @@ class ErrorHandlerCog(commands.Cog):
 
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.PERMISSION,
                 "errors.missing_permissions",
                 missing_permissions=missing_permissions or "Unknown",
             )
@@ -118,12 +124,14 @@ class ErrorHandlerCog(commands.Cog):
         elif isinstance(original, discord.Forbidden):
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.PERMISSION,
                 "errors.forbidden",
             )
 
         elif isinstance(original, discord.HTTPException):
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.UNEXPECTED,
                 "errors.http_error",
                 status_code=original.status,
             )
@@ -135,6 +143,7 @@ class ErrorHandlerCog(commands.Cog):
         elif isinstance(original, app_commands.TransformerError):
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.VALIDATION,
                 "errors.transformer_error",
             )
 
@@ -143,6 +152,7 @@ class ErrorHandlerCog(commands.Cog):
             traceback.print_exception(type(original), original, original.__traceback__)
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.UNEXPECTED,
                 "errors.unexpected_error",
             )
 
@@ -156,6 +166,7 @@ class ErrorHandlerCog(commands.Cog):
             traceback.print_exception(type(original), original, original.__traceback__)
             embed = await self._build_error_embed(
                 interaction,
+                ErrorEmbedCategory.UNEXPECTED,
                 "errors.unexpected_error",
             )
 

--- a/utility.py
+++ b/utility.py
@@ -78,6 +78,81 @@ class StatusIcon(enum.StrEnum):
     DISABLED = "❌"
 
 
+class ErrorEmbedCategory(enum.IntEnum):
+    """Categories for error embeds, mapped to distinct colors for visual distinction."""
+
+    PERMISSION = 0xE74C3C
+    NOT_FOUND = 0xE67E22
+    RATE_LIMIT = 0xF39C12
+    VALIDATION = 0x9B59B6
+    UNEXPECTED = 0xE74C3C
+    TIMEOUT = 0x95A5A6
+
+
+def error_embed(
+    category: ErrorEmbedCategory,
+    title: str,
+    description: str,
+) -> TanjunEmbed:
+    """Build a standardized error embed with proper color for the given category.
+
+    Parameters
+    ----------
+    category:
+        The error category determining the embed colour.
+    title:
+        The embed title (may be localized string).
+    description:
+        The embed description (may be localized string).
+
+    Returns
+    -------
+    TanjunEmbed:
+        A pre-configured error embed.
+    """
+    return TanjunEmbed(
+        colour=category.value,
+        title=title,
+        description=description,
+    )
+
+
+def success_embed(
+    title: str,
+    description: str,
+) -> TanjunEmbed:
+    """Build a standardized success embed."""
+    return TanjunEmbed(
+        colour=EmbedColor.SUCCESS,
+        title=title,
+        description=description,
+    )
+
+
+def warning_embed(
+    title: str,
+    description: str,
+) -> TanjunEmbed:
+    """Build a standardized warning embed."""
+    return TanjunEmbed(
+        colour=EmbedColor.WARNING,
+        title=title,
+        description=description,
+    )
+
+
+def info_embed(
+    title: str,
+    description: str,
+) -> TanjunEmbed:
+    """Build a standardized info embed."""
+    return TanjunEmbed(
+        colour=EmbedColor.INFO,
+        title=title,
+        description=description,
+    )
+
+
 # Map of friendly keys to guild emoji names (from issue #1332).
 # Maps friendly keys to the actual guild emoji names used in the Discord server.
 EMOJI_MAP: dict[str, str] = {

--- a/utility.py
+++ b/utility.py
@@ -93,7 +93,7 @@ def error_embed(
     category: ErrorEmbedCategory,
     title: str,
     description: str,
-) -> TanjunEmbed:
+) -> "TanjunEmbed":
     """Build a standardized error embed with proper color for the given category.
 
     Parameters
@@ -120,7 +120,7 @@ def error_embed(
 def success_embed(
     title: str,
     description: str,
-) -> TanjunEmbed:
+) -> "TanjunEmbed":
     """Build a standardized success embed."""
     return TanjunEmbed(
         colour=EmbedColor.SUCCESS,
@@ -132,7 +132,7 @@ def success_embed(
 def warning_embed(
     title: str,
     description: str,
-) -> TanjunEmbed:
+) -> "TanjunEmbed":
     """Build a standardized warning embed."""
     return TanjunEmbed(
         colour=EmbedColor.WARNING,
@@ -144,7 +144,7 @@ def warning_embed(
 def info_embed(
     title: str,
     description: str,
-) -> TanjunEmbed:
+) -> "TanjunEmbed":
     """Build a standardized info embed."""
     return TanjunEmbed(
         colour=EmbedColor.INFO,


### PR DESCRIPTION
## Summary

Adds standardized embed factory functions to `utility.py` for consistent embed styling across the bot:

### New additions to `utility.py`
- **`ErrorEmbedCategory`** enum — semantic error categories (PERMISSION, NOT_FOUND, RATE_LIMIT, VALIDATION, UNEXPECTED, TIMEOUT) each with distinct colors
- **`error_embed(category, title, description)`** — builds a standardized error embed
- **`success_embed(title, description)`** — builds a green success embed
- **`warning_embed(title, description)`** — builds a yellow warning embed  
- **`info_embed(title, description)`** — builds a blue info embed

### Migration (first batch)
- **`commands/level/disable_level_system.py`** — migrated permission errors to `error_embed(ErrorEmbedCategory.PERMISSION, ...)` and success messages to `success_embed(...)`
- **`extensions/error_handler.py`** — `_build_error_embed` now accepts a `category` parameter; all global error handlers pass the appropriate `ErrorEmbedCategory` (RATE_LIMIT for cooldown, PERMISSION for check/forbidden, VALIDATION for transformer errors, UNEXPECTED for HTTP/unhandled)

Progress toward #1326.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized embed creation so all messages (error/success/warning/info) use consistent styling and formatting.

* **Style**
  * Error responses now reflect distinct categories with appropriate coloring and clearer localized messages; confirmation messages use the new standardized success styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->