### PR TITLE
fix(#1778): Fix mypy typing errors in source files

### DIFF
--- a/commands/utility/brawlstars/bshelper.py
+++ b/commands/utility/brawlstars/bshelper.py
@@ -6,7 +6,7 @@ they can be updated without changing Python source code.
 
 import json
 import os
-from typing import Final
+from typing import Final, cast
 
 _DATA_DIR: Final[str] = os.path.join(os.path.dirname(__file__), "..", "..", "..", "data")
 
@@ -15,7 +15,7 @@ def _load_emoji_map(filename: str) -> dict[str, str]:
     path = os.path.join(_DATA_DIR, filename)
     try:
         with open(path, encoding="utf-8") as f:
-            return json.load(f)
+            return cast(dict[str, str], json.load(f))
     except (FileNotFoundError, json.JSONDecodeError):
         return {}
 

--- a/services/math.py
+++ b/services/math.py
@@ -14,7 +14,7 @@ import functools
 import math
 import operator as op
 import re
-from typing import Any, cast
+from typing import Any
 
 from pydantic import BaseModel
 from pyparsing import (
@@ -211,13 +211,13 @@ class MathService:
         if op in "+-*/^":
             op2 = self._evaluate_stack(s)
             op1 = self._evaluate_stack(s)
-            return cast(float, self._opn[op](op1, op2))
+            return float(self._opn[op](op1, op2))
         if op == "PI":
             return math.pi
         if op == "E":
             return math.e
         if op in self._fn:
-            return cast(float, self._fn[op](self._evaluate_stack(s)))
+            return float(self._fn[op](self._evaluate_stack(s)))
         if op[0].isalpha():
             raise UndefinedVariable(f"Unknown identifier: {op}")
         # Handle variables that are numbers

--- a/services/math.py
+++ b/services/math.py
@@ -14,7 +14,7 @@ import functools
 import math
 import operator as op
 import re
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel
 from pyparsing import (
@@ -211,13 +211,13 @@ class MathService:
         if op in "+-*/^":
             op2 = self._evaluate_stack(s)
             op1 = self._evaluate_stack(s)
-            return self._opn[op](op1, op2)
+            return cast(float, self._opn[op](op1, op2))
         if op == "PI":
             return math.pi
         if op == "E":
             return math.e
         if op in self._fn:
-            return self._fn[op](self._evaluate_stack(s))
+            return cast(float, self._fn[op](self._evaluate_stack(s)))
         if op[0].isalpha():
             raise UndefinedVariable(f"Unknown identifier: {op}")
         # Handle variables that are numbers


### PR DESCRIPTION
Fixes mypy typing errors found in the development branch report (#1778).

Changes:
- `commands/utility/brawlstars/bshelper.py`: Use `cast()` for `json.load()` return to fix `no-any-return` error
- `services/math.py`: Use `cast()` for operator/function call returns to fix `no-any-return` errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal type handling to make emoji/name lookups more consistent.
  * Normalized numeric results for arithmetic and built-in functions to ensure more consistent calculation behavior and reduce subtle precision discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->