### PR TITLE
Fix release branch workflow skipped on main merges

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -51,9 +51,7 @@ jobs:
           git push origin "${NEW_VERSION}"
 
   create_release_branch:
-    if: |
-      github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, '[ignore changelog]')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -72,20 +70,29 @@ jobs:
           echo "version=${release_version}" >> "$GITHUB_OUTPUT"
           echo "branch=${release_branch}" >> "$GITHUB_OUTPUT"
 
-      - name: Create release branch
+      - name: Create or update release branch
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
           RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
         run: |
-          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
-            echo "Branch ${RELEASE_BRANCH} already exists, skipping."
-            exit 0
+          git fetch origin main master 2>/dev/null || true
+          base_ref=origin/main
+          if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
+            base_ref=origin/master
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${RELEASE_BRANCH}"
+          branch_exists=false
+          if git ls-remote --exit-code --heads origin "${RELEASE_BRANCH}" >/dev/null 2>&1; then
+            branch_exists=true
+          fi
+
+          git checkout -B "${RELEASE_BRANCH}" "${base_ref}"
           echo "${RELEASE_VERSION}" > VERSION
           git add VERSION
           git commit -m "chore: set version to ${RELEASE_VERSION} [ignore changelog]"
-          git push origin "${RELEASE_BRANCH}"
+
+          if [ "${branch_exists}" = true ]; then
+            git push origin "${RELEASE_BRANCH}" --force-with-lease
+          else
+            git push origin "${RELEASE_BRANCH}"
+          fi


### PR DESCRIPTION
## Summary
- Fixes `create_release_branch` being skipped when merge commits include `[ignore changelog]` in the commit body (e.g. from the development patch bump commit in the same merge).
- Updates existing `ver/X.Y` branches from `main`/`master` instead of silently skipping when the branch already exists.

## Root cause
PR #1764 merge commit body contained `chore: bump version to 1.1.5 [ignore changelog]`, so the workflow condition `!contains(..., '[ignore changelog]')` evaluated to false and the release branch job never ran.

## Test plan
- [ ] Merge this PR into `development`
- [ ] Merge `development` into `main`
- [ ] Verify `ver/1.2` is updated from `main` with `VERSION=1.2.0`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release branch automation to create new release branches and automatically update existing ones, ensuring consistent version tracking across all configured branches without requiring manual intervention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->