### PR TITLE
test: auth, permissions, and error handler matrix

### DIFF
--- a/tests/integration/extensions/test_administration_auth.py
+++ b/tests/integration/extensions/test_administration_auth.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from extensions.administration import AdministrationCog
+from tests.helpers.discord import make_guild, make_member, make_message, make_text_channel
+from tests.integration.extensions.conftest import load_extension_bot
+
+pytestmark = pytest.mark.asyncio
+
+EXTENSION = "extensions.administration"
+COG_NAME = "AdministrationCog"
+MOCK_ADMIN_IDS = [42424242, 51515151]
+ADMIN_ID = MOCK_ADMIN_IDS[0]
+NON_ADMIN_ID = 88888888
+
+
+def make_context(
+    bot: MagicMock,
+    *,
+    author_id: int,
+) -> MagicMock:
+    guild = make_guild()
+    channel = make_text_channel(guild=guild)
+    author = make_member(user_id=author_id)
+    ctx = MagicMock()
+    ctx.author = author
+    ctx.guild = guild
+    ctx.channel = channel
+    ctx.bot = bot
+    ctx.send = AsyncMock()
+    ctx.message = make_message(author=author, guild=guild, channel=channel)
+    return ctx
+
+
+@pytest.fixture
+def mock_admin_ids() -> list[int]:
+    return list(MOCK_ADMIN_IDS)
+
+
+@pytest.fixture
+async def cog(mock_admin_ids: list[int]) -> AdministrationCog:
+    with patch("extensions.administration.config.adminIds", mock_admin_ids):
+        bot = await load_extension_bot(EXTENSION, fire_ready=False)
+    return bot.cogs[COG_NAME]
+
+
+@pytest.fixture
+def bot(cog: AdministrationCog) -> MagicMock:
+    return cog.bot
+
+
+@pytest.mark.parametrize(
+    "method_name,extra_kwargs",
+    [
+        ("sync", {}),
+        ("feedback", {"content": "hello"}),
+        ("me", {}),
+    ],
+)
+async def test_non_admin_denied(
+    cog: AdministrationCog,
+    bot: MagicMock,
+    mock_admin_ids: list[int],
+    method_name: str,
+    extra_kwargs: dict,
+) -> None:
+    ctx = make_context(bot, author_id=NON_ADMIN_ID)
+    with patch("extensions.administration.config.adminIds", mock_admin_ids):
+        await getattr(cog, method_name)(ctx, **extra_kwargs)
+    ctx.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_allowed_sync(
+    cog: AdministrationCog,
+    bot: MagicMock,
+    mock_admin_ids: list[int],
+) -> None:
+    ctx = make_context(bot, author_id=ADMIN_ID)
+    bot.tree = MagicMock()
+    bot.tree.sync = AsyncMock(return_value=[MagicMock()])
+    with patch("extensions.administration.config.adminIds", mock_admin_ids):
+        await cog.sync(ctx)
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_allowed_feedback(
+    cog: AdministrationCog,
+    bot: MagicMock,
+    mock_admin_ids: list[int],
+) -> None:
+    ctx = make_context(bot, author_id=ADMIN_ID)
+    with (
+        patch("extensions.administration.config.adminIds", mock_admin_ids),
+        patch("extensions.administration.addFeedback", new=AsyncMock()),
+    ):
+        await cog.feedback(ctx, content="hello")
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_admin_allowed_me(
+    cog: AdministrationCog,
+    bot: MagicMock,
+    mock_admin_ids: list[int],
+) -> None:
+    ctx = make_context(bot, author_id=ADMIN_ID)
+    with patch("extensions.administration.config.adminIds", mock_admin_ids):
+        await cog.me(ctx)
+    ctx.send.assert_awaited_once()
+
+
+async def test_second_configured_admin_allowed(
+    cog: AdministrationCog,
+    bot: MagicMock,
+    mock_admin_ids: list[int],
+) -> None:
+    ctx = make_context(bot, author_id=MOCK_ADMIN_IDS[1])
+    bot.tree = MagicMock()
+    bot.tree.sync = AsyncMock(return_value=[MagicMock()])
+    with patch("extensions.administration.config.adminIds", mock_admin_ids):
+        await cog.sync(ctx)
+    ctx.send.assert_awaited_once()

--- a/tests/integration/extensions/test_error_handler_matrix.py
+++ b/tests/integration/extensions/test_error_handler_matrix.py
@@ -39,35 +39,73 @@ async def _cog() -> ErrorHandlerCog:
     return bot.cogs["ErrorHandlerCog"]
 
 
-def _make_error(kind: str) -> Exception:
-    if kind == "cooldown":
-        return app_commands.CommandOnCooldown(retry_after=8.3)
-    if kind == "missing_permissions":
-        return app_commands.MissingPermissions(["manage_messages", "ban_members"])
-    if kind == "not_found":
-        return discord.NotFound(MagicMock(), "resource missing")
-    if kind == "unknown":
-        return RuntimeError("unexpected failure")
-    raise ValueError(f"unknown error kind: {kind}")
+def _http_exception(status: int) -> discord.HTTPException:
+    exc = discord.HTTPException(MagicMock(), "server error")
+    exc.status = status
+    return exc
 
 
 @pytest.mark.parametrize(
-    ("error_kind", "locale_key", "category"),
+    ("error_factory", "locale_key", "category"),
     [
-        ("cooldown", "errors.cooldown", ErrorEmbedCategory.RATE_LIMIT),
-        ("missing_permissions", "errors.missing_permissions", ErrorEmbedCategory.PERMISSION),
-        ("not_found", "errors.unexpected_error", ErrorEmbedCategory.UNEXPECTED),
-        ("unknown", "errors.unexpected_error", ErrorEmbedCategory.UNEXPECTED),
+        pytest.param(
+            lambda: app_commands.CommandOnCooldown(retry_after=8.3),
+            "errors.cooldown",
+            ErrorEmbedCategory.RATE_LIMIT,
+            id="cooldown",
+        ),
+        pytest.param(
+            lambda: app_commands.MissingPermissions(["manage_messages", "ban_members"]),
+            "errors.missing_permissions",
+            ErrorEmbedCategory.PERMISSION,
+            id="missing_permissions",
+        ),
+        pytest.param(
+            lambda: app_commands.BotMissingPermissions(["send_messages"]),
+            "errors.missing_permissions",
+            ErrorEmbedCategory.PERMISSION,
+            id="bot_missing_permissions",
+        ),
+        pytest.param(
+            lambda: app_commands.CheckFailure("generic check failed"),
+            "errors.missing_permissions",
+            ErrorEmbedCategory.PERMISSION,
+            id="check_failure",
+        ),
+        pytest.param(
+            lambda: discord.Forbidden(MagicMock(), "forbidden"),
+            "errors.forbidden",
+            ErrorEmbedCategory.PERMISSION,
+            id="forbidden",
+        ),
+        pytest.param(
+            lambda: _http_exception(503),
+            "errors.http_error",
+            ErrorEmbedCategory.UNEXPECTED,
+            id="http_exception",
+        ),
+        pytest.param(
+            lambda: app_commands.TransformerError(MagicMock(), ValueError("bad input")),
+            "errors.transformer_error",
+            ErrorEmbedCategory.VALIDATION,
+            id="transformer_error",
+        ),
+        pytest.param(
+            lambda: RuntimeError("unexpected failure"),
+            "errors.unexpected_error",
+            ErrorEmbedCategory.UNEXPECTED,
+            id="unknown",
+        ),
     ],
 )
 async def test_on_app_command_error_matrix(
-    error_kind: str,
+    error_factory: Callable[[], Exception],
     locale_key: str,
     category: ErrorEmbedCategory,
 ) -> None:
     cog = await _cog()
     ix = _interaction()
-    error = _make_error(error_kind)
+    error = error_factory()
     localized_keys: list[str] = []
 
     def _capture(_locale: str, key: str, **kwargs: Any) -> str:
@@ -87,12 +125,38 @@ async def test_on_app_command_error_matrix(
     assert sent_embed.colour == category.value
 
 
+async def test_command_not_found_sends_no_embed() -> None:
+    cog = await _cog()
+    ix = _interaction()
+    with patch("extensions.error_handler.sentry_dsn", ""):
+        await cog._on_app_command_error(ix, app_commands.CommandNotFound("missing", []))
+    ix.response.send_message.assert_not_called()
+    ix.followup.send.assert_not_called()
+
+
+async def test_unknown_error_reports_to_sentry_when_configured() -> None:
+    cog = await _cog()
+    ix = _interaction()
+    push_scope = MagicMock()
+    push_scope.__enter__ = MagicMock(return_value=MagicMock())
+    push_scope.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("extensions.error_handler.sentry_dsn", "https://example@sentry.io/1"),
+        patch("sentry_sdk.push_scope", return_value=push_scope),
+        patch("extensions.error_handler.tanjunLocalizer.localize", side_effect=lambda _l, k, **kw: k),
+    ):
+        await cog._on_app_command_error(ix, RuntimeError("boom"))
+
+    ix.response.send_message.assert_awaited_once()
+
+
 @pytest.mark.parametrize(
     "error_factory",
     [
         pytest.param(lambda: app_commands.CommandOnCooldown(retry_after=1.0), id="cooldown"),
         pytest.param(lambda: app_commands.MissingPermissions(["kick_members"]), id="missing_permissions"),
-        pytest.param(lambda: discord.NotFound(MagicMock(), "missing"), id="not_found"),
+        pytest.param(lambda: discord.Forbidden(MagicMock(), "forbidden"), id="forbidden"),
         pytest.param(lambda: ValueError("unknown"), id="unknown"),
     ],
 )

--- a/tests/integration/extensions/test_error_handler_matrix.py
+++ b/tests/integration/extensions/test_error_handler_matrix.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+from discord import app_commands
+
+from extensions.error_handler import ErrorHandlerCog
+from tests.helpers.discord import make_guild, make_interaction, make_member
+from tests.integration.extensions.conftest import load_extension_bot
+from utility import ErrorEmbedCategory
+
+pytestmark = pytest.mark.asyncio
+
+EXTENSION = "extensions.error_handler"
+
+
+def _interaction(*, response_done: bool = False) -> MagicMock:
+    ix = make_interaction(locale="en-US")
+    ix.id = 12345
+    ix.channel_id = 444444444
+    ix.user = make_member()
+    ix.guild = make_guild()
+    ix.guild.name = "Test Guild"
+    ix.command.qualified_name = "test_cmd"
+    ix.guild_locale = MagicMock(value="en-US")
+    ix.locale = MagicMock(value="en-US")
+    ix.response.is_done = MagicMock(return_value=response_done)
+    ix.response.send_message = AsyncMock()
+    ix.followup.send = AsyncMock()
+    return ix
+
+
+async def _cog() -> ErrorHandlerCog:
+    bot = await load_extension_bot(EXTENSION, fire_ready=True)
+    return bot.cogs["ErrorHandlerCog"]
+
+
+def _make_error(kind: str) -> Exception:
+    if kind == "cooldown":
+        return app_commands.CommandOnCooldown(retry_after=8.3)
+    if kind == "missing_permissions":
+        return app_commands.MissingPermissions(["manage_messages", "ban_members"])
+    if kind == "not_found":
+        return discord.NotFound(MagicMock(), "resource missing")
+    if kind == "unknown":
+        return RuntimeError("unexpected failure")
+    raise ValueError(f"unknown error kind: {kind}")
+
+
+@pytest.mark.parametrize(
+    ("error_kind", "locale_key", "category"),
+    [
+        ("cooldown", "errors.cooldown", ErrorEmbedCategory.RATE_LIMIT),
+        ("missing_permissions", "errors.missing_permissions", ErrorEmbedCategory.PERMISSION),
+        ("not_found", "errors.unexpected_error", ErrorEmbedCategory.UNEXPECTED),
+        ("unknown", "errors.unexpected_error", ErrorEmbedCategory.UNEXPECTED),
+    ],
+)
+async def test_on_app_command_error_matrix(
+    error_kind: str,
+    locale_key: str,
+    category: ErrorEmbedCategory,
+) -> None:
+    cog = await _cog()
+    ix = _interaction()
+    error = _make_error(error_kind)
+    localized_keys: list[str] = []
+
+    def _capture(_locale: str, key: str, **kwargs: Any) -> str:
+        localized_keys.append(key)
+        return key
+
+    with (
+        patch("extensions.error_handler.tanjunLocalizer.localize", side_effect=_capture),
+        patch("extensions.error_handler.sentry_dsn", ""),
+    ):
+        await cog._on_app_command_error(ix, error)
+
+    assert f"{locale_key}.title" in localized_keys
+    assert f"{locale_key}.description" in localized_keys
+    ix.response.send_message.assert_awaited_once()
+    sent_embed = ix.response.send_message.await_args.kwargs["embed"]
+    assert sent_embed.colour == category.value
+
+
+@pytest.mark.parametrize(
+    "error_factory",
+    [
+        pytest.param(lambda: app_commands.CommandOnCooldown(retry_after=1.0), id="cooldown"),
+        pytest.param(lambda: app_commands.MissingPermissions(["kick_members"]), id="missing_permissions"),
+        pytest.param(lambda: discord.NotFound(MagicMock(), "missing"), id="not_found"),
+        pytest.param(lambda: ValueError("unknown"), id="unknown"),
+    ],
+)
+async def test_matrix_sends_via_followup_when_response_done(
+    error_factory: Callable[[], Exception],
+) -> None:
+    cog = await _cog()
+    ix = _interaction(response_done=True)
+    with patch("extensions.error_handler.sentry_dsn", ""):
+        await cog._on_app_command_error(ix, error_factory())
+    ix.followup.send.assert_awaited_once()
+    ix.response.send_message.assert_not_called()

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.helpers.discord import (
+    make_command_info,
+    make_guild,
+    make_member,
+    make_permissions,
+    make_target_member,
+    make_text_channel,
+)
+from utils.checks import (
+    can_moderate,
+    check_bot_hierarchy,
+    check_bot_permission,
+    check_executor_hierarchy,
+    check_user_permission,
+    send_check_failure,
+)
+from utils.embeds import ErrorEmbedCategory
+
+
+class TestCheckUserPermission:
+    def test_non_member_fails(self):
+        info = make_command_info(user=MagicMock())
+        result = check_user_permission(info, "ban_members")
+        assert result == ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+
+    def test_missing_guild_permission(self):
+        member = make_member()
+        member.guild_permissions = make_permissions(ban_members=False)
+        info = make_command_info(user=member)
+        result = check_user_permission(info, "ban_members", use_guild_permissions=True)
+        assert result is not None
+        assert result[0] == "missingPermission"
+
+    def test_has_guild_permission(self):
+        member = make_member()
+        member.guild_permissions = make_permissions(ban_members=True)
+        info = make_command_info(user=member)
+        assert check_user_permission(info, "ban_members", use_guild_permissions=True) is None
+
+    def test_missing_channel_permission(self):
+        member = make_member()
+        channel = make_text_channel()
+        channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=False))
+        info = make_command_info(user=member, channel=channel)
+        result = check_user_permission(info, "manage_messages")
+        assert result is not None
+
+    def test_has_channel_permission(self):
+        member = make_member()
+        channel = make_text_channel()
+        channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=True))
+        info = make_command_info(user=member, channel=channel)
+        assert check_user_permission(info, "manage_messages") is None
+
+    def test_uses_explicit_channel(self):
+        member = make_member()
+        invocation_channel = make_text_channel()
+        invocation_channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=False))
+        target_channel = make_text_channel()
+        target_channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=True))
+        info = make_command_info(user=member, channel=invocation_channel)
+        assert check_user_permission(info, "manage_messages", channel=target_channel) is None
+
+    def test_channel_without_permissions_for(self):
+        member = make_member()
+        channel = MagicMock(spec=[])
+        info = make_command_info(user=member, channel=channel)
+        result = check_user_permission(info, "manage_messages")
+        assert result == ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+
+
+class TestCheckBotPermission:
+    def test_missing_guild_raises(self):
+        from utility import CommandInfo
+
+        info = CommandInfo(
+            user=make_member(),
+            guild=None,
+            channel=make_text_channel(),
+            locale="en-US",
+            client=MagicMock(),
+            command=MagicMock(),
+            message=None,
+            permissions=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="Guild is missing"):
+            check_bot_permission(info, "ban_members")
+
+    def test_missing_guild_permission(self):
+        guild = make_guild(me_permissions=make_permissions(ban_members=False))
+        info = make_command_info(guild=guild)
+        result = check_bot_permission(info, "ban_members")
+        assert result == ("missingPermissionBot", ErrorEmbedCategory.PERMISSION, True)
+
+    def test_has_guild_permission(self):
+        guild = make_guild(me_permissions=make_permissions(ban_members=True))
+        info = make_command_info(guild=guild)
+        assert check_bot_permission(info, "ban_members") is None
+
+    def test_channel_permission(self):
+        guild = make_guild()
+        channel = make_text_channel(guild=guild)
+        channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=True))
+        info = make_command_info(guild=guild, channel=channel)
+        assert check_bot_permission(info, "manage_messages", channel=channel) is None
+
+
+class TestCheckExecutorHierarchy:
+    def test_non_member_passes(self):
+        info = make_command_info(user=MagicMock())
+        target = make_target_member(top_role_position=99)
+        assert check_executor_hierarchy(info, target) is None
+
+    def test_target_too_high(self):
+        executor = make_member(top_role_position=2)
+        target = make_target_member(top_role_position=5)
+        info = make_command_info(user=executor)
+        result = check_executor_hierarchy(info, target)
+        assert result == ("targetTooHigh", ErrorEmbedCategory.PERMISSION, False)
+
+    def test_hierarchy_ok(self):
+        executor = make_member(top_role_position=10)
+        target = make_target_member(top_role_position=2)
+        info = make_command_info(user=executor)
+        assert check_executor_hierarchy(info, target) is None
+
+
+class TestCheckBotHierarchy:
+    def test_missing_guild_raises(self):
+        from utility import CommandInfo
+
+        info = CommandInfo(
+            user=make_member(),
+            guild=None,
+            channel=make_text_channel(),
+            locale="en-US",
+            client=MagicMock(),
+            command=MagicMock(),
+            message=None,
+            permissions=MagicMock(),
+        )
+        with pytest.raises(ValueError, match="Guild is missing"):
+            check_bot_hierarchy(info, make_target_member())
+
+    def test_bot_too_low(self):
+        guild = make_guild(me_top_role_position=2)
+        target = make_target_member(top_role_position=5)
+        info = make_command_info(guild=guild)
+        result = check_bot_hierarchy(info, target)
+        assert result == ("targetTooHighBot", ErrorEmbedCategory.PERMISSION, False)
+
+    def test_bot_hierarchy_ok(self):
+        guild = make_guild(me_top_role_position=50)
+        target = make_target_member(top_role_position=2)
+        info = make_command_info(guild=guild)
+        assert check_bot_hierarchy(info, target) is None
+
+
+class TestCanModerate:
+    def test_user_permission_failure(self):
+        member = make_member()
+        member.guild_permissions = make_permissions(kick_members=False)
+        guild = make_guild(me_permissions=make_permissions(kick_members=True), me_top_role_position=50)
+        info = make_command_info(user=member, guild=guild)
+        target = make_target_member(top_role_position=1)
+        result = can_moderate(info, target, "kick_members", "kick_members")
+        assert result is not None
+        assert result[0] == "missingPermission"
+
+    def test_bot_permission_failure(self):
+        member = make_member()
+        member.guild_permissions = make_permissions(kick_members=True)
+        guild = make_guild(me_permissions=make_permissions(kick_members=False), me_top_role_position=50)
+        info = make_command_info(user=member, guild=guild)
+        target = make_target_member(top_role_position=1)
+        result = can_moderate(info, target, "kick_members", "kick_members")
+        assert result == ("missingPermissionBot", ErrorEmbedCategory.PERMISSION, True)
+
+    def test_executor_hierarchy_failure(self):
+        member = make_member(top_role_position=2)
+        member.guild_permissions = make_permissions(kick_members=True)
+        guild = make_guild(me_permissions=make_permissions(kick_members=True), me_top_role_position=50)
+        info = make_command_info(user=member, guild=guild)
+        target = make_target_member(top_role_position=5)
+        result = can_moderate(info, target, "kick_members", "kick_members")
+        assert result == ("targetTooHigh", ErrorEmbedCategory.PERMISSION, False)
+
+    def test_all_pass(self):
+        member = make_member(top_role_position=10)
+        member.guild_permissions = make_permissions(kick_members=True)
+        guild = make_guild(me_permissions=make_permissions(kick_members=True), me_top_role_position=50)
+        info = make_command_info(user=member, guild=guild)
+        target = make_target_member(top_role_position=2)
+        assert can_moderate(info, target, "kick_members", "kick_members") is None
+
+
+class TestDmContext:
+    def test_dm_user_missing_permission(self):
+        user = MagicMock()
+        info = make_command_info(user=user, guild=None)
+        result = check_user_permission(info, "ban_members", use_guild_permissions=True)
+        assert result == ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+
+    def test_dm_can_moderate_fails_on_user_permission(self):
+        user = MagicMock()
+        info = make_command_info(user=user, guild=None)
+        target = make_target_member()
+        result = can_moderate(info, target, "kick_members", "kick_members")
+        assert result == ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+
+
+class TestManagedRolesAndEqualHierarchy:
+    def test_equal_executor_target_top_role_fails(self):
+        executor = make_member(top_role_position=7)
+        target = make_target_member(top_role_position=7)
+        info = make_command_info(user=executor)
+        result = check_executor_hierarchy(info, target)
+        assert result == ("targetTooHigh", ErrorEmbedCategory.PERMISSION, False)
+
+    def test_equal_bot_target_top_role_fails(self):
+        guild = make_guild(me_top_role_position=7)
+        target = make_target_member(top_role_position=7)
+        info = make_command_info(guild=guild)
+        result = check_bot_hierarchy(info, target)
+        assert result == ("targetTooHighBot", ErrorEmbedCategory.PERMISSION, False)
+
+    def test_managed_role_position_still_blocks_executor(self):
+        executor = make_member(top_role_position=3)
+        target = make_target_member(top_role_position=8)
+        target.top_role.managed = True
+        info = make_command_info(user=executor)
+        result = check_executor_hierarchy(info, target)
+        assert result == ("targetTooHigh", ErrorEmbedCategory.PERMISSION, False)
+
+
+class TestChannelPermissionOverrides:
+    def test_override_denies_when_guild_would_allow(self):
+        member = make_member()
+        member.guild_permissions = make_permissions(manage_messages=True)
+        channel = make_text_channel()
+        channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=False))
+        info = make_command_info(user=member, channel=channel)
+        result = check_user_permission(info, "manage_messages")
+        assert result == ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+
+    def test_override_grants_when_invocation_channel_denies(self):
+        member = make_member()
+        invocation = make_text_channel()
+        invocation.permissions_for = MagicMock(return_value=make_permissions(manage_messages=False))
+        override = make_text_channel()
+        override.permissions_for = MagicMock(return_value=make_permissions(manage_messages=True))
+        info = make_command_info(user=member, channel=invocation)
+        assert check_user_permission(info, "manage_messages", channel=override) is None
+
+    def test_bot_channel_override_denies(self):
+        guild = make_guild(me_permissions=make_permissions(manage_messages=True))
+        channel = make_text_channel(guild=guild)
+        channel.permissions_for = MagicMock(return_value=make_permissions(manage_messages=False))
+        info = make_command_info(guild=guild, channel=channel)
+        result = check_bot_permission(info, "manage_messages", channel=channel)
+        assert result == ("missingPermissionBot", ErrorEmbedCategory.PERMISSION, True)
+
+
+class TestSendCheckFailure:
+    @pytest.mark.asyncio
+    async def test_none_result_returns_false(self):
+        info = make_command_info()
+        assert await send_check_failure(info, "kick", None) is False
+
+    @pytest.mark.asyncio
+    async def test_sends_error_embed(self):
+        info = make_command_info()
+        result = ("targetTooHigh", ErrorEmbedCategory.PERMISSION, False)
+        with (
+            patch("localizer.tanjunLocalizer.localize", side_effect=lambda _loc, key: key),
+            patch("utils.checks.categorized_error_embed", return_value=MagicMock()) as mock_embed,
+        ):
+            sent = await send_check_failure(info, "kick", result)
+        assert sent is True
+        mock_embed.assert_called_once()
+        info.reply.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sends_warning_embed(self):
+        info = make_command_info()
+        result = ("missingPermission", ErrorEmbedCategory.PERMISSION, True)
+        with (
+            patch("localizer.tanjunLocalizer.localize", side_effect=lambda _loc, key: key),
+            patch("utils.checks.categorized_warning_embed", return_value=MagicMock()) as mock_embed,
+        ):
+            sent = await send_check_failure(info, "ban", result)
+        assert sent is True
+        mock_embed.assert_called_once()
+        info.reply.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_localize_keys_and_error_embed_path(self):
+        info = make_command_info(locale="de-DE")
+        result = ("targetTooHighBot", ErrorEmbedCategory.PERMISSION, False)
+        localized_keys: list[str] = []
+
+        def _capture(_locale: str, key: str) -> str:
+            localized_keys.append(key)
+            return key
+
+        embed = MagicMock()
+        with (
+            patch("localizer.tanjunLocalizer.localize", side_effect=_capture),
+            patch("utils.checks.categorized_error_embed", return_value=embed) as mock_embed,
+        ):
+            await send_check_failure(info, "ban", result)
+
+        assert localized_keys == [
+            "commands.admin.ban.targetTooHighBot.title",
+            "commands.admin.ban.targetTooHighBot.description",
+        ]
+        mock_embed.assert_called_once_with(
+            ErrorEmbedCategory.PERMISSION,
+            "commands.admin.ban.targetTooHighBot.title",
+            "commands.admin.ban.targetTooHighBot.description",
+        )
+        info.reply.assert_awaited_once_with(embed=embed)
+
+    @pytest.mark.asyncio
+    async def test_localize_keys_and_warning_embed_path(self):
+        info = make_command_info()
+        result = ("missingPermissionBot", ErrorEmbedCategory.PERMISSION, True)
+        localized_keys: list[str] = []
+
+        def _capture(_locale: str, key: str) -> str:
+            localized_keys.append(key)
+            return key
+
+        embed = MagicMock()
+        with (
+            patch("localizer.tanjunLocalizer.localize", side_effect=_capture),
+            patch("utils.checks.categorized_warning_embed", return_value=embed) as mock_embed,
+        ):
+            await send_check_failure(info, "kick", result)
+
+        assert localized_keys == [
+            "commands.admin.kick.missingPermissionBot.title",
+            "commands.admin.kick.missingPermissionBot.description",
+        ]
+        mock_embed.assert_called_once_with(
+            "commands.admin.kick.missingPermissionBot.title",
+            "commands.admin.kick.missingPermissionBot.description",
+        )
+        info.reply.assert_awaited_once_with(embed=embed)


### PR DESCRIPTION
## Summary
- Expand `checks.py` edge cases (DM, managed roles, hierarchy, channel overrides, `send_check_failure`)
- Parametrized error handler exception-to-embed matrix
- Administration cog bot-owner auth boundary tests

## Test plan
- [x] `pytest tests/unit/utils/test_checks.py tests/integration/extensions/test_error_handler_matrix.py tests/integration/extensions/test_administration_auth.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for administration command authorization covering admin and non-admin behavior.
  * Added integration tests for error handling across many error types, response vs follow-up behavior, and reporting when external error reporting is enabled.
  * Expanded unit tests for permission and moderation checks, including role hierarchy, channel/guild permission variations, and error-reporting helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->