### PR TITLE
Fix #1631: Add edit/cancel action buttons to /schedule list dashboard

### DIFF
--- a/commands/utility/listscheduled.py
+++ b/commands/utility/listscheduled.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable, Coroutine
 from typing import Any
 
 import discord
@@ -13,24 +14,40 @@ MAX_CONTENT_LENGTH = 1000  # Maximum length for message content preview
 MAX_EMBED_LENGTH = 6000  # Discord's maximum embed length
 
 
-class EditContentModal(Modal, title="Edit Scheduled Message"):
+class EditContentModal(Modal):
     """Modal for editing the content of a scheduled message."""
 
     new_content: TextInput[Any] = TextInput(
-        label="New content",
         style=discord.TextStyle.paragraph,
-        max_length=1024,
+        max_length=2000,
         required=True,
     )
 
-    def __init__(self, message_id: int, current_content: str, locale: str) -> None:
-        super().__init__(timeout=300)
-        self.message_id = message_id
+    def __init__(self, message_id: int, current_content: str, locale: str, view: View) -> None:
         self.locale = locale
+        super().__init__(
+            title=tanjunLocalizer.localize(
+                locale,
+                "commands.utility.listscheduled.edit_modal.title",
+            ),
+            timeout=300,
+        )
+        self.message_id = message_id
+        self.view = view
+        self.new_content.label = tanjunLocalizer.localize(
+            locale,
+            "commands.utility.listscheduled.edit_modal.content_label",
+        )
         self.new_content.default = current_content
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         await ScheduledMessageService.update_content(self.message_id, self.new_content.value)
+
+        # Update the in-memory model
+        for msg in self.view.messages:
+            if msg.message_id == self.message_id:
+                msg.content = self.new_content.value
+                break
 
         embed = utility.tanjunEmbed(
             title=tanjunLocalizer.localize(
@@ -114,7 +131,9 @@ async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
                 cancel_button.callback = self._make_cancel_callback(msg)  # type: ignore[method-assign]
                 self.add_item(cancel_button)
 
-        def _make_edit_callback(self, msg: ScheduledMessageModel) -> Any:
+        def _make_edit_callback(
+            self, msg: ScheduledMessageModel
+        ) -> Callable[[discord.Interaction], Coroutine[Any, Any, None]]:
             """Create a closure that opens the edit modal for *msg*."""
 
             async def _edit(interaction: discord.Interaction) -> None:
@@ -131,12 +150,15 @@ async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
                     message_id=msg.message_id,
                     current_content=msg.content,
                     locale=self.locale,
+                    view=self,
                 )
                 await interaction.response.send_modal(modal)
 
             return _edit
 
-        def _make_cancel_callback(self, msg: ScheduledMessageModel) -> Any:
+        def _make_cancel_callback(
+            self, msg: ScheduledMessageModel
+        ) -> Callable[[discord.Interaction], Coroutine[Any, Any, None]]:
             """Create a closure that cancels *msg*."""
 
             async def _cancel(interaction: discord.Interaction) -> None:

--- a/commands/utility/listscheduled.py
+++ b/commands/utility/listscheduled.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import discord
-from discord.ui import Button, View
+from discord.ui import Button, Modal, TextInput, View
 
 import utility
 from localizer import tanjunLocalizer
@@ -11,6 +11,39 @@ from services.scheduled_message_service import ScheduledMessageService
 MESSAGES_PER_PAGE = 1
 MAX_CONTENT_LENGTH = 1000  # Maximum length for message content preview
 MAX_EMBED_LENGTH = 6000  # Discord's maximum embed length
+
+
+class EditContentModal(Modal, title="Edit Scheduled Message"):
+    """Modal for editing the content of a scheduled message."""
+
+    new_content: TextInput[Any] = TextInput(
+        label="New content",
+        style=discord.TextStyle.paragraph,
+        max_length=1024,
+        required=True,
+    )
+
+    def __init__(self, message_id: int, current_content: str, locale: str) -> None:
+        super().__init__(timeout=300)
+        self.message_id = message_id
+        self.locale = locale
+        self.new_content.default = current_content
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await ScheduledMessageService.update_content(self.message_id, self.new_content.value)
+
+        embed = utility.tanjunEmbed(
+            title=tanjunLocalizer.localize(
+                self.locale,
+                "commands.utility.listscheduled.edit_success.title",
+            ),
+            description=tanjunLocalizer.localize(
+                self.locale,
+                "commands.utility.listscheduled.edit_success.description",
+                id=self.message_id,
+            ),
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
 
 async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
@@ -47,6 +80,101 @@ async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
             )
             next_button.callback = self.next_page  # type: ignore[method-assign]
             self.add_item(next_button)
+
+            # Edit and cancel buttons for the current page's message
+            self._add_action_buttons()
+
+        def _add_action_buttons(self) -> None:
+            """Add edit and cancel buttons for the message on the current page."""
+            start_idx = self.page * MESSAGES_PER_PAGE
+            page_messages = self.messages[start_idx : start_idx + MESSAGES_PER_PAGE]
+
+            for msg in page_messages:
+                edit_button: Button[Any] = Button(
+                    label=tanjunLocalizer.localize(
+                        self.locale,
+                        "commands.utility.listscheduled.edit_button",
+                    ),
+                    style=discord.ButtonStyle.primary,
+                    emoji="✏️",
+                    row=1,
+                )
+                edit_button.callback = self._make_edit_callback(msg)  # type: ignore[method-assign]
+                self.add_item(edit_button)
+
+                cancel_button: Button[Any] = Button(
+                    label=tanjunLocalizer.localize(
+                        self.locale,
+                        "commands.utility.listscheduled.cancel_button",
+                    ),
+                    style=discord.ButtonStyle.danger,
+                    emoji="🗑️",
+                    row=1,
+                )
+                cancel_button.callback = self._make_cancel_callback(msg)  # type: ignore[method-assign]
+                self.add_item(cancel_button)
+
+        def _make_edit_callback(self, msg: ScheduledMessageModel) -> Any:
+            """Create a closure that opens the edit modal for *msg*."""
+
+            async def _edit(interaction: discord.Interaction) -> None:
+                if interaction.user != command_info.user:
+                    await interaction.response.send_message(
+                        tanjunLocalizer.localize(
+                            self.locale,
+                            "commands.utility.listscheduled.error.not_authorized",
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+                modal = EditContentModal(
+                    message_id=msg.message_id,
+                    current_content=msg.content,
+                    locale=self.locale,
+                )
+                await interaction.response.send_modal(modal)
+
+            return _edit
+
+        def _make_cancel_callback(self, msg: ScheduledMessageModel) -> Any:
+            """Create a closure that cancels *msg*."""
+
+            async def _cancel(interaction: discord.Interaction) -> None:
+                if interaction.user != command_info.user:
+                    await interaction.response.send_message(
+                        tanjunLocalizer.localize(
+                            self.locale,
+                            "commands.utility.listscheduled.error.not_authorized",
+                        ),
+                        ephemeral=True,
+                    )
+                    return
+
+                await ScheduledMessageService.cancel(msg.message_id)
+
+                # Remove the message from the local list
+                self.messages = [m for m in self.messages if m.message_id != msg.message_id]
+                self.max_pages = (len(self.messages) - 1) // MESSAGES_PER_PAGE if self.messages else 0
+                if self.page > self.max_pages:
+                    self.page = self.max_pages
+
+                if not self.messages:
+                    embed = utility.tanjunEmbed(
+                        title=tanjunLocalizer.localize(
+                            self.locale,
+                            "commands.utility.listscheduled.no_messages.title",
+                        ),
+                        description=tanjunLocalizer.localize(
+                            self.locale,
+                            "commands.utility.listscheduled.no_messages.description",
+                        ),
+                    )
+                    await interaction.response.edit_message(embed=embed, view=discord.ui.View())
+                    return
+
+                await self.update_message(interaction)
+
+            return _cancel
 
         def truncate_content(self, content: str) -> str:
             """Truncate content and add ellipsis if necessary"""
@@ -182,6 +310,6 @@ async def list_scheduled_messages(command_info: utility.CommandInfo) -> None:
     view.set_message(
         await command_info.reply(
             embed=view.get_embed(),
-            view=view if len(messages) > MESSAGES_PER_PAGE else discord.ui.View(),
+            view=view,
         )
     )

--- a/locales/de.json
+++ b/locales/de.json
@@ -7352,6 +7352,38 @@
     "max_length": null
   },
   {
+    "identifier": "commands.utility.listscheduled.edit_button",
+    "source_string": "Bearbeiten",
+    "translation": "Bearbeiten",
+    "context": "commands -> utility -> listscheduled -> edit_button",
+    "labels": "de.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.cancel_button",
+    "source_string": "Löschen",
+    "translation": "Löschen",
+    "context": "commands -> utility -> listscheduled -> cancel_button",
+    "labels": "de.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.edit_success.title",
+    "source_string": "Nachricht aktualisiert",
+    "translation": "Nachricht aktualisiert",
+    "context": "commands -> utility -> listscheduled -> edit_success -> title",
+    "labels": "de.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.edit_success.description",
+    "source_string": "Die geplante Nachricht ${id} wurde aktualisiert.",
+    "translation": "Die geplante Nachricht ${id} wurde aktualisiert.",
+    "context": "commands -> utility -> listscheduled -> edit_success -> description",
+    "labels": "de.json",
+    "max_length": null
+  },
+  {
     "identifier": "commands.utility.removescheduled.select.placeholder",
     "source_string": "Wähle eine Nachricht aus",
     "translation": "Wähle eine Nachricht aus",

--- a/locales/en.json
+++ b/locales/en.json
@@ -7352,6 +7352,38 @@
     "max_length": null
   },
   {
+    "identifier": "commands.utility.listscheduled.edit_button",
+    "source_string": "Edit",
+    "translation": "Edit",
+    "context": "commands -> utility -> listscheduled -> edit_button",
+    "labels": "en.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.cancel_button",
+    "source_string": "Cancel",
+    "translation": "Cancel",
+    "context": "commands -> utility -> listscheduled -> cancel_button",
+    "labels": "en.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.edit_success.title",
+    "source_string": "Message Updated",
+    "translation": "Message Updated",
+    "context": "commands -> utility -> listscheduled -> edit_success -> title",
+    "labels": "en.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.listscheduled.edit_success.description",
+    "source_string": "Scheduled message ${id} has been updated.",
+    "translation": "Scheduled message ${id} has been updated.",
+    "context": "commands -> utility -> listscheduled -> edit_success -> description",
+    "labels": "en.json",
+    "max_length": null
+  },
+  {
     "identifier": "commands.utility.removescheduled.select.placeholder",
     "source_string": "Wähle eine Nachricht aus",
     "translation": "Select a message",


### PR DESCRIPTION
## Summary

Adds interactive edit and cancel buttons to the paginated `/schedule list` dashboard so users can manage their scheduled messages directly from the list view.

## Changes

- **Edit button** (✏️, primary) on each message page opens a Discord modal for inline content editing
- **Cancel button** (🗑️, danger) deletes the scheduled message and refreshes the view
- **EditContentModal** — new modal with a multi-line text input, validates max 1024 chars
- **Localization** — added `edit_button`, `cancel_button`, `edit_success.title`, and `edit_success.description` for both `en.json` and `de.json`
- Removed the conditional view toggle (now always shows nav + action buttons)

Closes #1631

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit scheduled message content directly from the message list via an interactive modal.
  * Per-message cancel buttons to remove scheduled messages from the list.
  * Pagination now shows action buttons for messages on the current page.
* **Localization**
  * Added English and German localized labels and success messages for edit/cancel flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->