### PR TITLE
Fix version bump workflow and add release branch automation

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,42 +1,91 @@
 name: Version Bump
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - development
-    types:
-      - merged
+  push:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: version-bump-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
   bump_version:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Get current version
-        id: get_version
-        run: |
-          # Get the current version from the `VERSION` file.
-          current_version=$(cat VERSION)
-          echo "Current version: $current_version"
-          echo "::set-output name=current::${current_version}"
+        uses: actions/checkout@v4
+        with:
+          ref: development
+          fetch-depth: 0
 
       - name: Bump version
         id: bump_version
         run: |
-          IFS='.' read -r major minor patch <<< "${{ steps.get_version.outputs.current }}"
+          current_version=$(tr -d '[:space:]' < VERSION)
+          IFS='.' read -r major minor patch <<< "$current_version"
           patch=$((patch + 1))
           new_version="$major.$minor.$patch"
-          echo "New version: $new_version"
           echo "$new_version" > VERSION
-          echo "::set-output name=new::${new_version}"
+          echo "new=$new_version" >> "$GITHUB_OUTPUT"
 
-      - name: Tag the new version
+      - name: Commit, tag, and push
+        env:
+          NEW_VERSION: ${{ steps.bump_version.outputs.new }}
         run: |
-          git config --local user.name "GitHub Action"
-          git config --local user.email "action@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add VERSION
-          git commit -m "Version bumped to ${{ steps.bump_version.outputs.new }}"
-          git tag -a "$new_version" -m "Tagging version $new_version"
-          git push origin development --tags
+          git commit -m "chore: bump version to ${NEW_VERSION} [ignore changelog]"
+          git tag -a "${NEW_VERSION}" -m "Version ${NEW_VERSION}"
+          git push origin development
+          git push origin "${NEW_VERSION}"
+
+  create_release_branch:
+    if: |
+      github.event_name == 'push' &&
+      !contains(github.event.head_commit.message, '[ignore changelog]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute release version
+        id: release
+        run: |
+          current_version=$(tr -d '[:space:]' < VERSION)
+          IFS='.' read -r major minor patch <<< "$current_version"
+          minor=$((minor + 1))
+          release_version="${major}.${minor}.0"
+          release_branch="ver/${major}.${minor}"
+          echo "version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "branch=${release_branch}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release branch
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            echo "Branch ${RELEASE_BRANCH} already exists, skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${RELEASE_BRANCH}"
+          echo "${RELEASE_VERSION}" > VERSION
+          git add VERSION
+          git commit -m "chore: set version to ${RELEASE_VERSION} [ignore changelog]"
+          git push origin "${RELEASE_BRANCH}"


### PR DESCRIPTION
## Summary
- Fixes the broken version bump workflow on merged PRs into `development` (invalid `push`/`merged` trigger, deprecated outputs, and incomplete git push/tag steps).
- Adds automatic release branch creation on pushes to `main`/`master`: creates `ver/X.Y` with `VERSION` set to `X.Y.0` when the branch does not already exist.
- Skips automated commits tagged with `[ignore changelog]` and uses concurrency to avoid race conditions.

## Test plan
- [ ] Merge this PR into `development` and verify the workflow bumps the patch version in `VERSION`
- [ ] Push to `master` and verify a new `ver/X.Y` branch is created with `VERSION=X.Y.0`
- [ ] Confirm existing `ver/X.Y` branches are not recreated


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated versioning and release branch creation workflow to improve release consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->