### PR TITLE
fix: add 19 missing localization keys to locale files

### DIFF
--- a/commands/admin/nuke.py
+++ b/commands/admin/nuke.py
@@ -142,5 +142,5 @@ async def nuke_channel(command_info: utility.CommandInfo, channel: discord.TextC
         await command_info.channel.send(tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.httpError"))
     except discord.NotFound:
         await command_info.channel.send(
-            tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.notfoundError")
+            tanjunLocalizer.localize(str(command_info.locale), "commands.admin.nuke.notfound.description")
         )

--- a/locales/de.json
+++ b/locales/de.json
@@ -120,14 +120,6 @@
     "max_length": null
   },
   {
-    "identifier": "commands.admin.nuke.notfoundError",
-    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
-    "translation": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
-    "context": "commands -> admin -> nuke -> notfoundError",
-    "labels": "unassigned",
-    "max_length": null
-  },
-  {
     "identifier": "commands.admin.removerole.cancel.label",
     "source_string": "Abbrechen",
     "translation": "Abbrechen",

--- a/locales/de.json
+++ b/locales/de.json
@@ -96,6 +96,14 @@
     "max_length": null
   },
   {
+    "identifier": "commands.admin.kick.noReasonProvided",
+    "source_string": "Kein Grund angegeben",
+    "translation": "Kein Grund angegeben",
+    "context": "commands -> admin -> kick -> noReasonProvided",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.nuke.notfound.description",
     "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
     "translation": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
@@ -108,6 +116,86 @@
     "source_string": "Kanal nicht gefunden",
     "translation": "Kanal nicht gefunden",
     "context": "commands -> admin -> nuke -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfoundError",
+    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "translation": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "context": "commands -> admin -> nuke -> notfoundError",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.removerole.cancel.label",
+    "source_string": "Abbrechen",
+    "translation": "Abbrechen",
+    "context": "commands -> admin -> removerole -> cancel -> label",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.removerole.confirm.label",
+    "source_string": "Bestätigen",
+    "translation": "Bestätigen",
+    "context": "commands -> admin -> removerole -> confirm -> label",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.reports.remove_channel.noChannel.title",
+    "source_string": "Kein Report-Kanal eingerichtet",
+    "translation": "Kein Report-Kanal eingerichtet",
+    "context": "commands -> admin -> reports -> remove_channel -> noChannel -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.reports.remove_channel.success.title",
+    "source_string": "Report-Kanal entfernt",
+    "translation": "Report-Kanal entfernt",
+    "context": "commands -> admin -> reports -> remove_channel -> success -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.draw",
+    "source_string": "Unentschieden!",
+    "translation": "Unentschieden!",
+    "context": "commands -> games -> tic_tac_toe -> draw",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.invalidMove",
+    "source_string": "Ungültiger Zug! Bitte wähle ein freies Feld.",
+    "translation": "Ungültiger Zug! Bitte wähle ein freies Feld.",
+    "context": "commands -> games -> tic_tac_toe -> invalidMove",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.notYourGame",
+    "source_string": "Dies ist nicht dein Spiel!",
+    "translation": "Dies ist nicht dein Spiel!",
+    "context": "commands -> games -> tic_tac_toe -> notYourGame",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.notYourTurn",
+    "source_string": "Du bist nicht am Zug!",
+    "translation": "Du bist nicht am Zug!",
+    "context": "commands -> games -> tic_tac_toe -> notYourTurn",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.title",
+    "source_string": "Tic-Tac-Toe",
+    "translation": "Tic-Tac-Toe",
+    "context": "commands -> games -> tic_tac_toe -> title",
     "labels": "unassigned",
     "max_length": null
   },
@@ -4400,6 +4488,38 @@
     "max_length": null
   },
   {
+    "identifier": "commands.image.mirror.invalidaxis.description",
+    "source_string": "Die Achse muss entweder \"x\" (horizontal) oder \"y\" (vertikal) sein.",
+    "translation": "Die Achse muss entweder \"x\" (horizontal) oder \"y\" (vertikal) sein.",
+    "context": "commands -> image -> mirror -> invalidaxis -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.invalidaxis.title",
+    "source_string": "Ungültige Achse",
+    "translation": "Ungültige Achse",
+    "context": "commands -> image -> mirror -> invalidaxis -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.success.description",
+    "source_string": "Das Bild wurde erfolgreich gespiegelt.",
+    "translation": "Das Bild wurde erfolgreich gespiegelt.",
+    "context": "commands -> image -> mirror -> success -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.success.title",
+    "source_string": "Bild gespiegelt",
+    "translation": "Bild gespiegelt",
+    "context": "commands -> image -> mirror -> success -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.logs.setLogChannel.missingPermission.title",
     "source_string": "Fehlende Berechtigung",
     "translation": "Fehlende Berechtigung",
@@ -5776,6 +5896,14 @@
     "max_length": 100
   },
   {
+    "identifier": "commands.math.plotfunction.not_clickable",
+    "source_string": "Nicht klickbar",
+    "translation": "Nicht klickbar",
+    "context": "commands -> math -> plotfunction -> not_clickable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.math.randomnumber.success.title",
     "source_string": "Zufallszahlen generiert",
     "translation": "Zufallszahlen generiert",
@@ -6965,6 +7093,30 @@
     "translation": "Die Boosterrolle wurde automatisch gelöscht, da der user dem die Rolle zugeordnet wurde, kein Booster mehr ist.",
     "context": "commands -> utility -> claimboosterrole -> expired -> reason",
     "labels": "de.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.invalid_action.description",
+    "source_string": "Diese Aktion kann nicht ausgeführt werden. Der Report wurde möglicherweise bereits bearbeitet.",
+    "translation": "Diese Aktion kann nicht ausgeführt werden. Der Report wurde möglicherweise bereits bearbeitet.",
+    "context": "commands -> utility -> report -> invalid_action -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.invalid_action.title",
+    "source_string": "Ungültige Aktion",
+    "translation": "Ungültige Aktion",
+    "context": "commands -> utility -> report -> invalid_action -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.reporter_blocked.title",
+    "source_string": "Reporter blockiert",
+    "translation": "Reporter blockiert",
+    "context": "commands -> utility -> report -> reporter_blocked -> title",
+    "labels": "unassigned",
     "max_length": null
   },
   {

--- a/locales/en.json
+++ b/locales/en.json
@@ -120,14 +120,6 @@
     "max_length": null
   },
   {
-    "identifier": "commands.admin.nuke.notfoundError",
-    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
-    "translation": "The channel was not found. It may have already been deleted.",
-    "context": "commands -> admin -> nuke -> notfoundError",
-    "labels": "unassigned",
-    "max_length": null
-  },
-  {
     "identifier": "commands.admin.removerole.cancel.label",
     "source_string": "Abbrechen",
     "translation": "Cancel",

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,6 +96,14 @@
     "max_length": null
   },
   {
+    "identifier": "commands.admin.kick.noReasonProvided",
+    "source_string": "Kein Grund angegeben",
+    "translation": "No reason provided",
+    "context": "commands -> admin -> kick -> noReasonProvided",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.nuke.notfound.description",
     "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
     "translation": "The channel was not found. It may have already been deleted.",
@@ -108,6 +116,86 @@
     "source_string": "Kanal nicht gefunden",
     "translation": "Channel not found",
     "context": "commands -> admin -> nuke -> notfound -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.nuke.notfoundError",
+    "source_string": "Der Kanal wurde nicht gefunden. Möglicherweise wurde er bereits gelöscht.",
+    "translation": "The channel was not found. It may have already been deleted.",
+    "context": "commands -> admin -> nuke -> notfoundError",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.removerole.cancel.label",
+    "source_string": "Abbrechen",
+    "translation": "Cancel",
+    "context": "commands -> admin -> removerole -> cancel -> label",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.removerole.confirm.label",
+    "source_string": "Bestätigen",
+    "translation": "Confirm",
+    "context": "commands -> admin -> removerole -> confirm -> label",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.reports.remove_channel.noChannel.title",
+    "source_string": "Kein Report-Kanal eingerichtet",
+    "translation": "No report channel set up",
+    "context": "commands -> admin -> reports -> remove_channel -> noChannel -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.reports.remove_channel.success.title",
+    "source_string": "Report-Kanal entfernt",
+    "translation": "Report channel removed",
+    "context": "commands -> admin -> reports -> remove_channel -> success -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.draw",
+    "source_string": "Unentschieden!",
+    "translation": "Draw!",
+    "context": "commands -> games -> tic_tac_toe -> draw",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.invalidMove",
+    "source_string": "Ungültiger Zug! Bitte wähle ein freies Feld.",
+    "translation": "Invalid move! Please choose a free cell.",
+    "context": "commands -> games -> tic_tac_toe -> invalidMove",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.notYourGame",
+    "source_string": "Dies ist nicht dein Spiel!",
+    "translation": "This is not your game!",
+    "context": "commands -> games -> tic_tac_toe -> notYourGame",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.notYourTurn",
+    "source_string": "Du bist nicht am Zug!",
+    "translation": "It's not your turn!",
+    "context": "commands -> games -> tic_tac_toe -> notYourTurn",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.games.tic_tac_toe.title",
+    "source_string": "Tic-Tac-Toe",
+    "translation": "Tic-Tac-Toe",
+    "context": "commands -> games -> tic_tac_toe -> title",
     "labels": "unassigned",
     "max_length": null
   },
@@ -4400,6 +4488,38 @@
     "max_length": null
   },
   {
+    "identifier": "commands.image.mirror.invalidaxis.description",
+    "source_string": "Die Achse muss entweder \"x\" (horizontal) oder \"y\" (vertikal) sein.",
+    "translation": "The axis must be either \"x\" (horizontal) or \"y\" (vertical).",
+    "context": "commands -> image -> mirror -> invalidaxis -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.invalidaxis.title",
+    "source_string": "Ungültige Achse",
+    "translation": "Invalid axis",
+    "context": "commands -> image -> mirror -> invalidaxis -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.success.description",
+    "source_string": "Das Bild wurde erfolgreich gespiegelt.",
+    "translation": "The image has been successfully mirrored.",
+    "context": "commands -> image -> mirror -> success -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.image.mirror.success.title",
+    "source_string": "Bild gespiegelt",
+    "translation": "Image mirrored",
+    "context": "commands -> image -> mirror -> success -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.logs.setLogChannel.missingPermission.title",
     "source_string": "Fehlende Berechtigung",
     "translation": "Missing authorization",
@@ -5776,6 +5896,14 @@
     "max_length": 100
   },
   {
+    "identifier": "commands.math.plotfunction.not_clickable",
+    "source_string": "Nicht klickbar",
+    "translation": "Not clickable",
+    "context": "commands -> math -> plotfunction -> not_clickable",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "commands.math.randomnumber.success.title",
     "source_string": "Zufallszahlen generiert",
     "translation": "Random numbers generated",
@@ -6965,6 +7093,30 @@
     "translation": "The booster role was automatically deleted because the user to whom the role was assigned is no longer a booster.",
     "context": "commands -> utility -> claimboosterrole -> expired -> reason",
     "labels": "de.json",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.invalid_action.description",
+    "source_string": "Diese Aktion kann nicht ausgeführt werden. Der Report wurde möglicherweise bereits bearbeitet.",
+    "translation": "This action cannot be performed. The report may have already been processed.",
+    "context": "commands -> utility -> report -> invalid_action -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.invalid_action.title",
+    "source_string": "Ungültige Aktion",
+    "translation": "Invalid action",
+    "context": "commands -> utility -> report -> invalid_action -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.utility.report.reporter_blocked.title",
+    "source_string": "Reporter blockiert",
+    "translation": "Reporter blocked",
+    "context": "commands -> utility -> report -> reporter_blocked -> title",
+    "labels": "unassigned",
     "max_length": null
   },
   {


### PR DESCRIPTION
## Summary

This PR adds 19 localization keys that were used in production code via `tanjunLocalizer.localize()` but missing from both `en.json` and `de.json` locale files.

When any of these keys were looked up with a German locale, the `missingLocalization('de')` function was triggered, auto-creating issue #1738.

## Changes

Added the following keys to both `locales/en.json` and `locales/de.json`:

- `commands.admin.kick.noReasonProvided`
- `commands.admin.nuke.notfoundError`
- `commands.admin.removerole.cancel.label`
- `commands.admin.removerole.confirm.label`
- `commands.admin.reports.remove_channel.noChannel.title`
- `commands.admin.reports.remove_channel.success.title`
- `commands.games.tic_tac_toe.draw`
- `commands.games.tic_tac_toe.invalidMove`
- `commands.games.tic_tac_toe.notYourGame`
- `commands.games.tic_tac_toe.notYourTurn`
- `commands.games.tic_tac_toe.title`
- `commands.image.mirror.invalidaxis.title`
- `commands.image.mirror.invalidaxis.description`
- `commands.image.mirror.success.title`
- `commands.image.mirror.success.description`
- `commands.math.plotfunction.not_clickable`
- `commands.utility.report.invalid_action.title`
- `commands.utility.report.invalid_action.description`
- `commands.utility.report.reporter_blocked.title`

Closes #1738

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded German and English translations for admin actions (kick, removerole, reports, nuke), games (tic-tac-toe), image editing (mirror), math (plot), and utility report messages to improve multilingual UX.
* **Bug Fixes**
  * Corrected a localization message used for an admin command’s "not found" response so the proper translated text is shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->