### PR TITLE
Fix AbstractSet ImportError and restore CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
   test-e2e-live:
     name: E2E Live Discord (optional)
     runs-on: ubuntu-latest
-    if: ${{ secrets.TANJUN_TEST_BOT_TOKEN != '' }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -186,7 +185,9 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - run: pytest tests/e2e_live/ -m live_discord -v --timeout=120
+      - name: Run live Discord tests
+        if: env.TANJUN_TEST_BOT_TOKEN != ''
+        run: pytest tests/e2e_live/ -m live_discord -v --timeout=120
         env:
           TANJUN_TEST_BOT_TOKEN: ${{ secrets.TANJUN_TEST_BOT_TOKEN }}
           TANJUN_TEST_GUILD_ID: ${{ secrets.TANJUN_TEST_GUILD_ID }}

--- a/tests/unit/core/test_app_imports.py
+++ b/tests/unit/core/test_app_imports.py
@@ -1,0 +1,11 @@
+"""Smoke tests ensuring core modules import without runtime errors."""
+
+from __future__ import annotations
+
+
+def test_utils_embeds_imports():
+    import utils.embeds  # noqa: F401
+
+
+def test_utility_imports():
+    import utility  # noqa: F401

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -5,8 +5,8 @@ Extracted from ``utility.py`` as part of refactoring (issue #1608).
 
 import datetime
 import enum
-from collections.abc import AbstractSet, Mapping
-from typing import Annotated, Any, Self
+from collections.abc import Mapping
+from typing import AbstractSet, Annotated, Any, Self
 
 import discord
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints


### PR DESCRIPTION
## Summary
- Fix bot startup crash: import `AbstractSet` from `typing` instead of `collections.abc` in `utils/embeds.py` (PR #1700 regression).
- Restore Tanjun CI workflow parsing by moving the live Discord test secret check from job-level `if` to step-level `if`.
- Add import smoke tests for `utils.embeds` and `utility` so future import-chain breaks fail early in unit tests.

## Test plan
- [x] `docker run --rm -v "$PWD:/app" -w /app python:3.12 bash -c "pip install -q discord.py pydantic && python -c 'from utils.embeds import TanjunEmbed'"` succeeds
- [x] `pytest tests/unit/core/test_app_imports.py tests/unit/utils/test_embeds.py` passes on Python 3.12
- [ ] CI `ci.yml` starts jobs again (run duration > 0s) after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke tests to verify library imports work correctly at runtime.

* **Chores**
  * Improved CI workflow to conditionally run live Discord tests when required credentials are available.
  * Updated import sources for type declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->