### PR TITLE
test: XP, boosters, and time-based logic

### DIFF
--- a/tests/integration/api/test_xp_cooldown_cache.py
+++ b/tests/integration/api/test_xp_cooldown_cache.py
@@ -69,3 +69,32 @@ class TestXpCooldownCache:
             await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=False)
             await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=False)
         assert action.await_count == 2
+
+
+class TestVoiceXpCooldownCache:
+    async def test_voice_cooldown_skips_second_write(self) -> None:
+        from api import update_user_xp_from_voice
+
+        _guild_config_cache.set(GUILD_ID, {"voice_cooldown": 60})
+        base_time = 3_000_000.0
+        with (
+            patch("api.time.time", return_value=base_time),
+            patch("api.execute_action", new_callable=AsyncMock) as action,
+        ):
+            await update_user_xp_from_voice(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp_from_voice(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+        assert action.await_count == 1
+
+    async def test_voice_cooldown_allows_write_after_expiry(self) -> None:
+        from api import update_user_xp_from_voice
+
+        _guild_config_cache.set(GUILD_ID, {"voice_cooldown": 60})
+        base_time = 4_000_000.0
+        with (
+            patch("api.time.time", side_effect=[base_time, base_time + 30, base_time + 61]),
+            patch("api.execute_action", new_callable=AsyncMock) as action,
+        ):
+            await update_user_xp_from_voice(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp_from_voice(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp_from_voice(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+        assert action.await_count == 2

--- a/tests/integration/api/test_xp_cooldown_cache.py
+++ b/tests/integration/api/test_xp_cooldown_cache.py
@@ -1,0 +1,71 @@
+"""Integration tests for XP cooldown cache in update_user_xp."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from api import (  # noqa: E402
+    _guild_config_cache,
+    _last_xp_gain_cache,
+    clear_db_read_caches,
+    update_user_xp,
+)
+from tests.helpers.factories import GUILD_ID, USER_ID  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> None:
+    clear_db_read_caches()
+    _guild_config_cache.clear()
+    _last_xp_gain_cache.clear()
+    yield
+    clear_db_read_caches()
+    _guild_config_cache.clear()
+    _last_xp_gain_cache.clear()
+
+
+class TestXpCooldownCache:
+    async def test_two_grants_within_cooldown_single_db_write(self) -> None:
+        _guild_config_cache.set(GUILD_ID, {"text_cooldown": 60})
+        with patch("api.execute_action", new_callable=AsyncMock) as action:
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+        assert action.await_count == 1
+
+    async def test_second_grant_allowed_after_cooldown_expires(self) -> None:
+        _guild_config_cache.set(GUILD_ID, {"text_cooldown": 60})
+        base_time = 1_000_000.0
+        with (
+            patch("api.time.time", side_effect=[base_time, base_time + 30, base_time + 61]),
+            patch("api.execute_action", new_callable=AsyncMock) as action,
+        ):
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+        assert action.await_count == 2
+
+    async def test_first_grant_updates_last_xp_gain_cache(self) -> None:
+        _guild_config_cache.set(GUILD_ID, {"text_cooldown": 60})
+        base_time = 2_000_000.0
+        with (
+            patch("api.time.time", return_value=base_time),
+            patch("api.execute_action", new_callable=AsyncMock),
+        ):
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=True)
+        assert _last_xp_gain_cache[(GUILD_ID, USER_ID)] == base_time
+
+    async def test_respect_cooldown_false_always_writes(self) -> None:
+        _guild_config_cache.set(GUILD_ID, {"text_cooldown": 60})
+        _last_xp_gain_cache[(GUILD_ID, USER_ID)] = 1_000_000.0
+        with patch("api.execute_action", new_callable=AsyncMock) as action:
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=False)
+            await update_user_xp(GUILD_ID, USER_ID, 5, respect_cooldown=False)
+        assert action.await_count == 2

--- a/tests/unit/loops/test_giveaway_loop.py
+++ b/tests/unit/loops/test_giveaway_loop.py
@@ -1,0 +1,131 @@
+"""Tests for loops/giveaway.py with time-based state transitions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from freezegun import freeze_time
+
+from loops import giveaway
+from loops._voice_tracker import voice_user_manager
+
+pytestmark = pytest.mark.asyncio
+
+FROZEN_START = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+
+class TestSendReadyGiveaways:
+    @freeze_time(FROZEN_START)
+    async def test_no_ready_giveaways_skips_send(self) -> None:
+        client = MagicMock()
+        with (
+            patch("loops.giveaway.giveaway_service.get_send_ready", new_callable=AsyncMock, return_value=[]),
+            patch("loops.giveaway.sendGiveaway", new_callable=AsyncMock) as mock_send,
+        ):
+            await giveaway.sendReadyGiveaways(client)
+        mock_send.assert_not_awaited()
+
+    @freeze_time(FROZEN_START)
+    async def test_ready_giveaways_trigger_send(self) -> None:
+        client = MagicMock()
+        with (
+            patch(
+                "loops.giveaway.giveaway_service.get_send_ready",
+                new_callable=AsyncMock,
+                return_value=[10, 20],
+            ),
+            patch("loops.giveaway.sendGiveaway", new_callable=AsyncMock) as mock_send,
+        ):
+            await giveaway.sendReadyGiveaways(client)
+        assert mock_send.await_count == 2
+        mock_send.assert_any_await(giveawayid=10, client=client)
+        mock_send.assert_any_await(giveawayid=20, client=client)
+
+    async def test_state_transition_empty_to_ready_over_time(self) -> None:
+        client = MagicMock()
+        call_times: list[datetime] = []
+
+        async def get_ready() -> list[int]:
+            call_times.append(datetime.now(UTC))
+            return [] if len(call_times) == 1 else [42]
+
+        with freeze_time(FROZEN_START) as frozen:
+            with (
+                patch("loops.giveaway.giveaway_service.get_send_ready", side_effect=get_ready),
+                patch("loops.giveaway.sendGiveaway", new_callable=AsyncMock) as mock_send,
+            ):
+                await giveaway.sendReadyGiveaways(client)
+                frozen.tick(delta=timedelta(hours=1))
+                await giveaway.sendReadyGiveaways(client)
+
+        mock_send.assert_awaited_once_with(giveawayid=42, client=client)
+        assert len(call_times) == 2
+        assert call_times[1] - call_times[0] == timedelta(hours=1)
+
+
+class TestCheckVoiceUsers:
+    @freeze_time(FROZEN_START)
+    async def test_no_active_users_skips_add_voice_minutes(self) -> None:
+        voice_user_manager.clear()
+        with patch("loops.giveaway.giveaway_service.add_voice_minutes", new_callable=AsyncMock) as mock_add:
+            await giveaway.checkVoiceUsers(MagicMock())
+        mock_add.assert_not_awaited()
+
+    @freeze_time(FROZEN_START)
+    async def test_active_users_receive_voice_minutes(self) -> None:
+        voice_user_manager.clear()
+        voice_user_manager.add(100, 200)
+        voice_user_manager.add(101, 201)
+        with patch("loops.giveaway.giveaway_service.add_voice_minutes", new_callable=AsyncMock) as mock_add:
+            await giveaway.checkVoiceUsers(MagicMock())
+        assert mock_add.await_count == 2
+        mock_add.assert_any_await(100, 200)
+        mock_add.assert_any_await(101, 201)
+        voice_user_manager.clear()
+
+
+class TestEndGiveaways:
+    @freeze_time(FROZEN_START)
+    async def test_no_ending_giveaways_skips_end(self) -> None:
+        client = MagicMock()
+        with (
+            patch("loops.giveaway.giveaway_service.get_end_ready", new_callable=AsyncMock, return_value=[]),
+            patch("loops.giveaway.endGiveaway", new_callable=AsyncMock) as mock_end,
+        ):
+            await giveaway.endGiveaways(client)
+        mock_end.assert_not_awaited()
+
+    @freeze_time(FROZEN_START)
+    async def test_ending_giveaways_trigger_end(self) -> None:
+        client = MagicMock()
+        with (
+            patch(
+                "loops.giveaway.giveaway_service.get_end_ready",
+                new_callable=AsyncMock,
+                return_value=[5, 6, 7],
+            ),
+            patch("loops.giveaway.endGiveaway", new_callable=AsyncMock) as mock_end,
+        ):
+            await giveaway.endGiveaways(client)
+        assert mock_end.await_count == 3
+
+    async def test_end_transition_after_deadline_passes(self) -> None:
+        client = MagicMock()
+        phases: list[int] = []
+
+        async def get_end_ready() -> list[int]:
+            phases.append(len(phases))
+            return [] if len(phases) == 1 else [99]
+
+        with freeze_time(FROZEN_START) as frozen:
+            with (
+                patch("loops.giveaway.giveaway_service.get_end_ready", side_effect=get_end_ready),
+                patch("loops.giveaway.endGiveaway", new_callable=AsyncMock) as mock_end,
+            ):
+                await giveaway.endGiveaways(client)
+                frozen.tick(delta=timedelta(days=1))
+                await giveaway.endGiveaways(client)
+
+        mock_end.assert_awaited_once_with(giveaway_id=99, client=client)

--- a/tests/unit/services/test_booster_service.py
+++ b/tests/unit/services/test_booster_service.py
@@ -2,16 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from services.booster_service import BoosterService, BoosterType, ClaimedBoosterType
+from services.booster_service import (
+    BoosterService,
+    BoosterType,
+    ClaimedBoosterType,
+    clear_booster_read_cache,
+)
+from tests.helpers.concurrency import stress_concurrent
+from tests.helpers.factories import CHANNEL_ID, GUILD_ID, ROLE_ID, USER_ID
 
 
 @pytest.fixture
 def service() -> BoosterService:
     return BoosterService()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    clear_booster_read_cache()
+    yield
+    clear_booster_read_cache()
 
 
 class TestBoosterService:
@@ -81,3 +96,190 @@ class TestBoosterService:
         with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
             mock_q.return_value = []
             assert await service.has_claim(ClaimedBoosterType.CHANNEL, "111") is False
+
+    @pytest.mark.asyncio
+    async def test_get_claim_for_user_found(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = [(CHANNEL_ID,)]
+            result = await service.get_claim_for_user(ClaimedBoosterType.CHANNEL, USER_ID, GUILD_ID)
+            assert result == CHANNEL_ID
+
+    @pytest.mark.asyncio
+    async def test_get_claim_for_user_empty(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = []
+            result = await service.get_claim_for_user(ClaimedBoosterType.ROLE, USER_ID, GUILD_ID)
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_user_claims_channel(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = [(USER_ID, CHANNEL_ID, GUILD_ID)]
+            claims = await service.get_user_claims(ClaimedBoosterType.CHANNEL, USER_ID)
+            assert len(claims) == 1
+            assert str(claims[0].channel_id) == CHANNEL_ID
+
+    @pytest.mark.asyncio
+    async def test_get_user_claims_role_empty(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = []
+            claims = await service.get_user_claims(ClaimedBoosterType.ROLE, USER_ID)
+            assert claims == []
+
+    @pytest.mark.asyncio
+    async def test_get_all_claims_channel(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = [(USER_ID, CHANNEL_ID, GUILD_ID)]
+            claims = await service.get_all_claims(ClaimedBoosterType.CHANNEL)
+            assert len(claims) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_all_claims_role_empty(self, service: BoosterService):
+        with patch("services.booster_service.safe_execute_query", new_callable=AsyncMock) as mock_q:
+            mock_q.return_value = []
+            claims = await service.get_all_claims(ClaimedBoosterType.ROLE)
+            assert claims == []
+
+
+class TestBoosterServiceDbErrors:
+    @pytest.mark.asyncio
+    async def test_add_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.execute_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db down"),
+        ):
+            with pytest.raises(RuntimeError, match="db down"):
+                await service.add(BoosterType.CHANNEL, GUILD_ID, CHANNEL_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.execute_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("query failed"),
+        ):
+            with pytest.raises(RuntimeError, match="query failed"):
+                await service.get(BoosterType.ROLE, GUILD_ID)
+
+    @pytest.mark.asyncio
+    async def test_delete_channel_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.execute_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("delete failed"),
+        ):
+            with pytest.raises(RuntimeError, match="delete failed"):
+                await service.delete(BoosterType.CHANNEL, GUILD_ID, CHANNEL_ID)
+
+    @pytest.mark.asyncio
+    async def test_claim_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.execute_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("claim failed"),
+        ):
+            with pytest.raises(RuntimeError, match="claim failed"):
+                await service.claim(ClaimedBoosterType.CHANNEL, USER_ID, CHANNEL_ID, GUILD_ID)
+
+    @pytest.mark.asyncio
+    async def test_unclaim_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.execute_action",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unclaim failed"),
+        ):
+            with pytest.raises(RuntimeError, match="unclaim failed"):
+                await service.unclaim(ClaimedBoosterType.ROLE, USER_ID, GUILD_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_claim_for_user_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.safe_execute_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("safe query failed"),
+        ):
+            with pytest.raises(RuntimeError, match="safe query failed"):
+                await service.get_claim_for_user(ClaimedBoosterType.CHANNEL, USER_ID, GUILD_ID)
+
+    @pytest.mark.asyncio
+    async def test_has_claim_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.safe_execute_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("has claim failed"),
+        ):
+            with pytest.raises(RuntimeError, match="has claim failed"):
+                await service.has_claim(ClaimedBoosterType.ROLE, USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_user_claims_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.safe_execute_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("user claims failed"),
+        ):
+            with pytest.raises(RuntimeError, match="user claims failed"):
+                await service.get_user_claims(ClaimedBoosterType.CHANNEL, USER_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_all_claims_propagates_db_error(self, service: BoosterService):
+        with patch(
+            "services.booster_service.safe_execute_query",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("all claims failed"),
+        ):
+            with pytest.raises(RuntimeError, match="all claims failed"):
+                await service.get_all_claims(ClaimedBoosterType.ROLE)
+
+
+class TestBoosterServiceCache:
+    @pytest.mark.asyncio
+    async def test_get_all_claims_concurrent_single_query(self, service: BoosterService):
+        safe = AsyncMock(return_value=[(USER_ID, ROLE_ID, GUILD_ID)])
+        with patch("services.booster_service.safe_execute_query", new=safe):
+            results = await asyncio.gather(
+                *[service.get_all_claims(ClaimedBoosterType.ROLE) for _ in range(30)]
+            )
+        assert len(results) == 30
+        assert safe.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_claim_invalidates_get_all_claims_cache(self, service: BoosterService):
+        with (
+            patch("services.booster_service.execute_action", new_callable=AsyncMock),
+            patch(
+                "services.booster_service.safe_execute_query",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as safe,
+        ):
+            await service.get_all_claims(ClaimedBoosterType.CHANNEL)
+            await service.claim(ClaimedBoosterType.CHANNEL, USER_ID, CHANNEL_ID, GUILD_ID)
+            await service.get_all_claims(ClaimedBoosterType.CHANNEL)
+        assert safe.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_unclaim_invalidates_get_all_claims_cache(self, service: BoosterService):
+        with (
+            patch("services.booster_service.execute_action", new_callable=AsyncMock),
+            patch(
+                "services.booster_service.safe_execute_query",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as safe,
+        ):
+            await service.get_all_claims(ClaimedBoosterType.ROLE)
+            await service.unclaim(ClaimedBoosterType.ROLE, USER_ID, GUILD_ID)
+            await service.get_all_claims(ClaimedBoosterType.ROLE)
+        assert safe.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_concurrent_claims_all_execute(self, service: BoosterService):
+        action = AsyncMock()
+        with patch("services.booster_service.execute_action", new=action):
+            await stress_concurrent(
+                lambda: service.claim(ClaimedBoosterType.CHANNEL, USER_ID, CHANNEL_ID, GUILD_ID),
+                n=20,
+            )
+        assert action.await_count == 20

--- a/tests/unit/services/test_xp_calculator_hypothesis.py
+++ b/tests/unit/services/test_xp_calculator_hypothesis.py
@@ -95,7 +95,7 @@ class TestEffectiveBoostHypothesis:
         assert result == pytest.approx(expected)
 
     @given(role_boosts=boost_list, user_boost=optional_boost, channel_boost=optional_boost)
-    @settings(max_examples=80)
+    @settings(max_examples=120)
     @pytest.mark.asyncio
     async def test_result_at_least_one_with_non_negative_boosts(
         self,
@@ -118,7 +118,7 @@ class TestEffectiveBoostHypothesis:
             max_size=5,
         )
     )
-    @settings(max_examples=40)
+    @settings(max_examples=120)
     @pytest.mark.asyncio
     async def test_additive_role_boosts_stack(self, role_boosts: list[tuple[float, bool]]) -> None:
         role_models = [_make_boost(b, a) for b, a in role_boosts]
@@ -129,7 +129,7 @@ class TestEffectiveBoostHypothesis:
         assert result == pytest.approx(1.0 + additive_sum)
 
     @given(channel_boost=boost_pair)
-    @settings(max_examples=40)
+    @settings(max_examples=120)
     @pytest.mark.asyncio
     async def test_channel_boost_isolation(self, channel_boost: tuple[float, bool]) -> None:
         channel_model = _make_boost(*channel_boost)
@@ -162,7 +162,7 @@ class TestCalculateXpHypothesis:
         channel_boost=optional_boost,
         base=base_xp,
     )
-    @settings(max_examples=80)
+    @settings(max_examples=120)
     @pytest.mark.asyncio
     async def test_calculate_xp_returns_int_in_valid_range(
         self,
@@ -183,3 +183,80 @@ class TestCalculateXpHypothesis:
         assert isinstance(xp, int)
         assert xp == int(base * effective)
         assert xp >= int(base * 1.0)
+
+
+class TestBoostEdgeCasesHypothesis:
+    @given(channel_boost=boost_pair)
+    @settings(max_examples=120)
+    @pytest.mark.asyncio
+    async def test_empty_role_boosts_with_channel_only(self, channel_boost: tuple[float, bool]) -> None:
+        channel_model = _make_boost(*channel_boost)
+        repo = _make_repo([], None, channel_model)
+        calculator = XpCalculator(boost_repo=repo)
+        result = await calculator.get_effective_boost(GUID, USER_ID, [], CHANNEL_A)
+        assert result == pytest.approx(_expected_boost([], None, channel_boost))
+
+    @given(user_boost=boost_pair)
+    @settings(max_examples=120)
+    @pytest.mark.asyncio
+    async def test_multiplicative_user_only(self, user_boost: tuple[float, bool]) -> None:
+        user_model = _make_boost(*user_boost)
+        calculator = XpCalculator(boost_repo=_make_repo([], user_model, None))
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        assert result == pytest.approx(_expected_boost([], user_boost, None))
+
+    @given(user_boost=st.tuples(st.floats(min_value=1.0, max_value=5.0), st.just(True)))
+    @settings(max_examples=120)
+    @pytest.mark.asyncio
+    async def test_additive_user_only(self, user_boost: tuple[float, bool]) -> None:
+        user_model = _make_boost(*user_boost)
+        calculator = XpCalculator(boost_repo=_make_repo([], user_model, None))
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        assert result == pytest.approx(1.0 + (user_boost[0] - 1))
+
+    @given(
+        role_boosts=st.lists(
+            st.tuples(st.floats(min_value=1.0, max_value=3.0), st.just(False)),
+            min_size=1,
+            max_size=4,
+        )
+    )
+    @settings(max_examples=120)
+    @pytest.mark.asyncio
+    async def test_multiplicative_role_product(self, role_boosts: list[tuple[float, bool]]) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        calculator = XpCalculator(boost_repo=_make_repo(role_models, None, None))
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        expected = 1.0
+        for boost, _ in role_boosts:
+            expected *= boost
+        assert result == pytest.approx(expected)
+
+    @given(
+        role_boosts=boost_list,
+        channel_boost=boost_pair,
+    )
+    @settings(max_examples=120)
+    @pytest.mark.asyncio
+    async def test_channel_does_not_affect_other_channel(
+        self,
+        role_boosts: list[tuple[float, bool]],
+        channel_boost: tuple[float, bool],
+    ) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        channel_model = _make_boost(*channel_boost)
+
+        async def _get_boost(guild_id: str, entity_id: str, target=None) -> XpBoostModel | None:
+            if target == BoostTarget.CHANNEL and entity_id == CHANNEL_A:
+                return channel_model
+            return None
+
+        repo = MagicMock()
+        repo.get_boosts_for_target = AsyncMock(return_value=role_models)
+        repo.get_boost = AsyncMock(side_effect=_get_boost)
+        calculator = XpCalculator(boost_repo=repo)
+
+        with_channel = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        without_channel = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_B)
+        assert with_channel >= without_channel
+        assert without_channel == pytest.approx(_expected_boost(role_boosts, None, None))

--- a/tests/unit/services/test_xp_calculator_hypothesis.py
+++ b/tests/unit/services/test_xp_calculator_hypothesis.py
@@ -1,0 +1,185 @@
+"""Hypothesis property tests for services/xp_calculator.py."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from api import BoostTarget
+from models import XpBoostModel
+from services.xp_calculator import XpCalculator
+
+pytestmark = pytest.mark.unit
+
+
+def _make_boost(boost: float, additive: bool) -> XpBoostModel:
+    return XpBoostModel(boost=boost, additive=additive)
+
+
+def _expected_boost(
+    role_boosts: list[tuple[float, bool]],
+    user_boost: tuple[float, bool] | None,
+    channel_boost: tuple[float, bool] | None,
+) -> float:
+    total_additive = 0.0
+    total_multiplicative = 1.0
+    for boost, additive in role_boosts:
+        if additive:
+            total_additive += boost - 1
+        else:
+            total_multiplicative *= boost
+    if user_boost:
+        boost, additive = user_boost
+        if additive:
+            total_additive += boost - 1
+        else:
+            total_multiplicative *= boost
+    if channel_boost:
+        boost, additive = channel_boost
+        if additive:
+            total_additive += boost - 1
+        else:
+            total_multiplicative *= boost
+    return (1.0 + total_additive) * total_multiplicative
+
+
+def _make_repo(
+    role_boosts: list[XpBoostModel],
+    user_boost: XpBoostModel | None,
+    channel_boost: XpBoostModel | None,
+) -> MagicMock:
+    repo = MagicMock()
+    repo.get_boosts_for_target = AsyncMock(return_value=role_boosts)
+
+    async def _get_boost(guild_id: str, entity_id: str, target=None) -> XpBoostModel | None:
+        if target == BoostTarget.CHANNEL:
+            return channel_boost
+        return user_boost
+
+    repo.get_boost = AsyncMock(side_effect=_get_boost)
+    return repo
+
+
+boost_pair = st.tuples(st.floats(min_value=1.0, max_value=20.0, allow_nan=False), st.booleans())
+boost_list = st.lists(boost_pair, max_size=6)
+optional_boost = st.one_of(st.none(), boost_pair)
+base_xp = st.integers(min_value=1, max_value=3)
+
+GUID = "12345678901234567"
+USER_ID = "11111111111111111"
+ROLE_IDS = ["22222222222222222", "33333333333333333"]
+CHANNEL_A = "44444444444444444"
+CHANNEL_B = "55555555555555555"
+
+
+class TestEffectiveBoostHypothesis:
+    @given(role_boosts=boost_list, user_boost=optional_boost, channel_boost=optional_boost)
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_formula_matches_manual(
+        self,
+        role_boosts: list[tuple[float, bool]],
+        user_boost: tuple[float, bool] | None,
+        channel_boost: tuple[float, bool] | None,
+    ) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        user_model = _make_boost(*user_boost) if user_boost else None
+        channel_model = _make_boost(*channel_boost) if channel_boost else None
+        calculator = XpCalculator(boost_repo=_make_repo(role_models, user_model, channel_model))
+
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        expected = _expected_boost(role_boosts, user_boost, channel_boost)
+        assert result == pytest.approx(expected)
+
+    @given(role_boosts=boost_list, user_boost=optional_boost, channel_boost=optional_boost)
+    @settings(max_examples=80)
+    @pytest.mark.asyncio
+    async def test_result_at_least_one_with_non_negative_boosts(
+        self,
+        role_boosts: list[tuple[float, bool]],
+        user_boost: tuple[float, bool] | None,
+        channel_boost: tuple[float, bool] | None,
+    ) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        user_model = _make_boost(*user_boost) if user_boost else None
+        channel_model = _make_boost(*channel_boost) if channel_boost else None
+        calculator = XpCalculator(boost_repo=_make_repo(role_models, user_model, channel_model))
+
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        assert result >= 1.0
+
+    @given(
+        role_boosts=st.lists(
+            st.tuples(st.floats(min_value=1.0, max_value=5.0, allow_nan=False), st.just(True)),
+            min_size=1,
+            max_size=5,
+        )
+    )
+    @settings(max_examples=40)
+    @pytest.mark.asyncio
+    async def test_additive_role_boosts_stack(self, role_boosts: list[tuple[float, bool]]) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        calculator = XpCalculator(boost_repo=_make_repo(role_models, None, None))
+
+        result = await calculator.get_effective_boost(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+        additive_sum = sum(b - 1 for b, _ in role_boosts)
+        assert result == pytest.approx(1.0 + additive_sum)
+
+    @given(channel_boost=boost_pair)
+    @settings(max_examples=40)
+    @pytest.mark.asyncio
+    async def test_channel_boost_isolation(self, channel_boost: tuple[float, bool]) -> None:
+        channel_model = _make_boost(*channel_boost)
+        repo = MagicMock()
+        repo.get_boosts_for_target = AsyncMock(return_value=[])
+        repo.get_boost = AsyncMock(return_value=None)
+
+        calculator_a = XpCalculator(boost_repo=repo)
+
+        async def _get_boost_with_channel(guild_id: str, entity_id: str, target=None) -> XpBoostModel | None:
+            if target == BoostTarget.CHANNEL and entity_id == CHANNEL_A:
+                return channel_model
+            return None
+
+        repo.get_boost = AsyncMock(side_effect=_get_boost_with_channel)
+        boost_a = await calculator_a.get_effective_boost(GUID, USER_ID, [], CHANNEL_A)
+
+        repo.get_boost = AsyncMock(return_value=None)
+        calculator_b = XpCalculator(boost_repo=repo)
+        boost_b = await calculator_b.get_effective_boost(GUID, USER_ID, [], CHANNEL_B)
+
+        assert boost_a == pytest.approx(_expected_boost([], None, channel_boost))
+        assert boost_b == 1.0
+
+
+class TestCalculateXpHypothesis:
+    @given(
+        role_boosts=boost_list,
+        user_boost=optional_boost,
+        channel_boost=optional_boost,
+        base=base_xp,
+    )
+    @settings(max_examples=80)
+    @pytest.mark.asyncio
+    async def test_calculate_xp_returns_int_in_valid_range(
+        self,
+        role_boosts: list[tuple[float, bool]],
+        user_boost: tuple[float, bool] | None,
+        channel_boost: tuple[float, bool] | None,
+        base: int,
+    ) -> None:
+        role_models = [_make_boost(b, a) for b, a in role_boosts]
+        user_model = _make_boost(*user_boost) if user_boost else None
+        channel_model = _make_boost(*channel_boost) if channel_boost else None
+        calculator = XpCalculator(boost_repo=_make_repo(role_models, user_model, channel_model))
+        effective = _expected_boost(role_boosts, user_boost, channel_boost)
+
+        with patch("services.xp_calculator.random.randint", return_value=base):
+            xp = await calculator.calculate_xp(GUID, USER_ID, ROLE_IDS, CHANNEL_A)
+
+        assert isinstance(xp, int)
+        assert xp == int(base * effective)
+        assert xp >= int(base * 1.0)


### PR DESCRIPTION
## Summary
- Hypothesis property tests for `XpCalculator` boost formula
- Full `BoosterService` coverage including concurrent claims and cache invalidation
- Giveaway loop tests with `freezegun`
- XP cooldown cache integration tests

## Test plan
- [x] `pytest tests/unit/services/test_xp_calculator_hypothesis.py tests/unit/services/test_booster_service.py tests/unit/loops/test_giveaway_loop.py tests/integration/api/test_xp_cooldown_cache.py`

**Stacked on:** #PR1 (cache-stampede-and-db-ci)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extensive new and expanded tests covering XP cooldowns, DB read caching, giveaway loops, booster service, XP calculator property tests, stampede cache concurrency, and numerous integration/unit suites.
* **Localization**
  * Large additions to English and German translation strings for many commands and UI/messages.
* **Bug Fixes / Improvements**
  * Cache and timing behavior fixes improving XP/logging/booster reliability.
* **Chores**
  * CI/workflow updates, test infra adjustments, Docker test compose tweaks, and a version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->