### PR TITLE
feat: Reactivate Crowdin for future translations (#1210)

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,57 @@
+name: Crowdin Sync
+
+on:
+  push:
+    branches:
+      - development
+    paths:
+      - 'locales/en.json'
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      upload_only:
+        description: 'Only upload source files (skip download)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  crowdin-sync:
+    name: Sync Translations with Crowdin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: development
+
+      - name: Upload source files to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          crowdin_branch_name: development
+          config: crowdin.yml
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Download translations from Crowdin
+        if: ${{ !inputs.upload_only }}
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          crowdin_branch_name: development
+          config: crowdin.yml
+          create_pull_request: true
+          pull_request_title: 'New Crowdin updates'
+          pull_request_body: 'Automated translation updates from Crowdin.'
+          pull_request_labels: 'translations'
+          pull_request_base_branch_name: development
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
## Description

This PR reactivates Crowdin translation sync by adding a proper GitHub Actions workflow file.

The previous Crowdin GitHub integration (web-based bundles) stopped creating automated PRs for translation updates. This PR replaces it with a CI-based approach using the official `crowdin/github-action` action.

## Changes

- Added `/.github/workflows/crowdin.yml` — GitHub Actions workflow for Crowdin sync
- Triggers on pushes to `development` that modify `locales/en.json`
- Also runs on a weekly schedule (Mondays at 06:00 UTC)
- Supports manual dispatch for on-demand syncs
- Uploads source strings to Crowdin and downloads translations
- Creates pull requests with title "New Crowdin updates" for translation changes

## Required Secrets

Before this workflow can run, the following secrets must be configured in the repository:
- `CROWDIN_PROJECT_ID` — The Crowdin project ID
- `CROWDIN_PERSONAL_TOKEN` — A Crowdin personal access token with appropriate permissions

## Related

Closes #1210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated translation synchronization workflow with Crowdin, enabling regular updates and manual sync capabilities for localized content management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->