### PR TITLE
Infrastructure: Sentry Integration for Error Tracking (#1621)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,8 @@ twitchSecret="123"
 twitchId="123"
 prefix="t."
 sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0"
-sentry_traces_sample_rate="0.0"
-sentry_environment="production"
+SENTRY_TRACES_SAMPLE_RATE=0.0
+SENTRY_ENVIRONMENT="production"
 
 # ── Emoji configuration (optional overrides) ─────────────────────────────────
 # Calculator button emojis  (format: name:id)

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ brawlstarsToken="123"
 twitchSecret="123"
 twitchId="123"
 prefix="t."
+sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0"
 
 # ── Emoji configuration (optional overrides) ─────────────────────────────────
 # Calculator button emojis  (format: name:id)

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ twitchSecret="123"
 twitchId="123"
 prefix="t."
 sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0"
+sentry_traces_sample_rate="0.0"
+sentry_environment="production"
 
 # ── Emoji configuration (optional overrides) ─────────────────────────────────
 # Calculator button emojis  (format: name:id)

--- a/config.py
+++ b/config.py
@@ -58,6 +58,8 @@ class Settings(BaseSettings, cli_parse_args=False):
 
     # ── Sentry ─────────────────────────────────────────────────────────────────
     sentry_dsn: str = Field(default="", alias="sentry_dsn")
+    sentry_traces_sample_rate: float = Field(default=0.0, alias="SENTRY_TRACES_SAMPLE_RATE")
+    sentry_environment: str = Field(default="", alias="SENTRY_ENVIRONMENT")
 
     # ── Activity ──────────────────────────────────────────────────────────────
     activity: str = "Tanjun {version}"
@@ -122,6 +124,8 @@ prefix: str = settings.prefix  # type: ignore[assignment]
 OPENROUTER_API_KEY: str = settings.openrouter_api_key.get_secret_value()
 OPENROUTER_MODEL: str = settings.openrouter_model
 sentry_dsn: str = settings.sentry_dsn
+sentry_traces_sample_rate: float = settings.sentry_traces_sample_rate
+sentry_environment: str = settings.sentry_environment
 
 
 # ── Emoji identifiers for calculator ─────────────────────────────────────────

--- a/config.py
+++ b/config.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings, cli_parse_args=False):
         default="deepseek/deepseek-v4-flash:free", alias="OPENROUTER_MODEL"
     )
 
+    # ── Sentry ─────────────────────────────────────────────────────────────────
+    sentry_dsn: str = Field(default="", alias="sentry_dsn")
+
     # ── Activity ──────────────────────────────────────────────────────────────
     activity: str = "Tanjun {version}"
 
@@ -118,6 +121,7 @@ twitchId: str = settings.twitch_id  # type: ignore[assignment]
 prefix: str = settings.prefix  # type: ignore[assignment]
 OPENROUTER_API_KEY: str = settings.openrouter_api_key.get_secret_value()
 OPENROUTER_MODEL: str = settings.openrouter_model
+sentry_dsn: str = settings.sentry_dsn
 
 
 # ── Emoji identifiers for calculator ─────────────────────────────────────────

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -12,10 +12,49 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import sentry_dsn
 from localizer import tanjunLocalizer
 from utility import ErrorEmbedCategory
 
 logger = logging.getLogger(__name__)
+
+
+# ── Sentry scope helpers ─────────────────────────────────────────────────────
+def _set_sentry_context(interaction: discord.Interaction, error: Exception) -> None:
+    """Attach user, guild, and command context to Sentry events.
+
+    This is a no-op when ``sentry_dsn`` is empty.
+    """
+    if not sentry_dsn:
+        return
+    try:
+        import sentry_sdk
+
+        with sentry_sdk.configure_scope() as scope:
+            # User context — User ID + guild ID provide enough info to triage.
+            scope.set_user({
+                "id": str(interaction.user.id),
+                "username": str(interaction.user),
+            })
+
+            # Guild context
+            if interaction.guild:
+                scope.set_tag("guild_id", str(interaction.guild.id))
+                scope.set_tag("guild_name", interaction.guild.name)
+
+            # Command context
+            command = interaction.command
+            if command:
+                scope.set_tag("command", command.qualified_name)
+
+            # Extra context
+            scope.set_extra("interaction_id", str(interaction.id))
+            scope.set_extra("channel_id", str(interaction.channel_id))
+
+            # Set the error as the current exception so Sentry groups correctly
+            scope._set_attr("exc_info", (type(error), error, error.__traceback__))
+    except Exception:
+        logger.debug("Failed to set Sentry context", exc_info=True)
 
 
 def _get_locale(interaction: discord.Interaction) -> str:
@@ -164,6 +203,10 @@ class ErrorHandlerCog(commands.Cog):
                 original,
             )
             traceback.print_exception(type(original), original, original.__traceback__)
+
+            # Attach user/guild/command context to Sentry for real errors.
+            _set_sentry_context(interaction, original)
+
             embed = await self._build_error_embed(
                 interaction,
                 ErrorEmbedCategory.UNEXPECTED,

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 # ── Sentry scope helpers ─────────────────────────────────────────────────────
-def _set_sentry_context(interaction: discord.Interaction, error: Exception) -> None:
+def _set_sentry_context(interaction: discord.Interaction) -> None:
     """Attach user, guild, and command context to Sentry events.
 
     This is a no-op when ``sentry_dsn`` is empty.
@@ -30,26 +30,27 @@ def _set_sentry_context(interaction: discord.Interaction, error: Exception) -> N
     try:
         import sentry_sdk
 
-        with sentry_sdk.configure_scope() as scope:
-            # User context — User ID + guild ID provide enough info to triage.
-            scope.set_user({
-                "id": str(interaction.user.id),
-                "username": str(interaction.user),
-            })
+        # User context — User ID + guild ID provide enough info to triage.
+        sentry_sdk.set_user({
+            "id": str(interaction.user.id),
+            "username": str(interaction.user),
+        })
 
-            # Guild context
-            if interaction.guild:
-                scope.set_tag("guild_id", str(interaction.guild.id))
-                scope.set_tag("guild_name", interaction.guild.name)
+        # Guild context
+        if interaction.guild:
+            sentry_sdk.set_tag("guild_id", str(interaction.guild.id))
+            sentry_sdk.set_tag("guild_name", interaction.guild.name)
 
-            # Command context
-            command = interaction.command
-            if command:
-                scope.set_tag("command", command.qualified_name)
+        # Command context
+        command = interaction.command
+        if command:
+            sentry_sdk.set_tag("command", command.qualified_name)
 
-            # Extra context
-            scope.set_extra("interaction_id", str(interaction.id))
-            scope.set_extra("channel_id", str(interaction.channel_id))
+        # Extra context
+        sentry_sdk.set_context("interaction", {
+            "interaction_id": str(interaction.id),
+            "channel_id": str(interaction.channel_id),
+        })
     except Exception:
         logger.debug("Failed to set Sentry context", exc_info=True)
 
@@ -194,7 +195,7 @@ class ErrorHandlerCog(commands.Cog):
 
         else:
             # Attach user/guild/command context to Sentry BEFORE logging.
-            _set_sentry_context(interaction, original)
+            _set_sentry_context(interaction)
 
             # Log unexpected errors with full traceback.
             logger.exception(

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -194,15 +194,56 @@ class ErrorHandlerCog(commands.Cog):
             )
 
         else:
-            # Attach user/guild/command context to Sentry BEFORE logging.
-            _set_sentry_context(interaction)
+            # Use a temporary Sentry scope to avoid context bleed between interactions
+            if sentry_dsn:
+                try:
+                    import sentry_sdk
 
-            # Log unexpected errors with full traceback.
-            logger.exception(
-                "Unhandled app command error in %s: %s",
-                interaction.command.qualified_name if interaction.command else "unknown",
-                original,
-            )
+                    with sentry_sdk.push_scope() as scope:
+                        # User context — User ID + guild ID provide enough info to triage.
+                        scope.set_user({
+                            "id": str(interaction.user.id),
+                            "username": str(interaction.user),
+                        })
+
+                        # Guild context
+                        if interaction.guild:
+                            scope.set_tag("guild_id", str(interaction.guild.id))
+                            scope.set_tag("guild_name", interaction.guild.name)
+
+                        # Command context
+                        command = interaction.command
+                        if command:
+                            scope.set_tag("command", command.qualified_name)
+
+                        # Extra context
+                        scope.set_context("interaction", {
+                            "interaction_id": str(interaction.id),
+                            "channel_id": str(interaction.channel_id),
+                        })
+
+                        # Log unexpected errors with full traceback (Sentry will capture this)
+                        logger.exception(
+                            "Unhandled app command error in %s: %s",
+                            interaction.command.qualified_name if interaction.command else "unknown",
+                            original,
+                        )
+                except Exception:
+                    logger.debug("Failed to set Sentry context", exc_info=True)
+                    # Still log the error even if Sentry context fails
+                    logger.exception(
+                        "Unhandled app command error in %s: %s",
+                        interaction.command.qualified_name if interaction.command else "unknown",
+                        original,
+                    )
+            else:
+                # Log unexpected errors with full traceback when Sentry is disabled
+                logger.exception(
+                    "Unhandled app command error in %s: %s",
+                    interaction.command.qualified_name if interaction.command else "unknown",
+                    original,
+                )
+
             traceback.print_exception(type(original), original, original.__traceback__)
 
             embed = await self._build_error_embed(

--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -50,9 +50,6 @@ def _set_sentry_context(interaction: discord.Interaction, error: Exception) -> N
             # Extra context
             scope.set_extra("interaction_id", str(interaction.id))
             scope.set_extra("channel_id", str(interaction.channel_id))
-
-            # Set the error as the current exception so Sentry groups correctly
-            scope._set_attr("exc_info", (type(error), error, error.__traceback__))
     except Exception:
         logger.debug("Failed to set Sentry context", exc_info=True)
 
@@ -196,6 +193,9 @@ class ErrorHandlerCog(commands.Cog):
             )
 
         else:
+            # Attach user/guild/command context to Sentry BEFORE logging.
+            _set_sentry_context(interaction, original)
+
             # Log unexpected errors with full traceback.
             logger.exception(
                 "Unhandled app command error in %s: %s",
@@ -203,9 +203,6 @@ class ErrorHandlerCog(commands.Cog):
                 original,
             )
             traceback.print_exception(type(original), original, original.__traceback__)
-
-            # Attach user/guild/command context to Sentry for real errors.
-            _set_sentry_context(interaction, original)
 
             embed = await self._build_error_embed(
                 interaction,

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -5,7 +5,23 @@ from datetime import time
 import discord
 from discord.ext import commands, tasks
 
-from ai.refill_token import refill_ai_token
+from config import sentry_dsn
+
+logger = logging.getLogger(__name__)
+
+
+# ── Sentry helper ────────────────────────────────────────────────────────────
+def _log_loop_error(task_name: str) -> None:
+    """Log a background loop exception and report to Sentry (if configured)."""
+    logger.exception("Error in loop task %s", task_name)
+    if sentry_dsn:
+        try:
+            import sentry_sdk
+
+            sentry_sdk.set_tag("loop_task", task_name)
+            sentry_sdk.capture_exception()
+        except Exception:
+            pass  # Don't let Sentry itself break the loop
 from commands.utility.claim_booster_channel import (
     remove_claimed_booster_channels_that_are_expired,
 )
@@ -34,77 +50,77 @@ class LoopCog(commands.Cog):
         try:
             await sendReadyGiveaways(self.bot)  # type: ignore[no-untyped-call]
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("sendSendReadyGiveaways")
 
     @tasks.loop(seconds=30)
     async def endGiveawaysLoop(self) -> None:
         try:
             await endGiveaways(self.bot)  # type: ignore[no-untyped-call]
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("endGiveawaysLoop")
 
     @tasks.loop(seconds=60)
     async def checkVoiceUsers(self) -> None:
         try:
             await checkVoiceUsers(self.bot)  # type: ignore[no-untyped-call]
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("checkVoiceUsers")
 
     @tasks.loop(seconds=60)
     async def clearNotifiedUsersLoop(self) -> None:
         try:
             clearNotifiedUsers(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("clearNotifiedUsersLoop")
 
     @tasks.loop(seconds=30)
     async def addVoiceUserLoop(self) -> None:
         try:
             await addXpToVoiceUsers(self.bot)  # type: ignore[no-untyped-call]
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("addVoiceUserLoop")
 
     @tasks.loop(seconds=60)
     async def refillAiTokenLoop(self) -> None:
         try:
             await refill_ai_token(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("refillAiTokenLoop")
 
     @tasks.loop(seconds=60)
     async def pingServerLoop(self) -> None:
         try:
             await ping_server(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("pingServerLoop")
 
     @tasks.loop(hours=1)
     async def backupDatabaseLoop(self) -> None:
         try:
             await create_database_backup(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("backupDatabaseLoop")
 
     @tasks.loop(seconds=30)
     async def removeExpiredClaimedBoosterRoles(self) -> None:
         try:
             await remove_claimed_booster_roles_that_are_expired(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("removeExpiredClaimedBoosterRoles")
 
     @tasks.loop(seconds=30)
     async def removeExpiredClaimedBoosterChannels(self) -> None:
         try:
             await remove_claimed_booster_channels_that_are_expired(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("removeExpiredClaimedBoosterChannels")
 
     @tasks.loop(seconds=30)
     async def sendScheduledMessages(self) -> None:
         try:
             await send_scheduled_messages(self.bot)
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("sendScheduledMessages")
 
     @tasks.loop(seconds=60)  # Twitch API rate limits
     async def pollTwitchStreams(self) -> None:
@@ -145,7 +161,7 @@ class LoopCog(commands.Cog):
                 twitch_service.stream_status[uuid] = uuid in live_streams
 
         except Exception:
-            logging.exception("Error in loop")
+            _log_loop_error("pollTwitchStreams")
 
     @tasks.loop(time=[time(hour=2), time(hour=8), time(hour=14), time(hour=20)])
     async def sendPokemonWerbung(self) -> None:
@@ -181,7 +197,7 @@ Jede(r) ist ♥️-lich willkommen! Wir freuen uns über jeden Neuzugang! Schaut
                 if sent_message.guild:
                     await sent_message.publish()
         except Exception:
-            logging.exception("Error in pokemon advertising loop")
+            _log_loop_error("sendPokemonWerbung")
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -18,8 +18,7 @@ def _log_loop_error(task_name: str) -> None:
         try:
             import sentry_sdk
 
-            sentry_sdk.set_tag("loop_task", task_name)
-            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception(tags={"loop_task": task_name})
         except Exception:
             pass  # Don't let Sentry itself break the loop
 from commands.utility.claim_booster_channel import (

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -34,6 +34,7 @@ from loops.alivemonitor import ping_server
 from loops.create_database_backup import create_database_backup
 from loops.giveaway import checkVoiceUsers, endGiveaways, sendReadyGiveaways
 from loops.level import addXpToVoiceUsers
+from ai.refill_token import refill_ai_token
 from minigames.add_level_xp import clearNotifiedUsers
 from services.twitch_service import get_twitch_service
 from utility import EmbedColor

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ from config import (
     database_user,
     prefix,
     sentry_dsn,
+    sentry_environment,
+    sentry_traces_sample_rate,
 )
 
 
@@ -70,11 +72,15 @@ def _should_discard_sentry_event(event: dict, hint: dict) -> dict | None:
 if sentry_dsn:
     import sentry_sdk
 
-    sentry_sdk.init(
-        dsn=sentry_dsn,
-        before_send=_should_discard_sentry_event,
-        traces_sample_rate=0.0,  # No performance tracing by default
-    )
+    init_kwargs = {
+        "dsn": sentry_dsn,
+        "before_send": _should_discard_sentry_event,
+        "traces_sample_rate": sentry_traces_sample_rate,
+    }
+    if sentry_environment:
+        init_kwargs["environment"] = sentry_environment
+
+    sentry_sdk.init(**init_kwargs)
 
 from DatabaseHealthCheck import DatabaseHealthCheck
 from di import services

--- a/main.py
+++ b/main.py
@@ -28,7 +28,54 @@ from config import (
     database_schema,
     database_user,
     prefix,
+    sentry_dsn,
 )
+
+
+# ── Sentry event filter ──────────────────────────────────────────────────────
+def _should_discard_sentry_event(event: dict, hint: dict) -> dict | None:
+    """Drop noisy known-safe Discord API errors to save Sentry quota.
+
+    Returns ``None`` to discard the event, or the ``event`` dict to send it.
+    """
+    exc_info = hint.get("exc_info", None)
+    if exc_info is None:
+        return event
+    _exc_type, exc_value, _tb = exc_info
+
+    # Discord HTTP 403 Forbidden — expected when the bot lacks a permission.
+    if isinstance(exc_value, discord.Forbidden):
+        return None
+
+    # Discord HTTP 404 — Unknown Message, Unknown Interaction, etc.
+    if isinstance(exc_value, discord.NotFound):
+        return None
+
+    # Discord HTTP 429 — rate-limited; logged locally, not actionable via Sentry.
+    if isinstance(exc_value, discord.HTTPException):
+        if exc_value.status in (429,):
+            return None
+
+    # Discord 10008 "Unknown Message" — common race when a message is deleted
+    # between when a component interaction fires and the bot tries to respond.
+    if isinstance(exc_value, discord.DiscordException):
+        msg = str(exc_value).lower()
+        if "10008" in msg and "unknown message" in msg:
+            return None
+
+    return event
+
+
+# ── Sentry initialization (must be early) ────────────────────────────────────
+if sentry_dsn:
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        before_send=_should_discard_sentry_event,
+        traces_sample_rate=0.0,  # No performance tracing by default
+    )
+
 from DatabaseHealthCheck import DatabaseHealthCheck
 from di import services
 from external_api_health_checks import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
     "python-dotenv==1.2.2",
     "requests==2.34.2",
     "scipy==1.17.1",
+    "sentry-sdk==2.27.0",
     "six==1.17.0",
     "sniffio==1.3.1",
     "soupsieve==2.8.4",


### PR DESCRIPTION
## Summary
Integrates Sentry SDK for real-time error tracking and aggregation.

## Changes
- Added `sentry-sdk` dependency to `pyproject.toml`
- Added `sentry_dsn` config option to Settings (optional, defaults to empty)
- Initializes Sentry at startup in `main.py` with configurable DSN
- Filters out known Discord API noise (403 Forbidden, 404 NotFound, 429 rate-limited, 10008 Unknown Message) via `before_send` hook
- Attaches user/guild/command context to Sentry events in the global error handler
- Reports background loop exceptions to Sentry via `_log_loop_error` helper
- Updates `.env.example` with `sentry_dsn` placeholder

## Success Criteria
- [x] Errors are automatically aggregated and reported to a central dashboard.
- [x] Faster debugging of production-only issues.

## Notes
- Sentry is opt-in: if `SENTRY_DSN` is not set, the SDK is not initialized.
- Known Discord API errors are silently dropped to avoid noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Sentry integration for error monitoring, capturing unhandled errors and background-task failures with richer context (user, guild, command, interaction).

* **Configuration**
  * New Sentry settings and example environment variables to enable monitoring, control sampling rate, and set environment.

* **Bug Fixes**
  * Event filtering to suppress expected/benign errors (rate limits, not-found, known race-condition noise) and reduce alert noise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->