### PR TITLE
test: Prometheus metrics and health observability

### DIFF
--- a/extensions/prometheus_metrics.py
+++ b/extensions/prometheus_metrics.py
@@ -88,7 +88,7 @@ class PrometheusMetricsCog(commands.Cog):
             # Update process metrics synchronously before serving.
             update_process_metrics()
             data = generate_latest()
-            return web.Response(body=data, content_type=CONTENT_TYPE_LATEST)
+            return web.Response(body=data, headers={"Content-Type": CONTENT_TYPE_LATEST})
 
         async def health_handler(request: web.Request) -> web.Response:
             return web.Response(text="OK", content_type="text/plain")

--- a/tests/integration/extensions/test_prometheus_metrics.py
+++ b/tests/integration/extensions/test_prometheus_metrics.py
@@ -104,3 +104,42 @@ async def test_cog_unload_cleans_up_http_runner(metrics_port: int) -> None:
     await cog.cog_unload()
     assert cog._runner is None
     assert cog._site is None
+
+
+async def test_cog_unload_emits_no_unclosed_session_warning(metrics_port: int) -> None:
+    import warnings
+
+    bot = make_bot_for_extensions()
+    cog = await _load_metrics_cog(bot, metrics_port)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", ResourceWarning)
+        await cog.cog_unload()
+    unclosed = [w for w in caught if "Unclosed client session" in str(w.message)]
+    assert not unclosed
+
+
+async def test_record_db_query_updates_scrape_metrics(metrics_port: int) -> None:
+    import tests.mock_config as mock_config
+    from unittest.mock import AsyncMock
+
+    mock_config.patch_config_module()
+
+    from api import execute_query, set_bot
+    from tests.integration.api.test_api import make_mock_pool
+
+    pool, _, cursor = make_mock_pool()
+    cursor.fetchall = AsyncMock(return_value=[(1,)])
+    bot = make_bot_for_extensions()
+    bot._pool = pool
+    set_bot(bot)
+
+    cog = await _load_metrics_cog(bot, metrics_port)
+    try:
+        await execute_query("SELECT 1", ())
+        async with ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{metrics_port}/metrics") as resp:
+                body = await resp.text()
+        assert "tanjun_database_tanjun_db_query_duration_seconds" in body
+        assert 'operation="execute_query"' in body
+    finally:
+        await cog.cog_unload()

--- a/tests/integration/extensions/test_prometheus_metrics.py
+++ b/tests/integration/extensions/test_prometheus_metrics.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import ClientSession
+
+from extensions.prometheus_metrics import PrometheusMetricsCog
+from services.metrics_service import command_usage
+from tests.helpers.extension_loader import load_extension, make_bot_for_extensions
+
+pytestmark = pytest.mark.asyncio
+
+EXTENSION = "extensions.prometheus_metrics"
+
+EXPECTED_METRIC_NAMES = (
+    "tanjun_bot_tanjun_guild_count",
+    "tanjun_commands_tanjun_command_usage_total",
+    "tanjun_bot_tanjun_bot_start_time_seconds",
+    "tanjun_system_tanjun_process_memory_bytes",
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def metrics_port() -> int:
+    return _free_port()
+
+
+async def _load_metrics_cog(bot: MagicMock, metrics_port: int) -> PrometheusMetricsCog:
+    bot.guilds = []
+    bot.users = []
+    bot.shards = {}
+    with patch("extensions.prometheus_metrics.metrics_port", metrics_port):
+        await load_extension(bot, EXTENSION)
+        cog: PrometheusMetricsCog = bot.cogs["PrometheusMetricsCog"]
+        await cog.cog_load()
+    return cog
+
+
+async def test_setup_loads_prometheus_cog(metrics_port: int) -> None:
+    bot = make_bot_for_extensions()
+    with patch("extensions.prometheus_metrics.metrics_port", metrics_port):
+        await load_extension(bot, EXTENSION)
+    assert "PrometheusMetricsCog" in bot.cogs
+
+
+async def test_metrics_endpoint_returns_expected_names(metrics_port: int) -> None:
+    bot = make_bot_for_extensions()
+    cog = await _load_metrics_cog(bot, metrics_port)
+    try:
+        async with ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{metrics_port}/metrics") as resp:
+                assert resp.status == 200
+                body = await resp.text()
+        for name in EXPECTED_METRIC_NAMES:
+            assert name in body
+    finally:
+        await cog.cog_unload()
+
+
+async def test_command_completion_increments_counter(metrics_port: int) -> None:
+    bot = make_bot_for_extensions()
+    cog = await _load_metrics_cog(bot, metrics_port)
+    try:
+        before = command_usage.labels(
+            command="test_ping",
+            guild_id="999",
+            status="success",
+        )._value.get()
+        ctx = MagicMock()
+        ctx.command = MagicMock()
+        ctx.command.qualified_name = "test_ping"
+        ctx.guild = MagicMock()
+        ctx.guild.id = 999
+        await cog.on_command_completion(ctx)
+        after = command_usage.labels(
+            command="test_ping",
+            guild_id="999",
+            status="success",
+        )._value.get()
+        assert after == before + 1
+
+        async with ClientSession() as session:
+            async with session.get(f"http://127.0.0.1:{metrics_port}/metrics") as resp:
+                body = await resp.text()
+        assert 'command="test_ping"' in body
+        assert 'guild_id="999"' in body
+    finally:
+        await cog.cog_unload()
+
+
+async def test_cog_unload_cleans_up_http_runner(metrics_port: int) -> None:
+    bot = make_bot_for_extensions()
+    cog = await _load_metrics_cog(bot, metrics_port)
+    assert cog._runner is not None
+    assert cog._site is not None
+    await cog.cog_unload()
+    assert cog._runner is None
+    assert cog._site is None

--- a/tests/unit/health/test_openai_health_check.py
+++ b/tests/unit/health/test_openai_health_check.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from health.checks.openai import OpenAIHealthCheck
+from health.checks.openrouter import OpenRouterHealthCheck
+
+from health.checks import HealthStatus
+
+
+def _mock_response(status: int):
+    resp = AsyncMock()
+    resp.status = status
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=None)
+    return resp
+
+
+class TestOpenAIHealthCheckCompat:
+    def test_openai_health_check_is_openrouter_alias(self):
+        assert OpenAIHealthCheck is OpenRouterHealthCheck
+
+
+class TestOpenAIHealthCheck:
+    @pytest.fixture
+    def check(self) -> OpenAIHealthCheck:
+        return OpenAIHealthCheck()
+
+    def test_name_and_critical(self, check: OpenAIHealthCheck):
+        assert check.name == "OpenRouter API"
+        assert check.critical is True
+
+    @pytest.mark.asyncio
+    async def test_missing_key_critical(self, check: OpenAIHealthCheck):
+        with patch("services.openrouter_client.get_openrouter_api_key", return_value=""):
+            result = await check.run()
+        assert result.status == HealthStatus.CRITICAL
+        assert "not configured" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_healthy_on_200(self, check: OpenAIHealthCheck):
+        mock_resp = _mock_response(200)
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        with patch("health.checks.openrouter.ClientSession", return_value=mock_session):
+            result = await check.run()
+        assert result.status == HealthStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_401_degraded(self, check: OpenAIHealthCheck):
+        mock_resp = _mock_response(401)
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        with patch("health.checks.openrouter.ClientSession", return_value=mock_session):
+            result = await check.run()
+        assert result.status == HealthStatus.DEGRADED
+        assert "401" in result.message
+
+    @pytest.mark.asyncio
+    async def test_429_degraded(self, check: OpenAIHealthCheck):
+        mock_resp = _mock_response(429)
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        with patch("health.checks.openrouter.ClientSession", return_value=mock_session):
+            result = await check.run()
+        assert result.status == HealthStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_other_status_degraded(self, check: OpenAIHealthCheck):
+        mock_resp = _mock_response(503)
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.get = MagicMock(return_value=mock_resp)
+
+        with patch("health.checks.openrouter.ClientSession", return_value=mock_session):
+            result = await check.run()
+        assert result.status == HealthStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_timeout_degraded(self, check: OpenAIHealthCheck):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.get = MagicMock(side_effect=TimeoutError)
+
+        with patch("health.checks.openrouter.ClientSession", return_value=mock_session):
+            result = await check.run()
+        assert result.status == HealthStatus.DEGRADED
+        assert "timed out" in result.message.lower()

--- a/tests/unit/services/test_metrics_service.py
+++ b/tests/unit/services/test_metrics_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from prometheus_client import REGISTRY
+
+from services import metrics_service
+
+
+class TestGetProcessStats:
+    def test_reads_linux_proc(self):
+        stats = metrics_service._get_process_stats()
+        assert "memory_bytes" in stats
+        assert stats["memory_bytes"] > 0
+        assert "cpu_seconds_total" in stats
+        assert stats["threads"] >= 1.0
+        assert stats["open_fds"] >= 1.0
+
+    def test_handles_missing_proc_files(self):
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("os.listdir", side_effect=FileNotFoundError),
+        ):
+            stats = metrics_service._get_process_stats()
+        assert stats == {}
+
+    def test_handles_malformed_stat(self):
+        from unittest.mock import mock_open
+
+        with patch("builtins.open", mock_open(read_data="1")):
+            stats = metrics_service._get_process_stats()
+        assert isinstance(stats, dict)
+
+
+class TestUpdateProcessMetrics:
+    def test_sets_gauges_from_stats(self):
+        fake_stats = {
+            "memory_bytes": 123456.0,
+            "cpu_seconds_total": 42.5,
+            "open_fds": 17.0,
+            "threads": 8.0,
+        }
+        with patch.object(metrics_service, "_get_process_stats", return_value=fake_stats):
+            metrics_service.update_process_metrics()
+        assert metrics_service.process_memory_bytes._value.get() == 123456.0
+        assert metrics_service.process_cpu_seconds._value.get() == 42.5
+        assert metrics_service.process_open_fds._value.get() == 17.0
+        assert metrics_service.process_threads._value.get() == 8.0
+
+    def test_skips_missing_keys(self):
+        with patch.object(metrics_service, "_get_process_stats", return_value={}):
+            metrics_service.update_process_metrics()
+
+
+class TestMetricRegistration:
+    def test_command_metrics_registered(self):
+        assert "tanjun_commands_tanjun_command_usage" in REGISTRY._names_to_collectors
+        assert "tanjun_database_tanjun_db_query_duration_seconds" in REGISTRY._names_to_collectors
+        assert "tanjun_bot_tanjun_guild_count" in REGISTRY._names_to_collectors
+
+    def test_counter_increments(self):
+        before = metrics_service.command_usage.labels(command="test_cmd", guild_id="1", status="ok")._value.get()
+        metrics_service.command_usage.labels(command="test_cmd", guild_id="1", status="ok").inc()
+        after = metrics_service.command_usage.labels(command="test_cmd", guild_id="1", status="ok")._value.get()
+        assert after == before + 1
+
+
+class TestLabelCardinality:
+    _LOW_CARDINALITY_METRICS = (
+        metrics_service.command_duration,
+        metrics_service.db_query_duration,
+        metrics_service.db_query_errors,
+        metrics_service.db_pool_size,
+        metrics_service.shard_latency,
+        metrics_service.shard_connected,
+        metrics_service.guild_count,
+        metrics_service.user_count,
+        metrics_service.message_processing_duration,
+        metrics_service.process_memory_bytes,
+        metrics_service.process_cpu_seconds,
+        metrics_service.process_open_fds,
+        metrics_service.process_threads,
+        metrics_service.bot_start_time,
+        metrics_service.loop_running,
+        metrics_service.loop_iteration_duration,
+        metrics_service.loop_iteration_errors,
+    )
+
+    _GUILD_ID_LABEL_METRICS = (
+        metrics_service.command_usage,
+        metrics_service.messages_processed,
+    )
+
+    def test_default_metrics_have_no_guild_id_label(self):
+        for metric in self._LOW_CARDINALITY_METRICS:
+            assert "guild_id" not in metric._labelnames, metric._name
+
+    def test_guild_scoped_counters_use_guild_id_label(self):
+        for metric in self._GUILD_ID_LABEL_METRICS:
+            assert "guild_id" in metric._labelnames, metric._name
+
+
+class TestUpdateProcessMetricsLive:
+    def test_gauges_reflect_proc_after_update(self):
+        metrics_service.update_process_metrics()
+        assert metrics_service.process_memory_bytes._value.get() > 0
+        assert metrics_service.process_cpu_seconds._value.get() > 0
+        assert metrics_service.process_open_fds._value.get() >= 1.0
+        assert metrics_service.process_threads._value.get() >= 1.0

--- a/tests/unit/services/test_metrics_service.py
+++ b/tests/unit/services/test_metrics_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from prometheus_client import REGISTRY
 
 from services import metrics_service
@@ -98,6 +99,56 @@ class TestLabelCardinality:
     def test_guild_scoped_counters_use_guild_id_label(self):
         for metric in self._GUILD_ID_LABEL_METRICS:
             assert "guild_id" in metric._labelnames, metric._name
+
+
+_ALL_METRICS = (
+    metrics_service.command_usage,
+    metrics_service.command_duration,
+    metrics_service.db_query_duration,
+    metrics_service.db_query_errors,
+    metrics_service.db_pool_size,
+    metrics_service.shard_latency,
+    metrics_service.shard_connected,
+    metrics_service.guild_count,
+    metrics_service.user_count,
+    metrics_service.messages_processed,
+    metrics_service.message_processing_duration,
+    metrics_service.process_memory_bytes,
+    metrics_service.process_cpu_seconds,
+    metrics_service.process_open_fds,
+    metrics_service.process_threads,
+    metrics_service.bot_start_time,
+    metrics_service.loop_running,
+    metrics_service.loop_iteration_duration,
+    metrics_service.loop_iteration_errors,
+)
+
+
+class TestEveryMetricReferenced:
+    @pytest.mark.parametrize("metric", _ALL_METRICS, ids=lambda m: m._name)
+    def test_metric_name_registered(self, metric):
+        assert metric._name in REGISTRY._names_to_collectors
+
+    def test_each_metric_can_be_observed_or_set(self):
+        metrics_service.command_usage.labels(command="x", guild_id="1", status="ok").inc()
+        metrics_service.command_duration.labels(command="x").observe(0.01)
+        metrics_service.db_query_duration.labels(operation="read").observe(0.001)
+        metrics_service.db_query_errors.labels(operation="read").inc()
+        metrics_service.db_pool_size.labels(type="used").set(1)
+        metrics_service.shard_latency.labels(shard_id="0").set(0.05)
+        metrics_service.shard_connected.labels(shard_id="0").set(1)
+        metrics_service.guild_count.set(10)
+        metrics_service.user_count.set(100)
+        metrics_service.messages_processed.labels(guild_id="1").inc()
+        metrics_service.message_processing_duration.observe(0.002)
+        metrics_service.process_memory_bytes.set(1024)
+        metrics_service.process_cpu_seconds.set(1.0)
+        metrics_service.process_open_fds.set(5)
+        metrics_service.process_threads.set(2)
+        metrics_service.bot_start_time.set(1_700_000_000)
+        metrics_service.loop_running.labels(loop_name="giveaway").set(1)
+        metrics_service.loop_iteration_duration.labels(loop_name="giveaway").observe(0.1)
+        metrics_service.loop_iteration_errors.labels(loop_name="giveaway").inc()
 
 
 class TestUpdateProcessMetricsLive:


### PR DESCRIPTION
## Summary
- End-to-end `/metrics` HTTP scrape tests for `PrometheusMetricsCog`
- Expand `metrics_service` unit tests (label cardinality, process gauges)
- OpenAI health check tests mirroring OpenRouter pattern
- Fix Prometheus content-type header for valid scrape responses

## Test plan
- [x] `pytest tests/integration/extensions/test_prometheus_metrics.py tests/unit/services/test_metrics_service.py tests/unit/health/test_openai_health_check.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for Prometheus metrics endpoint, covering scrape output, counter increments, database query metrics, and proper cleanup on unload.
  * Added unit tests for OpenAI/OpenRouter health check behavior across various responses and timeouts.
  * Added unit tests for metrics service to validate process stats collection and metric/counter behaviors.

* **Bug Fixes**
  * Adjusted Prometheus metrics endpoint response header handling for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->