### PR TITLE
Optimize: Implement Centralized Caching Strategy (#1618)

### DIFF
--- a/api.py
+++ b/api.py
@@ -44,6 +44,7 @@ from models import (
     XpBoostModel,
 )
 from utility import get_level_for_xp_async, get_xp_for_level_async
+from utils.cache import TTLCache
 
 
 # ── Log blacklist (delegated to LogBlacklistRepository) ─────────────────────────────
@@ -284,35 +285,31 @@ async def _execute_with_retry(
 
 
 # ── Cache System ──────────────────────────────────────────────────────────────
+# Centralised TTL caches.  Each cache owns its TTL and (optionally) max size;
+# LRU eviction happens automatically when ``maxsize`` is set.
 
-_BLACKLIST_CACHE_TTL = 30  # seconds
-_GUILD_CONFIG_CACHE_TTL = 300  # 5 minutes
-
-_blacklist_cache: dict[str, tuple[Any, float]] = {}
-_guild_config_cache: dict[str, tuple[dict[str, Any], float]] = {}
+_blacklist_cache: TTLCache[str, dict[str, list[BlacklistEntryModel]]] = TTLCache(
+    ttl=30
+)
+_guild_config_cache: TTLCache[str, dict[str, Any]] = TTLCache(ttl=300, maxsize=2000)
 # In-memory cache for XP cooldowns: (guild_id, user_id) -> last_xp_gain_timestamp
 # Eliminates DB queries entirely when user is on cooldown
 _last_xp_gain_cache: dict[tuple[str, str], float] = {}
-# In-memory cache for counting configs: channel_id -> (counting_config, challenge_config, modes_config, timestamp)
+# In-memory cache for counting configs: channel_id -> (counting_config, challenge_config, modes_config)
 # Reduces 3 DB queries per message to in-memory lookup
-_COUNTING_CACHE_TTL = 30  # seconds
-_counting_cache: dict[str, tuple[dict | None, dict | None, dict | None, float]] = {}
-
-
-def _is_cache_valid(entry: tuple[Any, float] | None, ttl: float) -> bool:
-    if entry is None:
-        return False
-    return (time.time() - entry[1]) < ttl
+_counting_cache: TTLCache[str, tuple[dict | None, dict | None, dict | None]] = TTLCache(
+    ttl=30
+)
 
 
 def _invalidate_guild_cache(guild_id: str) -> None:
-    _blacklist_cache.pop(guild_id, None)
-    _guild_config_cache.pop(guild_id, None)
+    _blacklist_cache.delete(guild_id)
+    _guild_config_cache.delete(guild_id)
 
 
 def invalidate_counting_cache(channel_id: str | int) -> None:
     """Remove the counting config cache entry for a specific channel."""
-    _counting_cache.pop(str(channel_id), None)
+    _counting_cache.delete(str(channel_id))
 
 
 async def preload_guild_configs(bot=None) -> None:
@@ -328,15 +325,15 @@ async def preload_guild_configs(bot=None) -> None:
     pool = _get_pool()
     if pool is None:
         return
-    global _guild_config_cache
-    _guild_config_cache = {}
+    _guild_config_cache.clear()
     try:
         conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
         async with conn, conn.cursor() as cursor:
             await asyncio.wait_for(cursor.execute(query), timeout=_QUERY_TIMEOUT)
             async for row in cursor:
                 guild_id = str(row[0])
-                _guild_config_cache[guild_id] = (
+                _guild_config_cache.set(
+                    guild_id,
                     {
                         "active": row[1],
                         "scaling": row[2],
@@ -347,7 +344,6 @@ async def preload_guild_configs(bot=None) -> None:
                         "text_cooldown": row[7],
                         "voice_cooldown": row[8],
                     },
-                    time.time(),
                 )
     except Exception as e:
         print(f"Error preloading guild configs: {e}")
@@ -356,18 +352,18 @@ async def preload_guild_configs(bot=None) -> None:
 async def _get_cached_blacklist(guild_id: str) -> dict[str, list[BlacklistEntryModel]]:
     """Get blacklist with TTL cache (30s), reducing per-message DB queries by ~97%."""
     cached = _blacklist_cache.get(guild_id)
-    if _is_cache_valid(cached, _BLACKLIST_CACHE_TTL):
-        return cached[0]
+    if cached is not None:
+        return cached
     data = await get_blacklist(guild_id)
-    _blacklist_cache[guild_id] = (data, time.time())
+    _blacklist_cache.set(guild_id, data)
     return data
 
 
 async def _get_cached_config(guild_id: str, key: str, default: Any = None) -> Any:
     """Get a cached level config value with TTL check. Falls back to DB on miss."""
     cache_entry = _guild_config_cache.get(guild_id)
-    if _is_cache_valid(cache_entry, _GUILD_CONFIG_CACHE_TTL):
-        return cache_entry[0].get(key, default)
+    if cache_entry is not None:
+        return cache_entry.get(key, default)
     # Cache miss — reload from DB
     query = """
     SELECT guild_id, active, difficulty, customFormula, level_up_messageActive,
@@ -393,10 +389,10 @@ async def _get_cached_config(guild_id: str, key: str, default: Any = None) -> An
                     "text_cooldown": row[7],
                     "voice_cooldown": row[8],
                 }
-                _guild_config_cache[guild_id] = (data, time.time())
+                _guild_config_cache.set(guild_id, data)
                 return data.get(key, default)
             # Cache the miss (no levelConfig row for this guild)
-            _guild_config_cache[guild_id] = ({}, time.time())
+            _guild_config_cache.set(guild_id, {})
     except Exception as e:
         print(f"Error caching guild config for {guild_id}: {e}")
     return default
@@ -1335,7 +1331,7 @@ async def get_counting_configs(channel_id: str | int) -> tuple[dict | None, dict
     """
     key = str(channel_id)
     cached = _counting_cache.get(key)
-    if cached is not None and _is_cache_valid((cached, cached[3]), _COUNTING_CACHE_TTL):
+    if cached is not None:
         return cached[0], cached[1], cached[2]
 
     counting_query = "SELECT progress, last_counter_id, guild_id FROM counting WHERE channel_id = %s"
@@ -1368,7 +1364,7 @@ async def get_counting_configs(channel_id: str | int) -> tuple[dict | None, dict
         if modes_result
         else None
     )
-    _counting_cache[key] = (counting_config, challenge_config, modes_config, time.time())
+    _counting_cache.set(key, (counting_config, challenge_config, modes_config))
     return counting_config, challenge_config, modes_config
 
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,4 +1,5 @@
 from .async_io import run_blocking
+from .cache import TTLCache
 from .dispatcher import (
     HandlerRegistry,
     MessageFilters,
@@ -16,6 +17,7 @@ from .dispatcher import (
 
 __all__ = [
     "run_blocking",
+    "TTLCache",
     "HandlerRegistry",
     "MessageFilters",
     "MessageHandler",

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -1,0 +1,217 @@
+"""Centralized TTL cache with LRU eviction support.
+
+Provides ``TTLCache``, an async-safe in-memory cache with
+per-entry time-to-live and optional maximum-size LRU eviction.
+
+Usage::
+
+    from utils.cache import TTLCache
+
+    # Simple TTL cache
+    user_cache: TTLCache[str, UserModel] = TTLCache(ttl=120)
+    item = user_cache.get("key")
+    if item is None:
+        item = await fetch_from_db()
+        user_cache.set("key", item)
+
+    # Bounded cache with LRU eviction (max 1000 entries)
+    bounded: TTLCache[str, bytes] = TTLCache(ttl=60, maxsize=1000)
+"""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from typing import Any, Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class TTLCache(Generic[K, V]):
+    """An in-memory cache with per-entry TTL and optional LRU eviction.
+
+    Parameters
+    ----------
+    ttl : float
+        Default time-to-live in seconds for each entry.
+    maxsize : int, optional
+        Maximum number of entries before LRU eviction kicks in.
+        ``None`` (default) means unbounded.
+
+    Thread-safety
+    -------------
+    This cache is **not** thread-safe by itself.  When used from
+    async code with a single event-loop thread, access is naturally
+    serialised.  For multi-threaded usage, wrap with ``asyncio.Lock``.
+    """
+
+    __slots__ = ("_ttl", "_maxsize", "_store", "_deadline")
+
+    def __init__(self, ttl: float, maxsize: int | None = None) -> None:
+        if ttl <= 0:
+            raise ValueError("ttl must be positive")
+        if maxsize is not None and maxsize <= 0:
+            raise ValueError("maxsize must be positive or None")
+        self._ttl = ttl
+        self._maxsize = maxsize
+        # OrderedDict for O(1) LRU: move_to_end on get/set
+        self._store: OrderedDict[K, V] = OrderedDict()
+        self._deadline: dict[K, float] = {}
+
+    # ── Public API ──────────────────────────────────────────────────────
+
+    @property
+    def ttl(self) -> float:
+        """Return the default TTL for this cache."""
+        return self._ttl
+
+    @property
+    def maxsize(self) -> int | None:
+        """Return the maximum size, or ``None`` if unbounded."""
+        return self._maxsize
+
+    @property
+    def size(self) -> int:
+        """Return the current number of entries (including expired ones)."""
+        self._evict_expired()
+        return len(self._store)
+
+    def get(self, key: K) -> V | None:
+        """Retrieve a value, returning ``None`` if missing or expired."""
+        deadline = self._deadline.get(key)
+        if deadline is None:
+            return None
+        if time.monotonic() > deadline:
+            self._discard(key)
+            return None
+        # LRU: move to end (most recently used)
+        self._store.move_to_end(key)
+        return self._store[key]
+
+    def set(self, key: K, value: V, *, ttl: float | None = None) -> None:
+        """Store a value with the default or explicit TTL."""
+        now = time.monotonic()
+        self._store[key] = value
+        self._deadline[key] = now + (ttl if ttl is not None else self._ttl)
+        self._store.move_to_end(key)  # most recently used
+        self._evict_lru()
+
+    def delete(self, key: K) -> None:
+        """Remove a single key if present; no-op otherwise."""
+        self._discard(key)
+
+    def invalidate(self, key: K) -> None:
+        """Alias for :meth:`delete` — immediately expire *key*."""
+        self.delete(key)
+
+    def pop(self, key: K, default: V | None = None) -> V | None:
+        """Remove *key* and return its value, or *default* if missing."""
+        value = self.get(key)
+        if value is None:
+            return default
+        self._discard(key)
+        return value
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self._store.clear()
+        self._deadline.clear()
+
+    def contains(self, key: K) -> bool:
+        """Check if *key* exists and is not expired (O(1))."""
+        return self.get(key) is not None
+
+    def keys(self) -> list[K]:
+        """Return a snapshot of valid (non-expired) keys."""
+        self._evict_expired()
+        return list(self._store.keys())
+
+    def values(self) -> list[V]:
+        """Return a snapshot of valid (non-expired) values."""
+        self._evict_expired()
+        return list(self._store.values())
+
+    def items(self) -> list[tuple[K, V]]:
+        """Return a snapshot of valid (non-expired) key-value pairs."""
+        self._evict_expired()
+        return list(self._store.items())
+
+    def get_or_compute(
+        self,
+        key: K,
+        factory: Callable[[], V | Awaitable[V]],
+        *,
+        ttl: float | None = None,
+    ) -> V | Awaitable[V]:
+        """Return cached value or compute via *factory* (sync **or** async).
+
+        If *factory* is a coroutine function, this returns an awaitable;
+        otherwise returns the value directly.
+        """
+        existing = self.get(key)
+        if existing is not None:
+            return existing
+
+        result = factory()
+        if isinstance(result, Awaitable):
+            return self._set_from_awaitable(key, result, ttl=ttl)
+        self.set(key, result, ttl=ttl)
+        return result
+
+    async def _set_from_awaitable(
+        self, key: K, awaitable: Awaitable[V], *, ttl: float | None
+    ) -> V:
+        value = await awaitable
+        self.set(key, value, ttl=ttl)
+        return value
+
+    def get_or_compute_sync(
+        self,
+        key: K,
+        factory: Callable[[], V],
+        *,
+        ttl: float | None = None,
+    ) -> V:
+        """Synchronous variant of :meth:`get_or_compute` that does NOT await."""
+        existing = self.get(key)
+        if existing is not None:
+            return existing
+        value = factory()
+        self.set(key, value, ttl=ttl)
+        return value
+
+    # ── Internal helpers ────────────────────────────────────────────────
+
+    def _discard(self, key: K) -> None:
+        self._store.pop(key, None)
+        self._deadline.pop(key, None)
+
+    def _evict_expired(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, d in self._deadline.items() if now > d]
+        for k in expired:
+            self._discard(k)
+
+    def _evict_lru(self) -> None:
+        if self._maxsize is not None and len(self._store) > self._maxsize:
+            # OrderedDict.popitem(last=False) removes the *first* (oldest) item
+            oldest = self._store.popitem(last=False)
+            self._deadline.pop(oldest[0], None)
+
+    def __contains__(self, key: object) -> bool:
+        """Check if *key* exists and is not expired."""
+        try:
+            return self.contains(key)  # type: ignore[arg-type]
+        except TypeError:
+            return False
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(ttl={self._ttl}, "
+            f"maxsize={self._maxsize}, size={self.size})"
+        )


### PR DESCRIPTION
## Summary

This PR implements a centralized, reusable caching utility (`TTLCache`) and migrates the existing ad-hoc dictionary-based caches in `api.py` to use it.

## Changes

### New file: `utils/cache.py`

- **`TTLCache[K, V]`** — generic in-memory cache with:
  - Per-entry TTL (default configurable per instance, overridable per `set()` call)
  - Optional LRU eviction (`maxsize` parameter) using `OrderedDict`
  - `get()`, `set()`, `delete()`, `clear()`, `pop()`, `contains()`, `keys()`, `values()`, `items()`
  - `get_or_compute(key, factory)` — sync/async factory support
  - Automatic expired-entry cleanup on access

### Refactored caches in `api.py`

| Cache | Old impl | New impl | TTL | Max size |
|---|---|---|---|---|
| `_blacklist_cache` | `dict[str, tuple[data, float]]` | `TTLCache` | 30s | unbounded |
| `_guild_config_cache` | `dict[str, tuple[data, float]]` | `TTLCache` | 300s (5 min) | 2000 (LRU) |
| `_counting_cache` | `dict[str, tuple[..., float]]` | `TTLCache` | 30s | unbounded |

### Removed

- `_is_cache_valid()` helper function
- `_BLACKLIST_CACHE_TTL`, `_GUILD_CONFIG_CACHE_TTL`, `_COUNTING_CACHE_TTL` constants

### Re-exports

- `TTLCache` is exported from `utils/__init__.py`

## Benefits

- Cache logic is centralized and reusable by any module
- LRU eviction prevents memory growth on the guild config cache
- No more manual `time.time()` + tuple unpacking scattered across the codebase
- `get_or_compute` simplifies the common pattern of "check cache → fetch → store"

Closes #1618

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked caching across the app for automatic expiration and smarter handling, reducing stale data and improving reliability.
  * Guild blacklist/config and counting configurations now update and invalidate more reliably, improving responsiveness to changes.
  * General performance improvements from centralized, size-limited in-memory caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->