### PR TITLE
fix: map Chinese locale variants to English fallback

### DIFF
--- a/localizer.py
+++ b/localizer.py
@@ -73,6 +73,8 @@ class LocalizerService:
             return "de"
         if raw.startswith("ko"):
             return "ko"
+        if raw in ("zh-CN", "zh-TW", "zh-Hans", "zh-Hant"):
+            return "en"
         return raw
 
     @staticmethod


### PR DESCRIPTION
## Description

Maps `zh-CN`, `zh-TW`, `zh-Hans`, and `zh-Hant` Discord locale values to `en` in the locale normalizer, since dedicated Chinese translation files are not yet available. This prevents auto-generated 'Missing localization' issues from being created every time a user with one of these locales interacts with the bot.

## Changes

- `localizer.py`: Added Chinese locale variants to `_normalize_locale()` to fall back to English translations.

Closes #1742

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization handling to standardize processing of multiple Chinese locale variants, ensuring consistent translation resource loading and fallback behavior for Chinese language configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanjunBot/new_tanjun/pull/1782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->