### PR TITLE
fix(#1760): add missing errors.guildOnly localization keys to locale files

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -31824,6 +31824,22 @@
     "max_length": null
   },
   {
+    "identifier": "errors.guildOnly.title",
+    "source_string": "Nur in Servern nutzbar",
+    "translation": "Nur in Servern nutzbar",
+    "context": "errors -> guildOnly -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.guildOnly.description",
+    "source_string": "Dieser Befehl kann nur in einem Server verwendet werden.",
+    "translation": "Dieser Befehl kann nur in einem Server verwendet werden.",
+    "context": "errors -> guildOnly -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "errors.http_error.title",
     "source_string": "Discord API-Fehler",
     "translation": "Discord API-Fehler",

--- a/locales/en.json
+++ b/locales/en.json
@@ -31824,6 +31824,22 @@
     "max_length": null
   },
   {
+    "identifier": "errors.guildOnly.title",
+    "source_string": "Guild-only command",
+    "translation": "Guild-only command",
+    "context": "errors -> guildOnly -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.guildOnly.description",
+    "source_string": "This command can only be used in a server.",
+    "translation": "This command can only be used in a server.",
+    "context": "errors -> guildOnly -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "errors.http_error.title",
     "source_string": "Discord API-Fehler",
     "translation": "Discord API error",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -31680,6 +31680,22 @@
     "max_length": null
   },
   {
+    "identifier": "errors.guildOnly.title",
+    "source_string": "Nur in Servern nutzbar",
+    "translation": "서버에서만 사용 가능",
+    "context": "errors -> guildOnly -> title",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
+    "identifier": "errors.guildOnly.description",
+    "source_string": "Dieser Befehl kann nur in einem Server verwendet werden.",
+    "translation": "이 명령어는 서버에서만 사용할 수 있습니다.",
+    "context": "errors -> guildOnly -> description",
+    "labels": "unassigned",
+    "max_length": null
+  },
+  {
     "identifier": "errors.http_error.title",
     "source_string": "Discord API-Fehler",
     "translation": "Discord API error",


### PR DESCRIPTION
## Description
Fixes #1760 

The code was referencing `errors.guildOnly.title` and `errors.guildOnly.description` localization keys in multiple commands (report.py, delete_booster_channel.py, autopublish.py), but these entries were missing from both locale files.

This adds the missing entries to `en.json` and `de.json` with appropriate translations for both languages.

## Changes
- Added `errors.guildOnly.title` and `errors.guildOnly.description` to `locales/en.json`
- Added `errors.guildOnly.title` and `errors.guildOnly.description` to `locales/de.json`

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added German, English, and Korean translations for the "guild-only" error title and description.

* **Chores**
  * Minor formatting adjustment in the Korean locale file to correct trailing bracket placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->