### PR TITLE
Sync release VERSION to main and development on main push

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -51,7 +51,9 @@ jobs:
           git push origin "${NEW_VERSION}"
 
   create_release_branch:
-    if: github.event_name == 'push'
+    if: |
+      github.event_name == 'push' &&
+      (github.event.head_commit == null || !startsWith(github.event.head_commit.message, 'chore: sync release version to'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -74,9 +76,13 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
           RELEASE_BRANCH: ${{ steps.release.outputs.branch }}
+          TARGET_BRANCH: ${{ github.ref_name }}
         run: |
-          git fetch origin main master 2>/dev/null || true
-          base_ref=origin/main
+          git fetch origin main master development "${TARGET_BRANCH}" 2>/dev/null || true
+          base_ref="origin/${TARGET_BRANCH}"
+          if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
+            base_ref=origin/main
+          fi
           if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
             base_ref=origin/master
           fi
@@ -88,6 +94,8 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          sync_commit_message="chore: sync release version to ${RELEASE_VERSION} [ignore changelog]"
+
           git checkout -B "${RELEASE_BRANCH}" "${base_ref}"
           echo "${RELEASE_VERSION}" > VERSION
           git add VERSION
@@ -97,4 +105,20 @@ jobs:
             git push origin "${RELEASE_BRANCH}" --force-with-lease
           else
             git push origin "${RELEASE_BRANCH}"
+          fi
+
+          git checkout -B "sync-${TARGET_BRANCH}" "${base_ref}"
+          echo "${RELEASE_VERSION}" > VERSION
+          git add VERSION
+          if ! git diff --cached --quiet; then
+            git commit -m "${sync_commit_message}"
+            git push origin "sync-${TARGET_BRANCH}:${TARGET_BRANCH}"
+          fi
+
+          git checkout -B sync-development origin/development
+          echo "${RELEASE_VERSION}" > VERSION
+          git add VERSION
+          if ! git diff --cached --quiet; then
+            git commit -m "${sync_commit_message}"
+            git push origin sync-development:development
           fi


### PR DESCRIPTION
## Summary
- After a push to `main`/`master`, the release workflow now also sets `VERSION` on `main`/`master` and `development` to `X.Y.0` (same as the `ver/X.Y` branch).
- Adds a guard so the follow-up sync commit on `main` does not trigger another release bump.

## Test plan
- [ ] Merge into `development`, then merge `development` into `main`
- [ ] Verify `main`, `development`, and `ver/X.Y` all have the same release `VERSION`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process automation and branch management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->