### PR TITLE
feat: Cache counting configs to reduce DB queries per message

### DIFF
--- a/api.py
+++ b/api.py
@@ -327,6 +327,10 @@ _guild_config_cache: dict[str, tuple[dict[str, Any], float]] = {}
 # In-memory cache for XP cooldowns: (guild_id, user_id) -> last_xp_gain_timestamp
 # Eliminates DB queries entirely when user is on cooldown
 _last_xp_gain_cache: dict[tuple[str, str], float] = {}
+# In-memory cache for counting configs: channel_id -> (counting_config, challenge_config, modes_config, timestamp)
+# Reduces 3 DB queries per message to in-memory lookup
+_COUNTING_CACHE_TTL = 30  # seconds
+_counting_cache: dict[str, tuple[dict | None, dict | None, dict | None, float]] = {}
 
 
 def _is_cache_valid(entry: tuple[Any, float] | None, ttl: float) -> bool:
@@ -338,6 +342,11 @@ def _is_cache_valid(entry: tuple[Any, float] | None, ttl: float) -> bool:
 def _invalidate_guild_cache(guild_id: str) -> None:
     _blacklist_cache.pop(guild_id, None)
     _guild_config_cache.pop(guild_id, None)
+
+
+def invalidate_counting_cache(channel_id: str | int) -> None:
+    """Remove the counting config cache entry for a specific channel."""
+    _counting_cache.pop(str(channel_id), None)
 
 
 async def preload_guild_configs(bot=None) -> None:
@@ -1391,11 +1400,19 @@ async def opt_in(user_id: str | int) -> None:
 
 
 async def get_counting_configs(channel_id: str | int) -> tuple[dict | None, dict | None, dict | None]:
-    """Fetch all counting configs (normal, challenge, modes) for a channel in a single query.
+    """Fetch all counting configs (normal, challenge, modes) for a channel.
+
+    Uses an in-memory cache with a short TTL to avoid 3 DB queries per message.
+    Cache is invalidated via invalidate_counting_cache() when configs are mutated.
 
     Returns (counting_config, challenge_config, modes_config) where each is a dict
     with keys like 'progress', 'last_counter_id', 'guild_id', or None if not configured.
     """
+    key = str(channel_id)
+    cached = _counting_cache.get(key)
+    if cached is not None and _is_cache_valid((cached, cached[3]), _COUNTING_CACHE_TTL):
+        return cached[0], cached[1], cached[2]
+
     counting_query = "SELECT progress, last_counter_id, guild_id FROM counting WHERE channel_id = %s"
     challenge_query = "SELECT progress, last_counter_id, guild_id FROM counting_challenge WHERE channel_id = %s"
     modes_query = "SELECT progress, mode, goal, last_counter_id, guild_id FROM counting_modes WHERE channel_id = %s"
@@ -1426,6 +1443,7 @@ async def get_counting_configs(channel_id: str | int) -> tuple[dict | None, dict
         if modes_result
         else None
     )
+    _counting_cache[key] = (counting_config, challenge_config, modes_config, time.time())
     return counting_config, challenge_config, modes_config
 
 

--- a/services/counting_repository.py
+++ b/services/counting_repository.py
@@ -5,7 +5,7 @@ Replaces 21 individual API functions in api.py with a single typed service.
 
 from enum import IntEnum
 
-from api import execute_action, execute_query
+from api import execute_action, execute_query, invalidate_counting_cache
 
 
 class CountingMode(IntEnum):
@@ -50,6 +50,7 @@ class CountingRepository:
             "VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE progress = %s"
         )
         await execute_action(query, (channel_id, progress, guild_id, progress))
+        invalidate_counting_cache(channel_id)
 
     @staticmethod
     async def get_progress(
@@ -97,6 +98,7 @@ class CountingRepository:
             "WHERE channel_id = %s"
         )
         await execute_action(query, (last_counter_id, channel_id))
+        invalidate_counting_cache(channel_id)
 
     # ── Clear ────────────────────────────────────────────────
 
@@ -106,6 +108,7 @@ class CountingRepository:
         table = _TABLE_MAP[mode]
         query = f"DELETE FROM {table} WHERE channel_id = %s"
         await execute_action(query, (channel_id,))
+        invalidate_counting_cache(channel_id)
 
     # ── Mode-specific (only applies to CountingMode.MODES) ───
 
@@ -155,6 +158,7 @@ class CountingRepository:
                 counter_id,
             ),
         )
+        invalidate_counting_cache(channel_id)
 
     @staticmethod
     async def set_challenge_progress(
@@ -174,6 +178,7 @@ class CountingRepository:
             "VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE progress = %s"
         )
         await execute_action(query, (channel_id, progress, guild_id, progress))
+        invalidate_counting_cache(channel_id)
 
     # ── Batch helpers for listeners ──────────────────────────
 


### PR DESCRIPTION
## Summary

Adds an in-memory cache for counting configurations (normal, challenge, modes) to avoid running 3 DB queries on every single message.

Closes #1635 (parent: #1627)

## Changes

- **api.py**: Added  dict with 30s TTL, updated  to serve cached data, added  function
- **services/counting_repository.py**: Imported invalidation function and added cache invalidation calls to all mutation methods (, , , , )

## How it works

- On message received →  checks in-memory cache first
- Cache miss → 3 parallel DB queries (same as before), result cached for 30s
- Any counting config change → cache entry invalidated immediately
- TTL ensures stale configs are never served longer than 30 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved counting channel configuration retrieval performance through caching optimization, reducing database load and enhancing application responsiveness during counting operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->