### PR TITLE
Refactor: Split api.py into domain-specific repositories

### DIFF
--- a/api.py
+++ b/api.py
@@ -1548,7 +1548,7 @@ async def get_all_level_roles(guild_id: str) -> list[LevelRolesGroupModel]:
 
 
 # ── XP Boost (delegated to XpBoostRepository) ──────────────────────────────────
-from repositories.xp_boost_repository import BoostTarget, XpBoostRepository, xp_boost_repo
+from repositories.xp_boost_repository import BoostTarget, XpBoostRepository
 
 # --- Legacy wrapper functions (backward compatible) ---
 

--- a/api.py
+++ b/api.py
@@ -7,7 +7,6 @@ import uuid
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
-from enum import Enum
 from typing import Any
 
 from discord import Entitlement
@@ -47,57 +46,24 @@ from models import (
 from utility import get_level_for_xp_async, get_xp_for_level_async
 
 
-class LogBlacklistType(Enum):
-    """Enum representing the three log blacklist types with their table/column mapping."""
-
-    CHANNEL = ("logBlacklistChannel", "channel_id")
-    ROLE = ("logRoleBlacklist", "role_id")
-    USER = ("logUserBlacklist", "user_id")
-
-    @property
-    def table(self) -> str:
-        return self.value[0]
-
-    @property
-    def column(self) -> str:
-        return self.value[1]
-
+# ── Log blacklist (delegated to LogBlacklistRepository) ─────────────────────────────
+from repositories.log_blacklist_repository import LogBlacklistType, log_blacklist_repo
 
 
 async def add_log_blacklist(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
-    """Add a log blacklist entry for the given entity type."""
-    table = blacklist_type.table
-    column = blacklist_type.column
-    query = f"INSERT INTO {table} (guild_id, {column}) VALUES (%s, %s)"
-    await execute_action(query, (guild_id, entity_id))
+    await log_blacklist_repo.add(guild_id, entity_id, blacklist_type)
 
 
 async def remove_log_blacklist(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
-    """Remove a log blacklist entry for the given entity type."""
-    table = blacklist_type.table
-    column = blacklist_type.column
-    query = f"DELETE FROM {table} WHERE guild_id = %s AND {column} = %s"
-    await execute_action(query, (guild_id, entity_id))
+    await log_blacklist_repo.remove(guild_id, entity_id, blacklist_type)
 
 
 async def get_log_blacklist(guild_id: str, blacklist_type: LogBlacklistType) -> list[str]:
-    """Retrieve all blacklisted entity IDs of a given type for a guild."""
-    table = blacklist_type.table
-    column = blacklist_type.column
-    query = f"SELECT {column} FROM {table} WHERE guild_id = %s"
-    entity_ids: list[str] = []
-    async for row in execute_query_iter(query, (guild_id,)):
-        entity_ids.append(row[0])
-    return entity_ids
+    return await log_blacklist_repo.get_all(guild_id, blacklist_type)
 
 
 async def is_log_entity_blacklisted(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> str | None:
-    """Check whether a specific entity is blacklisted."""
-    table = blacklist_type.table
-    column = blacklist_type.column
-    query = f"SELECT {column} FROM {table} WHERE guild_id = %s AND {column} = %s"
-    result = await execute_query(query, (guild_id, entity_id))
-    return result[0] if result else None
+    return await log_blacklist_repo.is_entity_blacklisted(guild_id, entity_id, blacklist_type)
 
 
 
@@ -1270,50 +1236,28 @@ async def create_tables(bot=None) -> None:
                 raise
 
 
+# ── Warning functions (delegated to WarningRepository) ───────────────────────────
+from repositories.warning_repository import warning_repo
+
+
 async def add_warning(
     guild_id: str | int, user_id: str | int, reason: str, created_by: str | int, expiration_date: datetime | None = None
 ) -> int:
-    query = "INSERT INTO warnings (guild_id, user_id, reason, expires_at, created_by) VALUES (%s, %s, %s, %s, %s)"
-    params = (guild_id, user_id, reason, expiration_date, created_by)
-    warning_id = await execute_insert_and_get_id(query, params)
-    return warning_id
+    return await warning_repo.add(guild_id, user_id, reason, created_by, expiration_date)
 
 
 async def get_warnings(guild_id: str | int, user_id: str | int | None = None) -> AsyncIterator[WarningModel]:
-    """Stream all active warnings for a guild (or a specific user).
-
-    Yields rows one at a time so that only one row is held in memory
-    at a time, even when the result set contains thousands of warnings.
-    """
-    if user_id:
-        query = "SELECT id, guild_id, user_id, reason, created_at, expires_at, created_by, escalation_level FROM warnings WHERE guild_id = %s AND user_id = %s AND (expires_at IS NULL OR expires_at > NOW())"
-        params = (guild_id, user_id)
-    else:
-        query = "SELECT id, guild_id, user_id, reason, created_at, expires_at, created_by, escalation_level FROM warnings WHERE guild_id = %s AND (expires_at IS NULL OR expires_at > NOW())"
-        params = (guild_id,)
-    async for row in WarningModel.iter_rows(query, params):
+    async for row in warning_repo.get_all(guild_id, user_id):
         yield row
 
 
 async def get_detailed_warnings(guild_id: str | int, user_id: str | int) -> AsyncIterator[DetailedWarningModel]:
-    """Stream detailed warnings for a specific user in a guild.
-
-    Yields rows one at a time, ordered by creation date descending.
-    """
-    query = (
-        "SELECT id, reason, created_at, expires_at, created_by "
-        "FROM warnings WHERE guild_id = %s AND user_id = %s "
-        "ORDER BY created_at DESC"
-    )
-    params = (guild_id, user_id)
-    async for row in DetailedWarningModel.iter_rows(query, params):
+    async for row in warning_repo.get_detailed(guild_id, user_id):
         yield row
 
 
 async def remove_warning(warning_id: int) -> None:
-    query = "DELETE FROM warnings WHERE id = %s"
-    params = (warning_id,)
-    await execute_action(query, params)
+    await warning_repo.remove(warning_id)
 
 
 async def set_warn_config(
@@ -1324,37 +1268,11 @@ async def set_warn_config(
     kick_threshold: int,
     ban_threshold: int,
 ) -> None:
-    query = (
-        "INSERT INTO warn_config (guild_id, expiration_days, "
-        "timeout_threshold, timeout_duration, "
-        "kick_threshold, ban_threshold) "
-        "VALUES (%s, %s, %s, %s, %s, %s) "
-        "ON DUPLICATE KEY UPDATE "
-        "expiration_days = VALUES(expiration_days), "
-        "timeout_threshold = VALUES(timeout_threshold), "
-        "timeout_duration = VALUES(timeout_duration), "
-        "kick_threshold = VALUES(kick_threshold), "
-        "ban_threshold = VALUES(ban_threshold)"
-    )
-    params = (
-        guild_id,
-        expiration_days,
-        timeout_threshold,
-        timeout_duration,
-        kick_threshold,
-        ban_threshold,
-    )
-    await execute_action(query, params)
+    await warning_repo.set_config(guild_id, expiration_days, timeout_threshold, timeout_duration, kick_threshold, ban_threshold)
 
 
 async def get_warn_config(guild_id: str | int) -> WarnConfigModel | None:
-    query = "SELECT guild_id, expiration_days, timeout_threshold, timeout_duration, kick_threshold, ban_threshold FROM warn_config WHERE guild_id = %s"
-    params = (guild_id,)
-    result = await execute_query(query, params)
-    if result:
-        return WarnConfigModel.from_row(result[0])
-    else:
-        return None
+    return await warning_repo.get_config(guild_id)
 
 
 async def save_channel_overwrites(channel_id: str | int, role_id: str | int, overwrites: str) -> None:
@@ -1627,111 +1545,10 @@ async def get_all_level_roles(guild_id: str) -> list[LevelRolesGroupModel]:
     return await level_role_repo.get_grouped_by_level(guild_id)
 
 
-from enum import Enum
 
 
-class BoostTarget(Enum):
-    """Type-safe enum for XP boost target types, mapping to DB table and entity column."""
-    ROLE = ("roleXpBoost", "role_id")
-    CHANNEL = ("channelXpBoost", "channel_id")
-    USER = ("userXpBoost", "user_id")
-
-    @property
-    def table(self) -> str:
-        return self.value[0]
-
-    @property
-    def entity_column(self) -> str:
-        return self.value[1]
-
-
-class XpBoostRepository:
-    """Consolidated XP boost CRUD using BoostTarget enum.
-
-    Replaces the 9+ individual add/remove/get functions for role, channel, and user boosts.
-    """
-
-    @staticmethod
-    async def add_boost(
-        guild_id: str,
-        entity_id: str,
-        boost: float,
-        additive: bool,
-        target: BoostTarget = BoostTarget.USER,
-    ) -> None:
-        """Add or update an XP boost entry."""
-        query = f"""
-        INSERT INTO {target.table} (guild_id, {target.entity_column}, boost, additive)
-        VALUES (%s, %s, %s, %s)
-        ON DUPLICATE KEY UPDATE boost = VALUES(boost), additive = VALUES(additive)
-        """
-        params = (guild_id, entity_id, boost, additive)
-        await execute_action(query, params)
-
-    @staticmethod
-    async def remove_boost(
-        guild_id: str,
-        entity_id: str,
-        target: BoostTarget = BoostTarget.USER,
-    ) -> None:
-        """Remove an XP boost entry."""
-        query = f"DELETE FROM {target.table} WHERE guild_id = %s AND {target.entity_column} = %s"
-        params = (guild_id, entity_id)
-        await execute_action(query, params)
-
-    @staticmethod
-    async def get_boost(
-        guild_id: str,
-        entity_id: str,
-        target: BoostTarget = BoostTarget.USER,
-    ) -> XpBoostModel | None:
-        """Get a specific XP boost entry by entity ID."""
-        query = f"SELECT boost, additive FROM {target.table} WHERE guild_id = %s AND {target.entity_column} = %s"
-        params = (guild_id, entity_id)
-        result = await execute_query(query, params)
-        return XpBoostModel.from_row(result[0]) if result else None
-
-    @staticmethod
-    async def get_boosts_for_target(
-        guild_id: str,
-        entity_ids: list[str],
-        target: BoostTarget = BoostTarget.ROLE,
-    ) -> list[XpBoostModel]:
-        """Get all boost entries for a list of entity IDs under a target type."""
-        if not entity_ids:
-            return []
-        query = f"SELECT boost, additive FROM {target.table} WHERE guild_id = %s AND {target.entity_column} IN %s"
-        params = (guild_id, tuple(entity_ids))
-        rows: list[XpBoostModel] = []
-        async for row in XpBoostModel.iter_rows(query, params):
-            rows.append(row)
-        return rows
-
-    @staticmethod
-    async def get_all_boosts(guild_id: str) -> dict[str, list[XpBoostModel]]:
-        """Get all boosts for a guild, grouped by target type."""
-        role_query = "SELECT boost, additive FROM roleXpBoost WHERE guild_id = %s"
-        channel_query = "SELECT boost, additive FROM channelXpBoost WHERE guild_id = %s"
-        user_query = "SELECT boost, additive FROM userXpBoost WHERE guild_id = %s"
-
-        roles: list[XpBoostModel] = []
-        async for row in XpBoostModel.iter_rows(role_query, (guild_id,)):
-            roles.append(row)
-
-        channels: list[XpBoostModel] = []
-        async for row in XpBoostModel.iter_rows(channel_query, (guild_id,)):
-            channels.append(row)
-
-        users: list[XpBoostModel] = []
-        async for row in XpBoostModel.iter_rows(user_query, (guild_id,)):
-            users.append(row)
-
-        return {
-            "roles": roles,
-            "channels": channels,
-            "users": users,
-        }
-
+# ── XP Boost (delegated to XpBoostRepository) ──────────────────────────────────
+from repositories.xp_boost_repository import BoostTarget, XpBoostRepository, xp_boost_repo
 
 # --- Legacy wrapper functions (backward compatible) ---
 
@@ -2902,77 +2719,40 @@ async def remove_report_channel(guild_id: str) -> None:
     await _report_svc.remove_channel(guild_id)
 
 
+# ── Trigger message functions (delegated to TriggerMessageRepository) ──────────────
+from repositories.trigger_message_repository import trigger_message_repo
+
+
 async def get_trigger_messages(guild_id: str) -> list[TriggerMessageModel]:
-    query = "SELECT id, guild_id, `trigger`, response, case_sensitive FROM triggerMessages WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[TriggerMessageModel] = []
-    async for row in TriggerMessageModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    return await trigger_message_repo.get_all(guild_id)
 
 
 async def add_trigger_message(guild_id: str, trigger: str, response: str, case_sensitive: bool = False) -> None:
-    query = "INSERT INTO triggerMessages (guild_id, `trigger`, response, case_sensitive) VALUES (%s, %s, %s, %s)"
-    params = (guild_id, trigger, response, case_sensitive)
-    await execute_action(query, params)
+    await trigger_message_repo.add(guild_id, trigger, response, case_sensitive)
 
 
 async def remove_trigger_message(guild_id: str, trigger: str) -> None:
-    query = "DELETE FROM triggerMessages WHERE guild_id = %s AND `trigger` = %s"
-    params = (guild_id, trigger)
-    await execute_action(query, params)
+    await trigger_message_repo.remove(guild_id, trigger)
 
 
 async def get_trigger_message_channels(guild_id: str, trigger_id: int) -> list[TriggerMessageChannelModel]:
-    query = "SELECT guild_id, channel_id, triggerId FROM triggerMessagesChannel WHERE guild_id = %s AND triggerId = %s"
-    params = (guild_id, trigger_id)
-    rows: list[TriggerMessageChannelModel] = []
-    async for row in TriggerMessageChannelModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    return await trigger_message_repo.get_channels(guild_id, trigger_id)
 
 
 async def get_trigger_messages_by_channel(guild_id: str, channel_id: str) -> list[TriggerMessageChannelModel]:
-    query = "SELECT guild_id, channel_id, triggerId FROM triggerMessagesChannel WHERE guild_id = %s AND channel_id = %s"
-    params = (guild_id, channel_id)
-    rows: list[TriggerMessageChannelModel] = []
-    async for row in TriggerMessageChannelModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    return await trigger_message_repo.get_by_channel(guild_id, channel_id)
 
 
 async def add_trigger_message_channel(guild_id: str, channel_id: str, trigger_id: int) -> None:
-    query = "INSERT INTO triggerMessagesChannel (guild_id, channel_id, triggerId) VALUES (%s, %s, %s)"
-    params = (guild_id, channel_id, trigger_id)
-    await execute_action(query, params)
+    await trigger_message_repo.add_channel(guild_id, channel_id, trigger_id)
 
 
 async def remove_trigger_message_channel(guild_id: str, channel_id: str, trigger_id: int) -> None:
-    query = "DELETE FROM triggerMessagesChannel WHERE guild_id = %s AND channel_id = %s AND triggerId = %s"
-    params = (guild_id, channel_id, trigger_id)
-    await execute_action(query, params)
+    await trigger_message_repo.remove_channel(guild_id, channel_id, trigger_id)
 
 
 async def is_trigger_message(guild_id: str, trigger: str, channel_id: str) -> TriggerMessageModel | None:
-    query = """
-        SELECT t.id, t.guild_id, t.`trigger`, t.response, t.case_sensitive FROM triggerMessages t
-        LEFT JOIN triggerMessagesChannel tc ON t.id = tc.triggerId AND t.guild_id = tc.guild_id
-        WHERE t.guild_id = %s AND t.`trigger` LIKE %s
-        AND (tc.channel_id = %s)
-    """
-    params = (guild_id, trigger, channel_id)
-    result = await execute_query(query, params)
-    result = result[0] if result and result[0] else None
-    if not result:
-        return None
-    trigger_message = TriggerMessageModel.from_row(result)
-    if trigger_message.case_sensitive:
-        if trigger != trigger_message.trigger:
-            return None
-    else:
-        if trigger.lower() != trigger_message.trigger.lower():
-            return None
-    return trigger_message
+    return await trigger_message_repo.find(guild_id, trigger, channel_id)
 
 
 # Ticket functions have been moved to TicketService in services/ticket_service.py
@@ -3206,13 +2986,12 @@ async def remove_cashed_slowmode_delay(channel_id: str) -> None:
     await execute_action(query, params)
 
 
+# ── Twitch notification functions (delegated to TwitchRepository) ──────────────────
+from repositories.twitch_repository import twitch_repo
+
+
 async def get_twitch_online_notification(channel_id: str) -> list[TwitchOnlineNotificationModel]:
-    query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE channel_id = %s"
-    params = (channel_id,)
-    rows: list[TwitchOnlineNotificationModel] = []
-    async for row in TwitchOnlineNotificationModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    return await twitch_repo.get_by_channel(channel_id)
 
 
 async def set_twitch_online_notification(
@@ -3223,40 +3002,24 @@ async def set_twitch_online_notification(
     notification_message: str,
 ) -> None:
     print("adding twitch online notification")
-    query = "INSERT INTO twitchOnlineNotification (guild_id, channel_id, twitchUuid, twitchName, notification_message) VALUES (%s, %s, %s, %s, %s)"
-    params = (guild_id, channel_id, twitch_uuid, twitch_name, notification_message)
-    await execute_action(query, params)
+    await twitch_repo.set(guild_id, channel_id, twitch_uuid, twitch_name, notification_message)
     print("added twitch online notification")
 
 
 async def remove_twitch_online_notification(id: str) -> None:
-    query = "DELETE FROM twitchOnlineNotification WHERE id = %s"
-    params = (id,)
-    await execute_action(query, params)
+    await twitch_repo.remove(id)
 
 
 async def get_twitch_online_notification_by_twitch_uuid(twitch_uuid: str) -> TwitchOnlineNotificationModel | None:
-    query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE twitchUuid = %s"
-    params = (twitch_uuid,)
-    result = await safe_execute_query(query, params)
-    return TwitchOnlineNotificationModel.from_row(result[0]) if result else None
+    return await twitch_repo.get_by_twitch_uuid(twitch_uuid)
 
 
 async def get_all_twitch_notification_uuids() -> list[str]:
-    query = "SELECT twitchUuid FROM twitchOnlineNotification"
-    uuids: list[str] = []
-    async for row in execute_query_iter(query):
-        uuids.append(row[0])
-    return uuids
+    return await twitch_repo.get_all_uuids()
 
 
 async def get_twitch_notification_by_guild_id(guild_id: str) -> list[TwitchOnlineNotificationModel]:
-    query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE guild_id = %s"
-    params = (guild_id,)
-    rows: list[TwitchOnlineNotificationModel] = []
-    async for row in TwitchOnlineNotificationModel.iter_rows(query, params):
-        rows.append(row)
-    return rows
+    return await twitch_repo.get_by_guild(guild_id)
 
 
 async def get_brawlstars_linked_account(user_id: str) -> str | None:

--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -1,0 +1,32 @@
+"""Repositories package - domain-specific data access layers.
+
+Each repository encapsulates the CRUD operations for a specific domain,
+replacing scattered functions in api.py with cohesive, testable classes.
+"""
+
+from repositories.level_config_repository import LevelConfigRepository, level_config_repo
+from repositories.level_role_repository import LevelRoleRepository, level_role_repo
+from repositories.log_blacklist_repository import LogBlacklistRepository, LogBlacklistType, log_blacklist_repo
+from repositories.trigger_message_repository import TriggerMessageRepository, trigger_message_repo
+from repositories.twitch_repository import TwitchRepository, twitch_repo
+from repositories.warning_repository import WarningRepository, warning_repo
+from repositories.xp_boost_repository import BoostTarget, XpBoostRepository, xp_boost_repo
+
+__all__ = [
+    "BoostTarget",
+    "LevelConfigRepository",
+    "LevelRoleRepository",
+    "LogBlacklistRepository",
+    "LogBlacklistType",
+    "TriggerMessageRepository",
+    "TwitchRepository",
+    "WarningRepository",
+    "XpBoostRepository",
+    "level_config_repo",
+    "level_role_repo",
+    "log_blacklist_repo",
+    "trigger_message_repo",
+    "twitch_repo",
+    "warning_repo",
+    "xp_boost_repo",
+]

--- a/repositories/log_blacklist_repository.py
+++ b/repositories/log_blacklist_repository.py
@@ -1,0 +1,71 @@
+"""LogBlacklistRepository: Consolidated CRUD for log blacklist management."""
+
+from __future__ import annotations
+
+from enum import Enum
+from dataclasses import dataclass
+
+
+class LogBlacklistType(Enum):
+    """Enum representing the three log blacklist types with their table/column mapping."""
+
+    CHANNEL = ("logBlacklistChannel", "channel_id")
+    ROLE = ("logRoleBlacklist", "role_id")
+    USER = ("logUserBlacklist", "user_id")
+
+    @property
+    def table(self) -> str:
+        return self.value[0]
+
+    @property
+    def column(self) -> str:
+        return self.value[1]
+
+
+@dataclass
+class LogBlacklistRepository:
+    """Repository for managing log blacklist entries."""
+
+    async def add(self, guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
+        """Add a log blacklist entry for the given entity type."""
+        from api import execute_action
+
+        table = blacklist_type.table
+        column = blacklist_type.column
+        query = f"INSERT INTO {table} (guild_id, {column}) VALUES (%s, %s)"
+        await execute_action(query, (guild_id, entity_id))
+
+    async def remove(self, guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
+        """Remove a log blacklist entry for the given entity type."""
+        from api import execute_action
+
+        table = blacklist_type.table
+        column = blacklist_type.column
+        query = f"DELETE FROM {table} WHERE guild_id = %s AND {column} = %s"
+        await execute_action(query, (guild_id, entity_id))
+
+    async def get_all(self, guild_id: str, blacklist_type: LogBlacklistType) -> list[str]:
+        """Retrieve all blacklisted entity IDs of a given type for a guild."""
+        from api import execute_query_iter
+
+        table = blacklist_type.table
+        column = blacklist_type.column
+        query = f"SELECT {column} FROM {table} WHERE guild_id = %s"
+        entity_ids: list[str] = []
+        async for row in execute_query_iter(query, (guild_id,)):
+            entity_ids.append(row[0])
+        return entity_ids
+
+    async def is_entity_blacklisted(self, guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> str | None:
+        """Check whether a specific entity is blacklisted."""
+        from api import execute_query
+
+        table = blacklist_type.table
+        column = blacklist_type.column
+        query = f"SELECT {column} FROM {table} WHERE guild_id = %s AND {column} = %s"
+        result = await execute_query(query, (guild_id, entity_id))
+        return result[0] if result else None
+
+
+# Module-level singleton for easy import
+log_blacklist_repo = LogBlacklistRepository()

--- a/repositories/trigger_message_repository.py
+++ b/repositories/trigger_message_repository.py
@@ -1,0 +1,99 @@
+"""TriggerMessageRepository: Consolidated CRUD for trigger message management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from models import TriggerMessageChannelModel, TriggerMessageModel
+
+
+@dataclass
+class TriggerMessageRepository:
+    """Repository for managing trigger messages and their channel bindings."""
+
+    async def get_all(self, guild_id: str) -> list[TriggerMessageModel]:
+        """Get all trigger messages for a guild."""
+        query = "SELECT id, guild_id, `trigger`, response, case_sensitive FROM triggerMessages WHERE guild_id = %s"
+        params = (guild_id,)
+        rows: list[TriggerMessageModel] = []
+        async for row in TriggerMessageModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    async def add(self, guild_id: str, trigger: str, response: str, case_sensitive: bool = False) -> None:
+        """Add a trigger message."""
+        from api import execute_action
+
+        query = "INSERT INTO triggerMessages (guild_id, `trigger`, response, case_sensitive) VALUES (%s, %s, %s, %s)"
+        params = (guild_id, trigger, response, case_sensitive)
+        await execute_action(query, params)
+
+    async def remove(self, guild_id: str, trigger: str) -> None:
+        """Remove a trigger message by trigger string."""
+        from api import execute_action
+
+        query = "DELETE FROM triggerMessages WHERE guild_id = %s AND `trigger` = %s"
+        params = (guild_id, trigger)
+        await execute_action(query, params)
+
+    async def get_channels(self, guild_id: str, trigger_id: int) -> list[TriggerMessageChannelModel]:
+        """Get all channel bindings for a specific trigger."""
+        query = "SELECT guild_id, channel_id, triggerId FROM triggerMessagesChannel WHERE guild_id = %s AND triggerId = %s"
+        params = (guild_id, trigger_id)
+        rows: list[TriggerMessageChannelModel] = []
+        async for row in TriggerMessageChannelModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    async def get_by_channel(self, guild_id: str, channel_id: str) -> list[TriggerMessageChannelModel]:
+        """Get all trigger-channel bindings for a specific channel."""
+        query = "SELECT guild_id, channel_id, triggerId FROM triggerMessagesChannel WHERE guild_id = %s AND channel_id = %s"
+        params = (guild_id, channel_id)
+        rows: list[TriggerMessageChannelModel] = []
+        async for row in TriggerMessageChannelModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    async def add_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
+        """Bind a channel to a trigger message."""
+        from api import execute_action
+
+        query = "INSERT INTO triggerMessagesChannel (guild_id, channel_id, triggerId) VALUES (%s, %s, %s)"
+        params = (guild_id, channel_id, trigger_id)
+        await execute_action(query, params)
+
+    async def remove_channel(self, guild_id: str, channel_id: str, trigger_id: int) -> None:
+        """Unbind a channel from a trigger message."""
+        from api import execute_action
+
+        query = "DELETE FROM triggerMessagesChannel WHERE guild_id = %s AND channel_id = %s AND triggerId = %s"
+        params = (guild_id, channel_id, trigger_id)
+        await execute_action(query, params)
+
+    async def find(self, guild_id: str, trigger: str, channel_id: str) -> TriggerMessageModel | None:
+        """Find a trigger message that matches a given trigger and channel."""
+        from api import execute_query
+
+        query = """
+            SELECT t.id, t.guild_id, t.`trigger`, t.response, t.case_sensitive FROM triggerMessages t
+            LEFT JOIN triggerMessagesChannel tc ON t.id = tc.triggerId AND t.guild_id = tc.guild_id
+            WHERE t.guild_id = %s AND t.`trigger` LIKE %s
+            AND (tc.channel_id = %s)
+        """
+        params = (guild_id, trigger, channel_id)
+        result = await execute_query(query, params)
+        result = result[0] if result and result[0] else None
+        if not result:
+            return None
+        trigger_message = TriggerMessageModel.from_row(result)
+        if trigger_message.case_sensitive:
+            if trigger != trigger_message.trigger:
+                return None
+        else:
+            if trigger.lower() != trigger_message.trigger.lower():
+                return None
+        return trigger_message
+
+
+# Module-level singleton for easy import
+trigger_message_repo = TriggerMessageRepository()

--- a/repositories/twitch_repository.py
+++ b/repositories/twitch_repository.py
@@ -1,0 +1,76 @@
+"""TwitchRepository: Consolidated CRUD for Twitch online notifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from models import TwitchOnlineNotificationModel
+
+
+@dataclass
+class TwitchRepository:
+    """Repository for managing Twitch online notification subscriptions."""
+
+    async def get_by_channel(self, channel_id: str) -> list[TwitchOnlineNotificationModel]:
+        """Get all Twitch notifications for a Discord channel."""
+        query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE channel_id = %s"
+        params = (channel_id,)
+        rows: list[TwitchOnlineNotificationModel] = []
+        async for row in TwitchOnlineNotificationModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    async def set(
+        self,
+        guild_id: str,
+        channel_id: str,
+        twitch_uuid: str,
+        twitch_name: str,
+        notification_message: str,
+    ) -> None:
+        """Create a Twitch online notification subscription."""
+        from api import execute_action
+
+        query = "INSERT INTO twitchOnlineNotification (guild_id, channel_id, twitchUuid, twitchName, notification_message) VALUES (%s, %s, %s, %s, %s)"
+        params = (guild_id, channel_id, twitch_uuid, twitch_name, notification_message)
+        await execute_action(query, params)
+
+    async def remove(self, id: str) -> None:
+        """Remove a Twitch notification by ID."""
+        from api import execute_action
+
+        query = "DELETE FROM twitchOnlineNotification WHERE id = %s"
+        params = (id,)
+        await execute_action(query, params)
+
+    async def get_by_twitch_uuid(self, twitch_uuid: str) -> TwitchOnlineNotificationModel | None:
+        """Get a Twitch notification by Twitch user UUID."""
+        from api import safe_execute_query
+
+        query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE twitchUuid = %s"
+        params = (twitch_uuid,)
+        result = await safe_execute_query(query, params)
+        return TwitchOnlineNotificationModel.from_row(result[0]) if result else None
+
+    async def get_all_uuids(self) -> list[str]:
+        """Get all tracked Twitch user UUIDs."""
+        from api import execute_query_iter
+
+        query = "SELECT twitchUuid FROM twitchOnlineNotification"
+        uuids: list[str] = []
+        async for row in execute_query_iter(query):
+            uuids.append(row[0])
+        return uuids
+
+    async def get_by_guild(self, guild_id: str) -> list[TwitchOnlineNotificationModel]:
+        """Get all Twitch notifications for a guild."""
+        query = "SELECT id, channel_id, guild_id, twitchUuid, twitchName, notification_message FROM twitchOnlineNotification WHERE guild_id = %s"
+        params = (guild_id,)
+        rows: list[TwitchOnlineNotificationModel] = []
+        async for row in TwitchOnlineNotificationModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+
+# Module-level singleton for easy import
+twitch_repo = TwitchRepository()

--- a/repositories/warning_repository.py
+++ b/repositories/warning_repository.py
@@ -1,0 +1,113 @@
+"""WarningRepository: Consolidated CRUD for warning management."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime
+from dataclasses import dataclass
+
+from models import DetailedWarningModel, WarnConfigModel, WarningModel
+
+
+@dataclass
+class WarningRepository:
+    """Repository for managing warnings and warning configuration."""
+
+    async def add(
+        self,
+        guild_id: str | int,
+        user_id: str | int,
+        reason: str,
+        created_by: str | int,
+        expiration_date: datetime | None = None,
+    ) -> int:
+        """Add a warning and return its ID."""
+        from api import execute_insert_and_get_id
+
+        query = "INSERT INTO warnings (guild_id, user_id, reason, expires_at, created_by) VALUES (%s, %s, %s, %s, %s)"
+        params = (guild_id, user_id, reason, expiration_date, created_by)
+        warning_id = await execute_insert_and_get_id(query, params)
+        return warning_id
+
+    async def get_all(
+        self, guild_id: str | int, user_id: str | int | None = None
+    ) -> AsyncIterator[WarningModel]:
+        """Stream all active warnings for a guild (or a specific user)."""
+        if user_id:
+            query = "SELECT id, guild_id, user_id, reason, created_at, expires_at, created_by, escalation_level FROM warnings WHERE guild_id = %s AND user_id = %s AND (expires_at IS NULL OR expires_at > NOW())"
+            params = (guild_id, user_id)
+        else:
+            query = "SELECT id, guild_id, user_id, reason, created_at, expires_at, created_by, escalation_level FROM warnings WHERE guild_id = %s AND (expires_at IS NULL OR expires_at > NOW())"
+            params = (guild_id,)
+        async for row in WarningModel.iter_rows(query, params):
+            yield row
+
+    async def get_detailed(
+        self, guild_id: str | int, user_id: str | int
+    ) -> AsyncIterator[DetailedWarningModel]:
+        """Stream detailed warnings for a specific user in a guild, ordered by creation date descending."""
+        query = (
+            "SELECT id, reason, created_at, expires_at, created_by "
+            "FROM warnings WHERE guild_id = %s AND user_id = %s "
+            "ORDER BY created_at DESC"
+        )
+        params = (guild_id, user_id)
+        async for row in DetailedWarningModel.iter_rows(query, params):
+            yield row
+
+    async def remove(self, warning_id: int) -> None:
+        """Remove a warning by ID."""
+        from api import execute_action
+
+        query = "DELETE FROM warnings WHERE id = %s"
+        params = (warning_id,)
+        await execute_action(query, params)
+
+    async def set_config(
+        self,
+        guild_id: str | int,
+        expiration_days: int,
+        timeout_threshold: int,
+        timeout_duration: int,
+        kick_threshold: int,
+        ban_threshold: int,
+    ) -> None:
+        """Set or update warning configuration for a guild."""
+        from api import execute_action
+
+        query = (
+            "INSERT INTO warn_config (guild_id, expiration_days, "
+            "timeout_threshold, timeout_duration, "
+            "kick_threshold, ban_threshold) "
+            "VALUES (%s, %s, %s, %s, %s, %s) "
+            "ON DUPLICATE KEY UPDATE "
+            "expiration_days = VALUES(expiration_days), "
+            "timeout_threshold = VALUES(timeout_threshold), "
+            "timeout_duration = VALUES(timeout_duration), "
+            "kick_threshold = VALUES(kick_threshold), "
+            "ban_threshold = VALUES(ban_threshold)"
+        )
+        params = (
+            guild_id,
+            expiration_days,
+            timeout_threshold,
+            timeout_duration,
+            kick_threshold,
+            ban_threshold,
+        )
+        await execute_action(query, params)
+
+    async def get_config(self, guild_id: str | int) -> WarnConfigModel | None:
+        """Get warning configuration for a guild."""
+        from api import execute_query
+
+        query = "SELECT guild_id, expiration_days, timeout_threshold, timeout_duration, kick_threshold, ban_threshold FROM warn_config WHERE guild_id = %s"
+        params = (guild_id,)
+        result = await execute_query(query, params)
+        if result:
+            return WarnConfigModel.from_row(result[0])
+        return None
+
+
+# Module-level singleton for easy import
+warning_repo = WarningRepository()

--- a/repositories/warning_repository.py
+++ b/repositories/warning_repository.py
@@ -33,7 +33,7 @@ class WarningRepository:
         self, guild_id: str | int, user_id: str | int | None = None
     ) -> AsyncIterator[WarningModel]:
         """Stream all active warnings for a guild (or a specific user)."""
-        if user_id:
+        if user_id is not None:
             query = "SELECT id, guild_id, user_id, reason, created_at, expires_at, created_by, escalation_level FROM warnings WHERE guild_id = %s AND user_id = %s AND (expires_at IS NULL OR expires_at > NOW())"
             params = (guild_id, user_id)
         else:

--- a/repositories/xp_boost_repository.py
+++ b/repositories/xp_boost_repository.py
@@ -87,8 +87,6 @@ class XpBoostRepository:
         """Get all boost entries for a list of entity IDs under a target type."""
         if not entity_ids:
             return []
-        from api import execute_query_iter
-
         query = f"SELECT boost, additive FROM {target.table} WHERE guild_id = %s AND {target.entity_column} IN %s"
         params = (guild_id, tuple(entity_ids))
         rows: list[XpBoostModel] = []

--- a/repositories/xp_boost_repository.py
+++ b/repositories/xp_boost_repository.py
@@ -1,0 +1,126 @@
+"""XpBoostRepository: Consolidated CRUD for XP boost entries.
+
+Replaces 9+ individual add/remove/get functions in api.py with
+type-safe repository methods using BoostTarget enum.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from models import XpBoostModel
+
+
+class BoostTarget(Enum):
+    """Type-safe enum for XP boost target types, mapping to DB table and entity column."""
+
+    ROLE = ("roleXpBoost", "role_id")
+    CHANNEL = ("channelXpBoost", "channel_id")
+    USER = ("userXpBoost", "user_id")
+
+    @property
+    def table(self) -> str:
+        return self.value[0]
+
+    @property
+    def entity_column(self) -> str:
+        return self.value[1]
+
+
+class XpBoostRepository:
+    """Consolidated XP boost CRUD using BoostTarget enum.
+
+    Replaces the 9+ individual add/remove/get functions for role, channel, and user boosts.
+    """
+
+    @staticmethod
+    async def add_boost(
+        guild_id: str,
+        entity_id: str,
+        boost: float,
+        additive: bool,
+        target: BoostTarget = BoostTarget.USER,
+    ) -> None:
+        """Add or update an XP boost entry."""
+        from api import execute_action
+
+        query = f"""
+        INSERT INTO {target.table} (guild_id, {target.entity_column}, boost, additive)
+        VALUES (%s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE boost = VALUES(boost), additive = VALUES(additive)
+        """
+        params = (guild_id, entity_id, boost, additive)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def remove_boost(
+        guild_id: str,
+        entity_id: str,
+        target: BoostTarget = BoostTarget.USER,
+    ) -> None:
+        """Remove an XP boost entry."""
+        from api import execute_action
+
+        query = f"DELETE FROM {target.table} WHERE guild_id = %s AND {target.entity_column} = %s"
+        params = (guild_id, entity_id)
+        await execute_action(query, params)
+
+    @staticmethod
+    async def get_boost(
+        guild_id: str,
+        entity_id: str,
+        target: BoostTarget = BoostTarget.USER,
+    ) -> XpBoostModel | None:
+        """Get a specific XP boost entry by entity ID."""
+        from api import execute_query
+
+        query = f"SELECT boost, additive FROM {target.table} WHERE guild_id = %s AND {target.entity_column} = %s"
+        params = (guild_id, entity_id)
+        result = await execute_query(query, params)
+        return XpBoostModel.from_row(result[0]) if result else None
+
+    @staticmethod
+    async def get_boosts_for_target(
+        guild_id: str,
+        entity_ids: list[str],
+        target: BoostTarget = BoostTarget.ROLE,
+    ) -> list[XpBoostModel]:
+        """Get all boost entries for a list of entity IDs under a target type."""
+        if not entity_ids:
+            return []
+        from api import execute_query_iter
+
+        query = f"SELECT boost, additive FROM {target.table} WHERE guild_id = %s AND {target.entity_column} IN %s"
+        params = (guild_id, tuple(entity_ids))
+        rows: list[XpBoostModel] = []
+        async for row in XpBoostModel.iter_rows(query, params):
+            rows.append(row)
+        return rows
+
+    @staticmethod
+    async def get_all_boosts(guild_id: str) -> dict[str, list[XpBoostModel]]:
+        """Get all boosts for a guild, grouped by target type."""
+        role_query = "SELECT boost, additive FROM roleXpBoost WHERE guild_id = %s"
+        channel_query = "SELECT boost, additive FROM channelXpBoost WHERE guild_id = %s"
+        user_query = "SELECT boost, additive FROM userXpBoost WHERE guild_id = %s"
+
+        roles: list[XpBoostModel] = []
+        async for row in XpBoostModel.iter_rows(role_query, (guild_id,)):
+            roles.append(row)
+
+        channels: list[XpBoostModel] = []
+        async for row in XpBoostModel.iter_rows(channel_query, (guild_id,)):
+            channels.append(row)
+
+        users: list[XpBoostModel] = []
+        async for row in XpBoostModel.iter_rows(user_query, (guild_id,)):
+            users.append(row)
+
+        return {
+            "roles": roles,
+            "channels": channels,
+            "users": users,
+        }
+
+
+# Module-level singleton for easy import
+xp_boost_repo = XpBoostRepository()


### PR DESCRIPTION
### Description
Decomposes the monolithic `api.py` (`~3041` lines down from \~3278) by moving domain-specific logic into focused repository classes in the `repositories/` directory.

### Changes
- **XpBoostRepository** (`repositories/xp_boost_repository.py`) — XP boost CRUD with `BoostTarget` enum
- **WarningRepository** (`repositories/warning_repository.py`) — warning and warn_config management
- **TriggerMessageRepository** (`repositories/trigger_message_repository.py`) — trigger message + channel binding CRUD
- **TwitchRepository** (`repositories/twitch_repository.py`) — Twitch online notification subscriptions
- **LogBlacklistRepository** (`repositories/log_blacklist_repository.py`) — log blacklist management with `LogBlacklistType` enum
- **repositories/__init__.py** — updated to export all new repositories
- **api.py** — backward-compatible wrappers now delegate to repository singletons

### Design
Each repository follows the existing pattern from `LevelConfigRepository` and `LevelRoleRepository`:
- Deferred imports of `execute_query`/etc. from `api.py` to avoid circular dependencies
- Module-level singleton for easy import
- Full backward compatibility — all existing imports from `api` continue to work

### Success Criteria
- [x] `api.py` reduced from 3278 to 3041 lines
- [x] All imports from `api` continue to work (backward-compatible wrappers)
- [x] No circular dependencies introduced
- [x] Each repository is independently testable

Closes #1607

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized backend persistence into centralized repository components for warnings, trigger messages, Twitch notifications, XP boosts, and log blacklists to improve reliability and maintainability.

* **Bug Fixes / Stability**
  * Improved consistency and streaming of warning data and trigger/Twitch notification lookups; existing user-facing commands remain unchanged but are more robust.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->