### PR TITLE
Sub: Add discord_message_id column to scheduled_messages table

### DIFF
--- a/api.py
+++ b/api.py
@@ -1032,10 +1032,12 @@ def get_table_definitions() -> dict[str, str]:
         `repeatInterval` MEDIUMINT UNSIGNED,
         `repeatAmount` MEDIUMINT UNSIGNED,
         `attachments` TEXT,
+        `discord_message_id` VARCHAR(20) DEFAULT NULL,
         `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         INDEX `idx_sendtime` (send_time),
         INDEX `idx_user` (user_id),
-        INDEX `idx_guild` (guild_id)
+        INDEX `idx_guild` (guild_id),
+        INDEX `idx_discord_message` (discord_message_id)
     ) ENGINE=InnoDB;
     """
     tables["reports"] = """
@@ -1256,6 +1258,11 @@ async def create_tables(bot=None) -> None:
         """ALTER TABLE `scheduledMessages`
          ADD COLUMN `attachments` TEXT DEFAULT NULL
          AFTER `repeatAmount`""",
+        # Add discord_message_id column to scheduledMessages for exact-match deletion
+        """ALTER TABLE `scheduledMessages`
+         ADD COLUMN `discord_message_id` VARCHAR(20) DEFAULT NULL
+         AFTER `attachments`,
+         ADD INDEX `idx_discord_message` (`discord_message_id`)""",
     ]
     for migration in migrations:
         try:
@@ -2733,7 +2740,7 @@ async def add_scheduled_message(
 
 async def get_scheduled_messages(user_id: str) -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, discord_message_id, created_at
     FROM scheduledMessages
     WHERE user_id = %s
     ORDER BY send_time ASC
@@ -2758,7 +2765,7 @@ async def get_user_scheduled_messages_in_timeframe(
     guild_id: str | None = None,
 ) -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, discord_message_id, created_at
     FROM scheduledMessages
     WHERE user_id = %s
     AND send_time BETWEEN %s AND %s
@@ -2789,7 +2796,7 @@ async def update_scheduled_message_repeat_amount(message_id: int, repeat_amount:
 
 async def get_ready_scheduled_messages() -> list[ScheduledMessageModel]:
     query = """
-    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, created_at
+    SELECT messageId, guild_id, channel_id, user_id, content, send_time, repeatInterval, repeatAmount, attachments, discord_message_id, created_at
     FROM scheduledMessages WHERE send_time <= NOW()
     """
     rows: list[ScheduledMessageModel] = []

--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -266,7 +266,11 @@ async def send_scheduled_messages(client: discord.Client) -> None:
             send_kwargs: dict = {"content": content, "embed": embed}
             if files:
                 send_kwargs["files"] = files
-            await target.send(**send_kwargs)
+            sent_message = await target.send(**send_kwargs)
+
+            # Store the Discord message ID for exact-match deletion
+            if sent_message:
+                await ScheduledMessageService.update_discord_message_id(message_id, str(sent_message.id))
 
             if repeat_amount and repeat_amount != 0:
                 repeat_amount -= 1

--- a/models.py
+++ b/models.py
@@ -147,6 +147,7 @@ class ScheduledMessageModel(BaseModel):
     repeat_interval: int | None
     repeat_amount: int | None
     attachments: str | None = None
+    discord_message_id: str | None = None
     created_at: datetime
 
     @classmethod

--- a/services/scheduled_message_service.py
+++ b/services/scheduled_message_service.py
@@ -79,7 +79,7 @@ class ScheduledMessageService:
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, attachments, created_at
+               repeatInterval, repeatAmount, attachments, discord_message_id, created_at
         FROM scheduledMessages
         WHERE user_id = %s
         ORDER BY send_time ASC
@@ -114,12 +114,20 @@ class ScheduledMessageService:
         await execute_action(query, (repeat_amount, message_id))
 
     @staticmethod
+    async def update_discord_message_id(message_id: int, discord_message_id: str) -> None:
+        """Store the Discord message ID after a scheduled message is sent."""
+        from api import execute_action
+
+        query = "UPDATE scheduledMessages SET discord_message_id = %s WHERE messageId = %s"
+        await execute_action(query, (discord_message_id, message_id))
+
+    @staticmethod
     async def get_due_messages() -> list[ScheduledMessageModel]:
         """Return all messages whose send_time is due (<= now)."""
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, attachments, created_at
+               repeatInterval, repeatAmount, attachments, discord_message_id, created_at
         FROM scheduledMessages WHERE send_time <= NOW()
         """
         rows: list[ScheduledMessageModel] = []
@@ -138,7 +146,7 @@ class ScheduledMessageService:
 
         query = """
         SELECT messageId, guild_id, channel_id, user_id, content, send_time,
-               repeatInterval, repeatAmount, attachments, created_at
+               repeatInterval, repeatAmount, attachments, discord_message_id, created_at
         FROM scheduledMessages
         WHERE user_id = %s
         AND send_time BETWEEN %s AND %s


### PR DESCRIPTION
Closes #1629

**Changes:**
- Added `discord_message_id VARCHAR(20) DEFAULT NULL` column to scheduledMessages DDL
- Added ALTER TABLE migration for existing databases
- Added `discord_message_id` field to `ScheduledMessageModel`
- Added `ScheduledMessageService.update_discord_message_id()` method
- Store Discord message ID after sending scheduled messages
- Added INDEX on `discord_message_id` for fast lookups

**Success Criteria:**
- Migration adds the column without data loss
- When a scheduled message is sent, its discord_message_id is stored in the DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled messages now capture and store Discord message IDs when delivered.
  * Stored IDs are returned with scheduled-message data, enabling reliable tracking and exact-match operations (e.g., cleanup or deletion) for delivered messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->