### PR TITLE
Fix PydanticUndefinedAnnotation in di.py

### DIFF
--- a/di.py
+++ b/di.py
@@ -7,25 +7,24 @@ Usage:
 
 from __future__ import annotations
 
+import asyncmy
+from discord.ext import commands
+
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
-if TYPE_CHECKING:
-    import asyncmy
-    from discord.ext import commands
-
-    from api import DatabaseManager
-    from services.afk_service import AfkService
-    from services.ai_service import AiService
-    from services.counting_repository import CountingRepository
-    from services.dynamicslowmode import DynamicSlowmodeService
-    from services.giveaway_service import GiveawayService
-    from services.report_service import ReportService
-    from services.scheduled_message_service import ScheduledMessageService
-    from services.ticket_service import TicketService
-    from services.trigger_message_service import TriggerMessageService
-    from services.xp_calculator import XpCalculator
+from api import DatabaseManager
+from services.afk_service import AfkService
+from services.ai_service import AiService
+from services.counting_repository import CountingRepository
+from services.dynamicslowmode import DynamicSlowmodeService
+from services.giveaway_service import GiveawayService
+from services.report_service import ReportService
+from services.scheduled_message_service import ScheduledMessageService
+from services.ticket_service import TicketService
+from services.trigger_message_service import TriggerMessageService
+from services.xp_calculator import XpCalculator
 
 
 class BotServices(BaseModel):


### PR DESCRIPTION
This PR fixes the  error that was causing deployment failures.

The issue was that several types used in the  Pydantic model were only imported inside an  block. Pydantic 2.x requires these names to be available in the global namespace at runtime when  is called to resolve forward references.

Verification confirms that moving these imports to the top level does not introduce any circular dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module import handling to enhance runtime efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->