### PR TITLE
fix: repair repeat_interval/repeat_amount logic for scheduled messages (#1632)

### DIFF
--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -277,8 +277,7 @@ async def send_scheduled_messages(client: discord.Client) -> None:
                     # Finite repeats: decrement count
                     if repeat_amount > 0:
                         new_amount = repeat_amount - 1
-                        await ScheduledMessageService.update_repeat(message_id, new_amount)
-                        await ScheduledMessageService.update_send_time(message_id, next_send_time)
+                        await ScheduledMessageService.update_repeat_and_send_time(message_id, new_amount, next_send_time)
                     else:
                         # repeat_amount == 0: no more repeats, cancel
                         await ScheduledMessageService.cancel(message_id)

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -268,14 +268,25 @@ async def send_scheduled_messages(client: discord.Client) -> None:
                 send_kwargs["files"] = files
             await target.send(**send_kwargs)
 
-            if repeat_amount and repeat_amount != 0:
-                repeat_amount -= 1
-                if repeat_amount == 0:
-                    await ScheduledMessageService.cancel(message_id)
-                else:
-                    await ScheduledMessageService.update_repeat(message_id, repeat_amount)
+            # --- Repeat logic ---
+            if repeat_interval and repeat_interval > 0:
+                # This is a repeating message — advance send_time
+                next_send_time = msg.send_time + timedelta(seconds=repeat_interval)
 
-            if not repeat_interval or not repeat_amount:
+                if repeat_amount is not None:
+                    # Finite repeats: decrement count
+                    if repeat_amount > 0:
+                        new_amount = repeat_amount - 1
+                        await ScheduledMessageService.update_repeat(message_id, new_amount)
+                        await ScheduledMessageService.update_send_time(message_id, next_send_time)
+                    else:
+                        # repeat_amount == 0: no more repeats, cancel
+                        await ScheduledMessageService.cancel(message_id)
+                else:
+                    # Infinite repeats (repeat_amount is None): keep going forever
+                    await ScheduledMessageService.update_send_time(message_id, next_send_time)
+            else:
+                # No repeat interval — one-shot message, always cancel
                 await ScheduledMessageService.cancel(message_id)
 
         except Exception:

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -114,6 +114,14 @@ class ScheduledMessageService:
         await execute_action(query, (repeat_amount, message_id))
 
     @staticmethod
+    async def update_send_time(message_id: int, send_time: datetime) -> None:
+        """Update the send time of a scheduled message (for repeat advancement)."""
+        from api import execute_action
+
+        query = "UPDATE scheduledMessages SET send_time = %s WHERE messageId = %s"
+        await execute_action(query, (send_time, message_id))
+
+    @staticmethod
     async def get_due_messages() -> list[ScheduledMessageModel]:
         """Return all messages whose send_time is due (<= now)."""
 

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -122,6 +122,14 @@ class ScheduledMessageService:
         await execute_action(query, (send_time, message_id))
 
     @staticmethod
+    async def update_repeat_and_send_time(message_id: int, repeat_amount: int, send_time: datetime) -> None:
+        """Atomically update both repeat amount and send time in a single query."""
+        from api import execute_action
+
+        query = "UPDATE scheduledMessages SET repeatAmount = %s, send_time = %s WHERE messageId = %s"
+        await execute_action(query, (repeat_amount, send_time, message_id))
+
+    @staticmethod
     async def get_due_messages() -> list[ScheduledMessageModel]:
         """Return all messages whose send_time is due (<= now)."""
 


### PR DESCRIPTION
## Summary

Fixes the repeat scheduling logic in `send_scheduled_messages` to correctly handle:
- Finite repeats decrementing without overlap
- Infinite repeats (repeat_amount=None) not being prematurely cancelled
- send_time advancing after each repeat so messages don't get re-sent every loop cycle

## Changes

1. **schedulemessage.py** - Rewrote the repeat logic block after message send:
   - Messages with `repeat_interval > 0` now advance their `send_time` by the interval
   - Finite repeats decrement `repeat_amount` correctly
   - Infinite repeats (`repeat_amount=None`) are never cancelled
   - One-shot messages (no interval) are always cancelled after send
   
2. **scheduled_message_service.py** - Added `update_send_time()` method to support advancing the send_time column

## Testing

Manually traced through all states:
| repeat_interval | repeat_amount | Expected behavior |
|---|---|---|
| None | None | Cancel after send (one-shot) |
| 3600 | None | Advance send_time by 1h (infinite) |
| 3600 | 3 | Advance + decrement to 2 (3 more sends) |
| 3600 | 0 | Advance + cancel (no more repeats left) |
| None | 3 | Cancel after send (no interval = one-shot) |

Fixes #1632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to update scheduled message send times and to update repeat count together with next send time in a single action.

* **Bug Fixes**
  * Improved repeat scheduling logic to correctly handle finite repeats, infinite repeats, and one-time scheduled messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->