### PR TITLE
Wrap remaining plain-text counting sends in embeds

### DIFF
--- a/minigames/_counting_common.py
+++ b/minigames/_counting_common.py
@@ -117,5 +117,5 @@ async def counting(
     await increase_progress_func(message.channel.id, message.author.id)
     # nosec: B311
     if random.randint(1, 100) == 1:
-        await DiscordSafe.send(message.channel, content=str(progress + 2))
+        await DiscordSafe.send(message.channel, embed=tanjunEmbed(description=str(progress + 2)))
         await increase_progress_func(message.channel.id, "me")

--- a/minigames/counting_modes.py
+++ b/minigames/counting_modes.py
@@ -557,7 +557,7 @@ async def counting(message: discord.Message, config: dict | None = None) -> None
                 number_to_romeal(correct_number) if mode == CountingMode.ROMEAN else str(correct_number)
             )
         )
-        await DiscordSafe.send(message.channel, content=display_number)
+        await DiscordSafe.send(message.channel, embed=tanjunEmbed(description=display_number))
         await repo.set_mode_progress(
             channel_id=message.channel.id,
             progress=(romeal_to_number(correct_number) if mode == CountingMode.ROMEAN else correct_number),


### PR DESCRIPTION
Closes #1330

Migrates the last two plain `content=` sends in counting minigames to use `tanjungEmbed` with description, completing the migration of all ~145 plain-text sends identified in issue #1330.

This was already mostly done by previous work — only two files remained:
- `minigames/counting_modes.py` (binary/romean display)
- `minigames/_counting_common.py` (random bonus number)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced counting minigame presentation. Failure messages, extra messages, and next correct number notifications now display as formatted embeds instead of plain text. This upgrade improves visual clarity and message organization, making important game notifications more prominent and easier to distinguish, enhancing the overall user experience during gameplay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->