### PR TITLE
Fix ImportError in utils.dispatcher (ver/1.2)

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,21 +1,31 @@
 from .async_io import run_blocking
 from .dispatcher import (
+    HandlerRegistry,
     MessageFilters,
     MessageHandler,
     clear,
     dispatch,
     freeze,
     register,
+    register_handler,
     registered_handlers,
+    registry,
+    run_handlers_safe,
+    run_handlers_sequential,
 )
 
 __all__ = [
     "run_blocking",
+    "HandlerRegistry",
     "MessageFilters",
     "MessageHandler",
     "clear",
     "dispatch",
     "freeze",
     "register",
+    "register_handler",
     "registered_handlers",
+    "registry",
+    "run_handlers_safe",
+    "run_handlers_sequential",
 ]

--- a/utils/dispatcher.py
+++ b/utils/dispatcher.py
@@ -321,3 +321,39 @@ def register_handler(
 # Module-level singleton – imported by listener cog and extensions
 # ------------------------------------------------------------------
 registry: HandlerRegistry = HandlerRegistry()
+
+
+# ------------------------------------------------------------------
+# Module-level functional API (wrappers for the singleton)
+# ------------------------------------------------------------------
+
+
+def register(handler: MessageHandler) -> None:
+    """Register a single message handler in the global registry."""
+    registry.register(handler)
+
+
+def clear() -> None:
+    """Remove all handlers from the global registry."""
+    registry._handlers.clear()
+
+
+def registered_handlers() -> list[MessageHandler]:
+    """Return a list of all handlers in the global registry."""
+    return registry._handlers
+
+
+def freeze() -> None:
+    """No-op for backward compatibility."""
+    pass
+
+
+async def dispatch(message: discord.Message) -> None:
+    """Dispatch message to all matching global handlers concurrently."""
+    handlers = registry.get_handlers(message)
+    # Convert MessageHandler objects to the tuple format expected by run_handlers_safe
+    to_run = [
+        (h.name, h.callback, (message,), h.kwargs)  # type: ignore[arg-type]
+        for h in handlers
+    ]
+    await run_handlers_safe(to_run, message)


### PR DESCRIPTION
This PR fixes the ImportError in utils.dispatcher on the ver/1.2 branch by restoring the functional API (register, clear, dispatch, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Expanded dispatcher utility exports to provide more granular control over handler management and message routing.
  * Added functional API wrapper for handler registration, clearing, and status tracking to simplify integration with the core messaging system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->