### PR TITLE
fix: reduce DB pool contention with read caches and contention tests

### DIFF
--- a/api.py
+++ b/api.py
@@ -317,6 +317,8 @@ async def _execute_with_retry(
 
 _blacklist_cache: TTLCache[str, dict[str, list[BlacklistEntryModel]]] = TTLCache(ttl=30)
 _guild_config_cache: TTLCache[str, dict[str, Any]] = TTLCache(ttl=300, maxsize=2000)
+_log_enable_cache: TTLCache[str, LogEnableModel] = TTLCache(ttl=60, maxsize=5000)
+_log_enable_fetch_locks: dict[str, asyncio.Lock] = {}
 # In-memory cache for XP cooldowns: (guild_id, user_id) -> last_xp_gain_timestamp
 # Eliminates DB queries entirely when user is on cooldown
 _last_xp_gain_cache: dict[tuple[str, str], float] = {}
@@ -2719,6 +2721,7 @@ async def set_log_channel(guild_id: str, channel_id: str) -> None:
     if not existing:
         query = "REPLACE INTO log_enables (guild_id) VALUES (%s)"
         params = (guild_id,)
+        _log_enable_cache.delete(str(guild_id))
     await execute_action(query, params)
 
 
@@ -2784,14 +2787,10 @@ async def set_log_enable(guild_id: str, **kwargs: Any) -> None:
     query = query.rstrip(", ") + end_query
 
     await execute_action(query, tuple(params))
+    _log_enable_cache.delete(str(guild_id))
 
 
-async def get_log_enable(guild_id: str | int) -> LogEnableModel:
-    query = "SELECT guild_id, automodRuleCreate, automodRuleUpdate, automodRuleDelete, automodAction, guild_channelDelete, guild_channelCreate, guild_channelUpdate, guildUpdate, inviteCreate, inviteDelete, memberJoin, memberLeave, memberUpdate, userUpdate, memberBan, memberUnban, presenceUpdate, messageEdit, messageDelete, reactionAdd, reactionRemove, guildRoleCreate, guildRoleDelete, guildRoleUpdate FROM log_enables WHERE guild_id = %s"
-    params = (str(guild_id),)
-    result = await execute_query(query, params)
-    if result and result[0]:
-        return LogEnableModel.from_row(result[0])
+def _default_log_enable(guild_id: str | int) -> LogEnableModel:
     return LogEnableModel(
         guild_id=str(guild_id),
         automod_rule_create=True,
@@ -2819,6 +2818,45 @@ async def get_log_enable(guild_id: str | int) -> LogEnableModel:
         guild_role_delete=True,
         guild_role_update=True,
     )
+
+
+_LOG_ENABLE_SELECT = (
+    "SELECT guild_id, automodRuleCreate, automodRuleUpdate, automodRuleDelete, automodAction, "
+    "guild_channelDelete, guild_channelCreate, guild_channelUpdate, guildUpdate, inviteCreate, "
+    "inviteDelete, memberJoin, memberLeave, memberUpdate, userUpdate, memberBan, memberUnban, "
+    "presenceUpdate, messageEdit, messageDelete, reactionAdd, reactionRemove, guildRoleCreate, "
+    "guildRoleDelete, guildRoleUpdate FROM log_enables WHERE guild_id = %s"
+)
+
+
+async def _fetch_log_enable_from_db(guild_id: str) -> LogEnableModel:
+    result = await execute_query(_LOG_ENABLE_SELECT, (guild_id,))
+    if result and result[0]:
+        return LogEnableModel.from_row(result[0])
+    return _default_log_enable(guild_id)
+
+
+def _log_enable_lock(guild_id: str) -> asyncio.Lock:
+    lock = _log_enable_fetch_locks.get(guild_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _log_enable_fetch_locks[guild_id] = lock
+    return lock
+
+
+async def get_log_enable(guild_id: str | int) -> LogEnableModel:
+    gid = str(guild_id)
+    cached = _log_enable_cache.get(gid)
+    if cached is not None:
+        return cached
+
+    async with _log_enable_lock(gid):
+        cached = _log_enable_cache.get(gid)
+        if cached is not None:
+            return cached
+        model = await _fetch_log_enable_from_db(gid)
+        _log_enable_cache.set(gid, model)
+        return model
 
 
 async def add_scheduled_message(

--- a/api.py
+++ b/api.py
@@ -48,19 +48,29 @@ from models import (
 # ── Log blacklist (delegated to LogBlacklistRepository) ─────────────────────────────
 from repositories.log_blacklist_repository import LogBlacklistType, log_blacklist_repo
 from utility import get_level_for_xp_async, get_xp_for_level_async
-from utils.cache import TTLCache
+from utils.cache import StampedeProtectedCache, TTLCache
+
+
+def _log_blacklist_cache_key(guild_id: str | int, blacklist_type: LogBlacklistType) -> tuple[str, str]:
+    return (str(guild_id), blacklist_type.name)
 
 
 async def add_log_blacklist(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
     await log_blacklist_repo.add(guild_id, entity_id, blacklist_type)
+    _log_blacklist_cache.invalidate(_log_blacklist_cache_key(guild_id, blacklist_type))
 
 
 async def remove_log_blacklist(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> None:
     await log_blacklist_repo.remove(guild_id, entity_id, blacklist_type)
+    _log_blacklist_cache.invalidate(_log_blacklist_cache_key(guild_id, blacklist_type))
 
 
 async def get_log_blacklist(guild_id: str, blacklist_type: LogBlacklistType) -> list[str]:
-    return await log_blacklist_repo.get_all(guild_id, blacklist_type)
+    key = _log_blacklist_cache_key(guild_id, blacklist_type)
+    return await _log_blacklist_cache.get_or_fetch(
+        key,
+        lambda: log_blacklist_repo.get_all(guild_id, blacklist_type),
+    )
 
 
 async def is_log_entity_blacklisted(guild_id: str, entity_id: str, blacklist_type: LogBlacklistType) -> str | None:
@@ -317,8 +327,16 @@ async def _execute_with_retry(
 
 _blacklist_cache: TTLCache[str, dict[str, list[BlacklistEntryModel]]] = TTLCache(ttl=30)
 _guild_config_cache: TTLCache[str, dict[str, Any]] = TTLCache(ttl=300, maxsize=2000)
-_log_enable_cache: TTLCache[str, LogEnableModel] = TTLCache(ttl=60, maxsize=5000)
-_log_enable_fetch_locks: dict[str, asyncio.Lock] = {}
+_log_enable_cache: StampedeProtectedCache[str, LogEnableModel] = StampedeProtectedCache(ttl=60, maxsize=5000)
+_log_blacklist_cache: StampedeProtectedCache[tuple[str, str], list[str]] = StampedeProtectedCache(ttl=30, maxsize=5000)
+_log_channel_cache: StampedeProtectedCache[str, str | None] = StampedeProtectedCache(ttl=60, maxsize=5000)
+
+
+def clear_db_read_caches() -> None:
+    """Reset hot-path read caches (for tests and maintenance)."""
+    _log_enable_cache.clear()
+    _log_blacklist_cache.clear()
+    _log_channel_cache.clear()
 # In-memory cache for XP cooldowns: (guild_id, user_id) -> last_xp_gain_timestamp
 # Eliminates DB queries entirely when user is on cooldown
 _last_xp_gain_cache: dict[tuple[str, str], float] = {}
@@ -2721,21 +2739,28 @@ async def set_log_channel(guild_id: str, channel_id: str) -> None:
     if not existing:
         query = "REPLACE INTO log_enables (guild_id) VALUES (%s)"
         params = (guild_id,)
-        _log_enable_cache.delete(str(guild_id))
+        _log_enable_cache.invalidate(str(guild_id))
     await execute_action(query, params)
+    _log_channel_cache.invalidate(str(guild_id))
 
 
 async def remove_log_channel(guild_id: str) -> None:
     query = "DELETE FROM log_channel WHERE guild_id = %s"
     params = (guild_id,)
     await execute_action(query, params)
+    _log_channel_cache.invalidate(str(guild_id))
 
 
-async def get_log_channel(guild_id: str) -> str | None:
+async def _fetch_log_channel_from_db(guild_id: str) -> str | None:
     query = "SELECT channel_id FROM log_channel WHERE guild_id = %s"
     params = (guild_id,)
     result = await execute_query(query, params)
     return result[0][0] if result else None
+
+
+async def get_log_channel(guild_id: str) -> str | None:
+    gid = str(guild_id)
+    return await _log_channel_cache.get_or_fetch(gid, lambda: _fetch_log_channel_from_db(gid))
 
 
 _LOG_ENABLE_COLUMNS = frozenset(
@@ -2787,7 +2812,7 @@ async def set_log_enable(guild_id: str, **kwargs: Any) -> None:
     query = query.rstrip(", ") + end_query
 
     await execute_action(query, tuple(params))
-    _log_enable_cache.delete(str(guild_id))
+    _log_enable_cache.invalidate(str(guild_id))
 
 
 def _default_log_enable(guild_id: str | int) -> LogEnableModel:
@@ -2836,27 +2861,9 @@ async def _fetch_log_enable_from_db(guild_id: str) -> LogEnableModel:
     return _default_log_enable(guild_id)
 
 
-def _log_enable_lock(guild_id: str) -> asyncio.Lock:
-    lock = _log_enable_fetch_locks.get(guild_id)
-    if lock is None:
-        lock = asyncio.Lock()
-        _log_enable_fetch_locks[guild_id] = lock
-    return lock
-
-
 async def get_log_enable(guild_id: str | int) -> LogEnableModel:
     gid = str(guild_id)
-    cached = _log_enable_cache.get(gid)
-    if cached is not None:
-        return cached
-
-    async with _log_enable_lock(gid):
-        cached = _log_enable_cache.get(gid)
-        if cached is not None:
-            return cached
-        model = await _fetch_log_enable_from_db(gid)
-        _log_enable_cache.set(gid, model)
-        return model
+    return await _log_enable_cache.get_or_fetch(gid, lambda: _fetch_log_enable_from_db(gid))
 
 
 async def add_scheduled_message(

--- a/services/booster_service.py
+++ b/services/booster_service.py
@@ -17,6 +17,13 @@ from enum import Enum
 
 from api import execute_action, execute_query, safe_execute_query
 from models import ClaimedBoosterChannelModel, ClaimedBoosterRoleModel
+from utils.cache import StampedeProtectedCache
+
+_claimed_all_cache: StampedeProtectedCache[str, list] = StampedeProtectedCache(ttl=30, maxsize=8)
+
+
+def clear_booster_read_cache() -> None:
+    _claimed_all_cache.clear()
 
 
 class BoosterType(Enum):
@@ -90,6 +97,7 @@ class BoosterService:
         id_column = "channel_id" if claimed_type == ClaimedBoosterType.CHANNEL else "role_id"
         query = f"INSERT INTO {claimed_type.value} (user_id, {id_column}, guild_id) VALUES (%s, %s, %s)"
         await execute_action(query, (user_id, entity_id, guild_id))
+        _claimed_all_cache.invalidate(claimed_type.name)
 
     async def unclaim(
         self,
@@ -100,6 +108,7 @@ class BoosterService:
         """Remove a claimed booster channel or role for a user."""
         query = f"DELETE FROM {claimed_type.value} WHERE user_id = %s AND guild_id = %s"
         await execute_action(query, (user_id, guild_id))
+        _claimed_all_cache.invalidate(claimed_type.name)
 
     async def get_claim_for_user(
         self,
@@ -144,19 +153,24 @@ class BoosterService:
             result = await safe_execute_query(query, (user_id,))
             return [ClaimedBoosterRoleModel.from_row(row) for row in result]
 
+    async def _fetch_all_claims_from_db(self, claimed_type: ClaimedBoosterType) -> list:
+        if claimed_type == ClaimedBoosterType.CHANNEL:
+            query = "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel"
+            result = await safe_execute_query(query)
+            return [ClaimedBoosterChannelModel.from_row(row) for row in result]
+        query = "SELECT user_id, role_id, guild_id FROM claimedBoosterRole"
+        result = await safe_execute_query(query)
+        return [ClaimedBoosterRoleModel.from_row(row) for row in result]
+
     async def get_all_claims(
         self,
         claimed_type: ClaimedBoosterType,
     ) -> list:
         """Get all claimed booster entities as model instances."""
-        if claimed_type == ClaimedBoosterType.CHANNEL:
-            query = "SELECT user_id, channel_id, guild_id FROM claimedBoosterChannel"
-            result = await safe_execute_query(query)
-            return [ClaimedBoosterChannelModel.from_row(row) for row in result]
-        else:
-            query = "SELECT user_id, role_id, guild_id FROM claimedBoosterRole"
-            result = await safe_execute_query(query)
-            return [ClaimedBoosterRoleModel.from_row(row) for row in result]
+        return await _claimed_all_cache.get_or_fetch(
+            claimed_type.name,
+            lambda: self._fetch_all_claims_from_db(claimed_type),
+        )
 
 
 # ------------------------------------------------------------------ #

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -138,10 +138,12 @@ def pool_conn_cursor() -> tuple[Any, Any, Any]:
 def reset_globals() -> Iterator[None]:
     """Reset global state in api.py between tests."""
     set_bot(None)
-    from api import _blacklist_cache, _guild_config_cache
+    from api import _blacklist_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
 
     _guild_config_cache.clear()
     _blacklist_cache.clear()
+    _log_enable_cache.clear()
+    _log_enable_fetch_locks.clear()
     yield
 
 

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -138,12 +138,13 @@ def pool_conn_cursor() -> tuple[Any, Any, Any]:
 def reset_globals() -> Iterator[None]:
     """Reset global state in api.py between tests."""
     set_bot(None)
-    from api import _blacklist_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
+    from api import _blacklist_cache, _guild_config_cache, clear_db_read_caches
+    from services.booster_service import clear_booster_read_cache
 
     _guild_config_cache.clear()
     _blacklist_cache.clear()
-    _log_enable_cache.clear()
-    _log_enable_fetch_locks.clear()
+    clear_db_read_caches()
+    clear_booster_read_cache()
     yield
 
 

--- a/tests/integration/api/test_api_coverage.py
+++ b/tests/integration/api/test_api_coverage.py
@@ -79,11 +79,13 @@ pytestmark = pytest.mark.asyncio
 def reset_api() -> Iterator[None]:
     set_bot(None)
     db_manager._pool = None
-    from api import _blacklist_cache, _counting_cache, _guild_config_cache
+    from api import _blacklist_cache, _counting_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
 
     _blacklist_cache.clear()
     _guild_config_cache.clear()
     _counting_cache.clear()
+    _log_enable_cache.clear()
+    _log_enable_fetch_locks.clear()
     yield
     set_bot(None)
     db_manager._pool = None

--- a/tests/integration/api/test_api_coverage.py
+++ b/tests/integration/api/test_api_coverage.py
@@ -79,13 +79,12 @@ pytestmark = pytest.mark.asyncio
 def reset_api() -> Iterator[None]:
     set_bot(None)
     db_manager._pool = None
-    from api import _blacklist_cache, _counting_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
+    from api import _blacklist_cache, _counting_cache, _guild_config_cache, clear_db_read_caches
 
     _blacklist_cache.clear()
     _guild_config_cache.clear()
     _counting_cache.clear()
-    _log_enable_cache.clear()
-    _log_enable_fetch_locks.clear()
+    clear_db_read_caches()
     yield
     set_bot(None)
     db_manager._pool = None

--- a/tests/integration/api/test_api_extended.py
+++ b/tests/integration/api/test_api_extended.py
@@ -86,13 +86,14 @@ ROLE_VARIANTS = [ROLE_ID, "88888888888888888", "99999999999999999"]
 @pytest.fixture(autouse=True)
 def reset_globals() -> Iterator[None]:
     set_bot(None)
-    from api import _blacklist_cache, _counting_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
+    from api import _blacklist_cache, _counting_cache, _guild_config_cache, clear_db_read_caches
+    from services.booster_service import clear_booster_read_cache
 
     _guild_config_cache.clear()
     _blacklist_cache.clear()
     _counting_cache.clear()
-    _log_enable_cache.clear()
-    _log_enable_fetch_locks.clear()
+    clear_db_read_caches()
+    clear_booster_read_cache()
     yield
 
 
@@ -815,18 +816,27 @@ class TestLogChannelApi:
         execute.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_set_log_enable_invalidates_cache(self, bot_with_pool):
-        from api import get_log_enable, set_log_enable
+    async def test_get_log_channel_uses_cache(self, bot_with_pool):
+        from api import get_log_channel
 
-        execute = AsyncMock(return_value=[_LOG_ENABLE_ROW])
-        with (
-            patch("api.execute_query", new=execute),
-            patch("api.execute_action", new=AsyncMock()),
-        ):
-            await get_log_enable(GUILD_ID)
-            await set_log_enable(GUILD_ID, memberJoin=False)
-            await get_log_enable(GUILD_ID)
-        assert execute.await_count == 2
+        execute = AsyncMock(return_value=[(CHANNEL_ID,)])
+        with patch("api.execute_query", new=execute):
+            assert await get_log_channel(GUILD_ID) == CHANNEL_ID
+            assert await get_log_channel(GUILD_ID) == CHANNEL_ID
+        channel_queries = [c for c in execute.await_args_list if "log_channel" in c.args[0]]
+        assert len(channel_queries) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_log_blacklist_uses_cache(self, bot_with_pool):
+        from api import get_log_blacklist
+
+        with patch(
+            "api.log_blacklist_repo.get_all",
+            new=AsyncMock(return_value=["role1"]),
+        ) as get_all:
+            assert await get_log_blacklist(GUILD_ID, LogBlacklistType.ROLE) == ["role1"]
+            assert await get_log_blacklist(GUILD_ID, LogBlacklistType.ROLE) == ["role1"]
+        assert get_all.await_count == 1
 
     @pytest.mark.parametrize("field", ["memberJoin", "messageEdit", "reactionAdd"])
     @pytest.mark.asyncio

--- a/tests/integration/api/test_api_extended.py
+++ b/tests/integration/api/test_api_extended.py
@@ -86,11 +86,13 @@ ROLE_VARIANTS = [ROLE_ID, "88888888888888888", "99999999999999999"]
 @pytest.fixture(autouse=True)
 def reset_globals() -> Iterator[None]:
     set_bot(None)
-    from api import _blacklist_cache, _counting_cache, _guild_config_cache
+    from api import _blacklist_cache, _counting_cache, _guild_config_cache, _log_enable_cache, _log_enable_fetch_locks
 
     _guild_config_cache.clear()
     _blacklist_cache.clear()
     _counting_cache.clear()
+    _log_enable_cache.clear()
+    _log_enable_fetch_locks.clear()
     yield
 
 
@@ -799,6 +801,32 @@ class TestLogChannelApi:
         with patch("api.execute_query", new=AsyncMock(return_value=[_LOG_ENABLE_ROW] if has_row else None)):
             result = await get_log_enable(GUILD_ID)
         assert result.guild_id == GUILD_ID
+
+    @pytest.mark.asyncio
+    async def test_get_log_enable_uses_cache(self, bot_with_pool):
+        from api import get_log_enable
+
+        execute = AsyncMock(return_value=[_LOG_ENABLE_ROW])
+        with patch("api.execute_query", new=execute):
+            first = await get_log_enable(GUILD_ID)
+            second = await get_log_enable(GUILD_ID)
+        assert first.member_join is True
+        assert second.member_join is True
+        execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_set_log_enable_invalidates_cache(self, bot_with_pool):
+        from api import get_log_enable, set_log_enable
+
+        execute = AsyncMock(return_value=[_LOG_ENABLE_ROW])
+        with (
+            patch("api.execute_query", new=execute),
+            patch("api.execute_action", new=AsyncMock()),
+        ):
+            await get_log_enable(GUILD_ID)
+            await set_log_enable(GUILD_ID, memberJoin=False)
+            await get_log_enable(GUILD_ID)
+        assert execute.await_count == 2
 
     @pytest.mark.parametrize("field", ["memberJoin", "messageEdit", "reactionAdd"])
     @pytest.mark.asyncio

--- a/tests/integration/api/test_db_read_cache.py
+++ b/tests/integration/api/test_db_read_cache.py
@@ -1,0 +1,197 @@
+"""Tests for hot-path DB read caches (log enable, blacklist, channel, booster claims)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from api import (  # noqa: E402
+    _LOG_ENABLE_SELECT,
+    clear_db_read_caches,
+    get_log_blacklist,
+    get_log_channel,
+    get_log_enable,
+    set_log_enable,
+)
+from repositories.log_blacklist_repository import LogBlacklistType  # noqa: E402
+from services.booster_service import BoosterService, ClaimedBoosterType, clear_booster_read_cache  # noqa: E402
+from tests.helpers.factories import CHANNEL_ID, GUILD_ID, ROLE_ID, USER_ID  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+_LOG_ENABLE_ROW = (
+    GUILD_ID,
+    1,
+    1,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    1,
+    0,
+    0,
+    1,
+    1,
+    1,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    clear_db_read_caches()
+    clear_booster_read_cache()
+    yield
+    clear_db_read_caches()
+    clear_booster_read_cache()
+
+
+def _log_enable_calls(execute: AsyncMock) -> int:
+    return sum(
+        1
+        for call in execute.await_args_list
+        if call.args and _LOG_ENABLE_SELECT in call.args[0]
+    )
+
+
+class TestLogEnableCacheContention:
+    async def test_concurrent_get_log_enable_single_db_query(self) -> None:
+        execute = AsyncMock(return_value=[_LOG_ENABLE_ROW])
+        with patch("api.execute_query", new=execute):
+            results = await asyncio.gather(*[get_log_enable(GUILD_ID) for _ in range(100)])
+        assert len(results) == 100
+        assert all(r.guild_id == GUILD_ID for r in results)
+        assert _log_enable_calls(execute) == 1
+
+    async def test_concurrent_get_log_enable_different_guilds(self) -> None:
+        guilds = [str(900000000000000000 + i) for i in range(10)]
+        execute = AsyncMock(
+            side_effect=lambda q, p=None, bot=None: [
+                (
+                    p[0],
+                    1,
+                    1,
+                    1,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    1,
+                    1,
+                    1,
+                )
+            ]
+        )
+        with patch("api.execute_query", new=execute):
+            await asyncio.gather(*[get_log_enable(g) for g in guilds])
+        assert _log_enable_calls(execute) == len(guilds)
+
+
+class TestLogBlacklistCache:
+    async def test_get_log_blacklist_cached_per_type(self) -> None:
+        with patch(
+            "api.log_blacklist_repo.get_all",
+            new=AsyncMock(return_value=["111"]),
+        ) as get_all:
+            first = await get_log_blacklist(GUILD_ID, LogBlacklistType.ROLE)
+            second = await get_log_blacklist(GUILD_ID, LogBlacklistType.ROLE)
+            other = await get_log_blacklist(GUILD_ID, LogBlacklistType.USER)
+        assert first == ["111"]
+        assert second == ["111"]
+        assert get_all.await_count == 2
+
+    async def test_add_log_blacklist_invalidates_cache(self) -> None:
+        from api import add_log_blacklist
+
+        with (
+            patch("api.log_blacklist_repo.add", new=AsyncMock()),
+            patch(
+                "api.log_blacklist_repo.get_all",
+                new=AsyncMock(return_value=[]),
+            ) as get_all,
+        ):
+            await get_log_blacklist(GUILD_ID, LogBlacklistType.CHANNEL)
+            await add_log_blacklist(GUILD_ID, "999", LogBlacklistType.CHANNEL)
+            await get_log_blacklist(GUILD_ID, LogBlacklistType.CHANNEL)
+        assert get_all.await_count == 2
+
+
+class TestLogChannelCache:
+    async def test_get_log_channel_concurrent_single_query(self) -> None:
+        execute = AsyncMock(return_value=[(CHANNEL_ID,)])
+        with patch("api.execute_query", new=execute):
+            results = await asyncio.gather(*[get_log_channel(GUILD_ID) for _ in range(50)])
+        assert all(r == CHANNEL_ID for r in results)
+        channel_queries = [c for c in execute.await_args_list if "log_channel" in c.args[0]]
+        assert len(channel_queries) == 1
+
+
+class TestBoosterClaimsCache:
+    async def test_get_all_claims_concurrent_single_query(self) -> None:
+        service = BoosterService()
+        row = (USER_ID, ROLE_ID, GUILD_ID)
+        safe = AsyncMock(return_value=[row])
+        with patch("services.booster_service.safe_execute_query", new=safe):
+            results = await asyncio.gather(
+                *[service.get_all_claims(ClaimedBoosterType.ROLE) for _ in range(40)]
+            )
+        assert len(results) == 40
+        assert safe.await_count == 1
+
+    async def test_claim_invalidates_get_all_claims_cache(self) -> None:
+        service = BoosterService()
+        with (
+            patch("services.booster_service.execute_action", new=AsyncMock()),
+            patch(
+                "services.booster_service.safe_execute_query",
+                new=AsyncMock(return_value=[]),
+            ) as safe,
+        ):
+            await service.get_all_claims(ClaimedBoosterType.CHANNEL)
+            await service.claim(ClaimedBoosterType.CHANNEL, "u", "c", GUILD_ID)
+            await service.get_all_claims(ClaimedBoosterType.CHANNEL)
+        assert safe.await_count == 2
+
+
+class TestSetLogEnableInvalidatesCache:
+    async def test_set_log_enable_refetches_after_update(self) -> None:
+        execute = AsyncMock(return_value=[_LOG_ENABLE_ROW])
+        with (
+            patch("api.execute_query", new=execute),
+            patch("api.execute_action", new=AsyncMock()),
+        ):
+            await get_log_enable(GUILD_ID)
+            await set_log_enable(GUILD_ID, memberJoin=False)
+            await get_log_enable(GUILD_ID)
+        assert _log_enable_calls(execute) == 2

--- a/tests/integration/extensions/test_logs_db_cache.py
+++ b/tests/integration/extensions/test_logs_db_cache.py
@@ -1,0 +1,100 @@
+"""Verify log event handlers share cached get_log_enable DB access."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api import _LOG_ENABLE_SELECT, clear_db_read_caches
+from tests.helpers.discord import make_guild, make_member
+from tests.helpers.factories import GUILD_ID
+from tests.helpers.extensions import async_audit_logs
+from tests.integration.extensions.conftest import load_extension_bot
+
+pytestmark = pytest.mark.asyncio
+
+EXTENSION = "extensions.logs"
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_caches() -> None:
+    clear_db_read_caches()
+    yield
+    clear_db_read_caches()
+
+
+def _count_log_enable_queries(execute: AsyncMock) -> int:
+    return sum(
+        1
+        for call in execute.await_args_list
+        if call.args and _LOG_ENABLE_SELECT in call.args[0]
+    )
+
+
+async def test_concurrent_member_updates_one_log_enable_query() -> None:
+    bot = await load_extension_bot(EXTENSION, fire_ready=False)
+    cog = bot.cogs["LogsCog"]
+    guild = make_guild(guild_id=int(GUILD_ID))
+    guild.audit_logs = MagicMock(return_value=async_audit_logs())
+
+    before = make_member()
+    before.guild = guild
+    before.display_name = "a"
+    before.display_avatar = MagicMock()
+    before.display_avatar.read = AsyncMock(return_value=b"")
+    before.roles = []
+
+    after = make_member()
+    after.guild = guild
+    after.display_name = "b"
+    after.display_avatar = MagicMock()
+    after.display_avatar.read = AsyncMock(return_value=b"")
+    after.roles = []
+
+    log_enable_row = (
+        GUILD_ID,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+    )
+
+    execute = AsyncMock(
+        side_effect=lambda q, p=None, bot=None: (
+            [log_enable_row]
+            if _LOG_ENABLE_SELECT in q
+            else ([] if "logRoleBlacklist" in q or "logUserBlacklist" in q else None)
+        )
+    )
+
+    with (
+        patch("api.execute_query", new=execute),
+        patch("extensions.logs.is_log_entity_blacklisted", new=AsyncMock(return_value=None)),
+        patch("extensions.logs.get_log_blacklist", new=AsyncMock(return_value=[])),
+        patch("extensions.logs.log_event_producer", new=AsyncMock()),
+    ):
+        await asyncio.gather(*[cog.on_member_update(before, after) for _ in range(30)])
+
+    assert _count_log_enable_queries(execute) == 1

--- a/tests/unit/utils/test_stampede_cache.py
+++ b/tests/unit/utils/test_stampede_cache.py
@@ -1,0 +1,82 @@
+"""Tests for StampedeProtectedCache — prevents duplicate concurrent fetches."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable
+
+import pytest
+
+from utils.cache import StampedeProtectedCache
+
+
+@pytest.mark.asyncio
+async def test_get_or_fetch_single_call_on_concurrent_miss() -> None:
+    cache: StampedeProtectedCache[str, int] = StampedeProtectedCache(ttl=60)
+    calls = 0
+    started = asyncio.Event()
+
+    async def slow_fetch() -> int:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await asyncio.sleep(0.05)
+        return 42
+
+    results = await asyncio.gather(*[cache.get_or_fetch("k", slow_fetch) for _ in range(50)])
+    assert all(r == 42 for r in results)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_or_fetch_cache_hit_skips_fetch() -> None:
+    cache: StampedeProtectedCache[str, int] = StampedeProtectedCache(ttl=60)
+    calls = 0
+
+    async def fetch() -> int:
+        nonlocal calls
+        calls += 1
+        return 1
+
+    assert await cache.get_or_fetch("a", fetch) == 1
+    assert await cache.get_or_fetch("a", fetch) == 1
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidate_forces_refetch() -> None:
+    cache: StampedeProtectedCache[str, int] = StampedeProtectedCache(ttl=60)
+    calls = 0
+
+    async def fetch() -> int:
+        nonlocal calls
+        calls += 1
+        return calls
+
+    assert await cache.get_or_fetch("x", fetch) == 1
+    cache.invalidate("x")
+    assert await cache.get_or_fetch("x", fetch) == 2
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_plain_ttl_cache_get_or_compute_allows_duplicate_async_fetches() -> None:
+    """Plain TTLCache has no per-key lock; concurrent misses may fetch multiple times."""
+    from utils.cache import TTLCache
+
+    cache: TTLCache[str, int] = TTLCache(ttl=60)
+    calls = 0
+
+    async def factory() -> int:
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.03)
+        return 7
+
+    async def run() -> int:
+        result = cache.get_or_compute("k", factory)
+        assert isinstance(result, Awaitable)
+        return await result
+
+    await asyncio.gather(*[run() for _ in range(10)])
+    assert calls > 1

--- a/utils/cache.py
+++ b/utils/cache.py
@@ -20,6 +20,7 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
@@ -210,3 +211,44 @@ class TTLCache(Generic[K, V]):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(ttl={self._ttl}, maxsize={self._maxsize}, size={self.size})"
+
+
+class StampedeProtectedCache(Generic[K, V]):
+    """TTL cache with per-key ``asyncio.Lock`` to prevent concurrent cache-miss stampedes."""
+
+    __slots__ = ("_cache", "_locks")
+
+    def __init__(self, ttl: float, maxsize: int | None = None) -> None:
+        self._cache = TTLCache[K, V](ttl=ttl, maxsize=maxsize)
+        self._locks: dict[K, asyncio.Lock] = {}
+
+    @property
+    def ttl(self) -> float:
+        return self._cache.ttl
+
+    def get(self, key: K) -> V | None:
+        return self._cache.get(key)
+
+    def set(self, key: K, value: V, *, ttl: float | None = None) -> None:
+        self._cache.set(key, value, ttl=ttl)
+
+    def invalidate(self, key: K) -> None:
+        self._cache.invalidate(key)
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._locks.clear()
+
+    async def get_or_fetch(self, key: K, fetch: Callable[[], Awaitable[V]]) -> V:
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            cached = self._cache.get(key)
+            if cached is not None:
+                return cached
+            value = await fetch()
+            self._cache.set(key, value)
+            return value


### PR DESCRIPTION
## Summary

- Add `StampedeProtectedCache` (TTL + per-key lock) to prevent cache-miss stampedes under concurrent Discord events.
- Cache hot read paths: `get_log_enable`, `get_log_blacklist`, `get_log_channel`, and `booster_service.get_all_claims`, with invalidation on writes.
- Add concurrency/integration tests that fail without caching (e.g. 100 concurrent `get_log_enable` → 1 DB query; 30 log handlers → 1 `log_enables` query).

## Context

Production logs showed `Timeout on execute_query` for `get_log_enable` and booster cleanup during event bursts, exhausting the 20-connection pool. Tests previously mocked `get_log_enable` in log tests and used instant mock pools, so this was not caught in CI.

## Test plan

- [x] `pytest tests/unit/utils/test_stampede_cache.py tests/integration/api/test_db_read_cache.py tests/integration/extensions/test_logs_db_cache.py -q`
- [x] `pytest tests/integration/api/ tests/unit/utils/ -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stampede-protected, TTL-backed read caches for log configs and booster claims; helpers to clear those caches.

* **Refactor**
  * Refactored log and booster read paths to use cache-first, concurrency-coalesced reads and invalidate caches on mutations.

* **Tests**
  * Added extensive integration/unit tests verifying cache concurrency, correctness, and invalidation; updated fixtures to reset new caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->