### PR TITLE
fix: remove non-existent LICENSE.txt from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -m appuser && \
 USER appuser
 
 # Install Python dependencies
-COPY pyproject.toml README.md LICENSE.txt ./
+COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir .
 


### PR DESCRIPTION
This PR fixes the Docker build failure by removing the reference to `LICENSE.txt`, which is not present in the repository root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Optimized Docker image build configuration to streamline the build context by refining which project files are included during image construction, improving overall build efficiency and reducing unnecessary data in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->