### PR TITLE
Fix ImportError in extensions.minigames

### DIFF
--- a/commands/minigames/counting_modes/setcountingprogress.py
+++ b/commands/minigames/counting_modes/setcountingprogress.py
@@ -15,7 +15,7 @@ LOCALE_KEY = "minigames.setcountingchallengeprogress"
 _repo = CountingRepository
 
 
-async def set_counting_progress(command_info: CommandInfo, channel: discord.TextChannel, progress: int) -> None:
+async def setCountingProgress(command_info: CommandInfo, channel: discord.TextChannel, progress: int) -> None:
     if await require_moderate_members(command_info, LOCALE_KEY):
         return
 


### PR DESCRIPTION
This PR fixes the  error.

The function was named  in the source file but was being imported as  in . I've renamed the function to  to match the import and stay consistent with the naming convention used in other counting modules ( and ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements for maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->