### PR TITLE
fix: gracefully normalize unsupported locales to English to prevent spam issues

### DIFF
--- a/localizer.py
+++ b/localizer.py
@@ -65,7 +65,12 @@ class LocalizerService:
 
     @staticmethod
     def _normalize_locale(locale: discord.Locale | str) -> str:
-        """Normalize a locale value to a short identifier (e.g. ``de``, ``en``)."""
+        """Normalize a locale value to a short identifier (e.g. ``de``, ``en``).
+
+        Unsupported Discord locales (e.g. ``ja``, ``zh-TW``, ``es-419``) are
+        silently mapped to ``"en"`` to avoid creating spam "missing localization"
+        GitHub issues for languages that the bot does not ship locale files for.
+        """
         raw = str(locale.value if isinstance(locale, discord.Locale) else locale)
         if raw in ("en", "en-US", "en-GB"):
             return "en"
@@ -73,7 +78,8 @@ class LocalizerService:
             return "de"
         if raw.startswith("ko"):
             return "ko"
-        return raw
+        # Any other unknown or unsupported locale falls back to English
+        return "en"
 
     @staticmethod
     def _validate_json(data: object) -> list[TranslationEntry] | None:

--- a/tests/unit/core/test_localizer.py
+++ b/tests/unit/core/test_localizer.py
@@ -186,7 +186,7 @@ class TestNormalizeLocale:
         assert service._normalize_locale("en") == "en"
 
     def test_str_unknown(self, service: LocalizerService):
-        assert service._normalize_locale("fr") == "fr"
+        assert service._normalize_locale("fr") == "en"
 
 
 # ===================================================================
@@ -552,8 +552,9 @@ class TestTanjunTranslator:
             loop = asyncio.new_event_loop()
             r = loop.run_until_complete(t.translate(s, unsupported_locale, MagicMock()))
             loop.close()
-            # '_normalize_locale("fr")' returns "fr", which has no locale file,
-            # so _load_sync falls back to English -> "Operation successful."
+            # '_normalize_locale("fr")' now returns "en" because unknown locales
+            # are silently mapped to English to avoid creating spam "missing
+            # localization" GitHub issues.  The English file is loaded directly.
             assert r == "Operation successful."
         finally:
             restore()


### PR DESCRIPTION
## Summary

Fixes #1760 (Missing localization for de) — root cause and preventative fix.

## Problem

The `_normalize_locale` method in `localizer.py` was returning raw locale strings for unsupported Discord locales (e.g. `'fr'`, `'ja'`, `'zh-TW'`, `'es-419'`, `'hu'`, `'it'`, etc.). When the localizer then tried to load `locales/{locale}.json`, it would fail with `FileNotFoundError`, trigger the English fallback, **but still call `_report_missing()`** which auto-creates "Missing localization" GitHub issues — even though the bot simply doesn't have a locale file for that language.

Additionally, the de.json locale file previously had keys missing that existed in en.json, which was the original trigger for #1760. These have since been synced (both files now have 4203 entries), but the unsupported-locale gap remained.

## Changes

### `localizer.py`
- `_normalize_locale` now returns `"en"` for any locale that isn't explicitly `en`, `de`, or `ko`, instead of returning the raw locale string.

### `tests/unit/core/test_localizer.py`
- Updated `test_str_unknown` to expect `"en"` instead of `"fr"`
- Updated comment in `test_translate_fallback_locale`

## Impact

- Prevents creation of spam "missing localization" issues for unsupported locales (currently \~17 open issues for es-419, ja, hu, it, hi, nl, el, fi, fr, hr, id, da, cs, zh-TW, zh-CN, bg, etc.)
- The de.json and en.json locale files are fully in sync (4203 identifiers each), so #1760 is resolved
- No functional change for supported locales (en, de, ko)

Closes #1760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown or unsupported Discord locales now gracefully fall back to English instead of returning unrecognized values, preventing repeated missing localization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->