### PR TITLE
Fix: Robust scheduled message repeat logic with catch-up handling

### DIFF
--- a/commands/utility/schedulemessage.py
+++ b/commands/utility/schedulemessage.py
@@ -270,16 +270,38 @@ async def send_scheduled_messages(client: discord.Client) -> None:
 
             # --- Repeat logic ---
             if repeat_interval and repeat_interval > 0:
-                # This is a repeating message — advance send_time
-                next_send_time = msg.send_time + timedelta(seconds=repeat_interval)
+                now = datetime.now()
+
+                # Determine how many repeat intervals this message is overdue.
+                # If the bot was offline and missed several repeat windows,
+                # we skip the backlog and advance send_time past 'now'.
+                elapsed = (now - msg.send_time).total_seconds()
+                intervals_behind = max(0, int(elapsed // repeat_interval))
+
+                # We always consume at least the current execution (intervals_behind
+                # may be 0 if the message is on time).
+                total_consumed = intervals_behind + 1
+                next_send_time = msg.send_time + timedelta(seconds=repeat_interval * total_consumed)
+
+                if intervals_behind > 0:
+                    logging.info(
+                        "Scheduled message %s was %d repeat intervals behind. "
+                        "Catching up: advancing send_time by %d intervals.",
+                        message_id,
+                        intervals_behind,
+                        total_consumed,
+                    )
 
                 if repeat_amount is not None:
-                    # Finite repeats: decrement count
-                    if repeat_amount > 0:
-                        new_amount = repeat_amount - 1
-                        await ScheduledMessageService.update_repeat_and_send_time(message_id, new_amount, next_send_time)
+                    # Finite repeats: consume the owed intervals and the current one
+                    new_amount = max(0, repeat_amount - total_consumed)
+
+                    if new_amount > 0:
+                        await ScheduledMessageService.update_repeat_and_send_time(
+                            message_id, new_amount, next_send_time,
+                        )
                     else:
-                        # repeat_amount == 0: no more repeats, cancel
+                        # No more repeats remaining — cancel the task
                         await ScheduledMessageService.cancel(message_id)
                 else:
                     # Infinite repeats (repeat_amount is None): keep going forever

--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -157,12 +157,18 @@ class ListenerCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message) -> None:
-        # NOTE: message.id is a Discord snowflake, not necessarily a scheduled message ID.
-        # This only works if the deleted message happens to have the same ID as a
-        # scheduled message entry — which is not generally the case.
-        # A proper fix would require storing the message ID returned by the send
-        # in the scheduled_messages table, then looking it up on delete.
-        # For now we keep this best-effort behavior.
+        """
+        Best-effort cancel when a message is deleted.
+
+        NOTE: message.id is a Discord snowflake, not a scheduled-message DB ID.
+        This only works if the deleted message happens to have the same ID as a
+        scheduled-message entry — which is extremely unlikely.
+
+        A proper fix requires storing the Discord message ID returned by
+        message.send() in a dedicated `discord_message_id` column on the
+        scheduledMessages table, then looking up the scheduled entry by that
+        column on delete. See issues #1629 and #1630.
+        """
         await ScheduledMessageService.cancel(message.id)
 
     @commands.Cog.listener()


### PR DESCRIPTION
## Summary

Fixes the repeat logic for scheduled messages (issue #1628) to handle bot downtime gracefully. Instead of spamming the channel with backlogged messages when the bot comes back, the send_time is advanced past 'now' and the repeat count is decremented accordingly.

## Changes

### `commands/utility/schedulemessage.py`
- **Catch-up logic**: When a repeating scheduled message is overdue by multiple repeat intervals (bot was offline), compute the number of missed intervals and advance send_time past the current time in one step, skipping backlog sends.
- **Correct decrement**: Finite-repeat messages now consume both the current execution and any caught-up intervals from `repeat_amount`, ensuring they expire at the right time.
- **Infinite repeats**: Also handle catch-up by advancing send_time by multiple intervals at once.

### `extensions/listeners.py`
- Improved docstring for `on_message_delete` to clarify the current best-effort limitation and cross-reference the proper fix in #1629/#1630 (`discord_message_id` column).

## Previous vs. New Behavior

| Scenario | Before | After |
|---|---|---|
| Bot offline 2h, msg every 30min, finite repeats=5 | Next send_time advances only 30min, repeats exhausted early, channel flooded one-by-one | Advance by all 4 missed + 1 current = 5 intervals, catch up to now in one go |
| Bot offline, msg every 30min, infinite repeats | Same backlog flooding | Single advance past now, no flooding |
| On-time, no downtime | Same (single interval advance) | Same |

Closes #1628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of scheduled repeating messages when they fall behind (e.g., during downtime). Messages now resume at the next scheduled interval instead of sending multiple backlog messages in succession.

* **Documentation**
  * Updated documentation clarifying message deletion behavior for scheduled messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->