### PR TITLE
test: command coverage gaps (logs, brawlstars, games, fun)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           pytest tests/integration -m "not slow and not live_discord" \
             --cov --cov-report=term-missing --cov-fail-under=85 -q
+      - name: Check command test coverage mapping
+        run: python scripts/check_command_test_coverage.py
 
   integration-db:
     runs-on: ubuntu-latest

--- a/scripts/check_command_test_coverage.py
+++ b/scripts/check_command_test_coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Verify integration tests exist for command handler modules."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMMANDS_DIR = ROOT / "commands"
+TESTS_DIR = ROOT / "tests" / "integration" / "commands"
+
+
+def _is_command_module(path: Path) -> bool:
+    if path.name.startswith("_") or path.name == "__init__.py":
+        return False
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            if any(arg.arg == "command_info" for arg in node.args.args):
+                return True
+    return False
+
+
+def _module_path(command_file: Path) -> str:
+    rel = command_file.relative_to(COMMANDS_DIR).with_suffix("")
+    return "commands." + ".".join(rel.parts)
+
+
+def _has_matching_test(module_path: str, stem: str, parent: Path) -> bool:
+    direct = TESTS_DIR / parent / f"test_{stem}.py"
+    if direct.is_file():
+        return True
+    needles = (module_path, module_path.replace(".", "/"), f"from {module_path}", f"import {module_path}")
+    for test_file in TESTS_DIR.rglob("test_*.py"):
+        text = test_file.read_text(encoding="utf-8")
+        if any(n in text for n in needles):
+            return True
+    return False
+
+
+def main() -> int:
+    missing: list[str] = []
+    for command_file in sorted(COMMANDS_DIR.rglob("*.py")):
+        if not _is_command_module(command_file):
+            continue
+        rel_parent = command_file.relative_to(COMMANDS_DIR).parent
+        module_path = _module_path(command_file)
+        if not _has_matching_test(module_path, command_file.stem, rel_parent):
+            missing.append(module_path)
+    if missing:
+        print("Command modules without integration test coverage:", file=sys.stderr)
+        for mod in missing:
+            print(f"  - {mod}", file=sys.stderr)
+        return 1
+    covered = sum(1 for p in COMMANDS_DIR.rglob("*.py") if _is_command_module(p))
+    print(f"All {covered} command handler modules have integration test coverage")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/commands/admin/test_copy_7tv_emote.py
+++ b/tests/integration/commands/admin/test_copy_7tv_emote.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.admin.copy_7tv_emote import copy_7tv_emote
+from services.seventv_service import SevenTVEmote, SevenTVUser
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_permissions
+
+pytestmark = pytest.mark.asyncio
+
+
+def _seventv_user(emote_count: int = 2) -> SevenTVUser:
+    emotes = [
+        SevenTVEmote(id=f"e{i}", name=f"emote{i}", animated=False, owner_name="Owner", image_url=f"https://cdn.test/{i}.png")
+        for i in range(emote_count)
+    ]
+    return SevenTVUser(
+        id="u1",
+        username="streamer",
+        display_name="Streamer",
+        avatar_url="https://cdn.test/avatar.png",
+        emote_set_id="set1",
+        emotes=emotes,
+    )
+
+
+async def test_missing_user_permission(restricted_command_info):
+    await copy_7tv_emote(restricted_command_info, "streamer")
+    assert_reply_embed(restricted_command_info)
+
+
+async def test_missing_bot_permission(admin_command_info):
+    admin_command_info.channel.permissions_for = MagicMock(
+        return_value=make_permissions(administrator=True, manage_emojis=True)
+    )
+    admin_command_info.guild.me.guild_permissions = make_permissions(manage_emojis=False)
+    await copy_7tv_emote(admin_command_info, "streamer")
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.admin.copy_7tv_emote.get_seventv_service")
+async def test_user_not_found(mock_get_service, emoji_command_info):
+    mock_service = MagicMock()
+    mock_service.get_user_by_twitch = AsyncMock(return_value=None)
+    mock_get_service.return_value = mock_service
+    await copy_7tv_emote(emoji_command_info, "unknown")
+    assert_reply_embed(emoji_command_info)
+
+
+@patch("commands.admin.copy_7tv_emote.get_seventv_service")
+async def test_success(mock_get_service, emoji_command_info):
+    mock_service = MagicMock()
+    mock_service.get_user_by_twitch = AsyncMock(return_value=_seventv_user())
+    mock_get_service.return_value = mock_service
+    await copy_7tv_emote(emoji_command_info, "streamer")
+    emoji_command_info.reply.assert_awaited_once()
+    assert emoji_command_info.reply.await_args.kwargs.get("embed") is not None
+    assert emoji_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+@patch("commands.admin.copy_7tv_emote.get_seventv_service")
+async def test_empty_emotes(mock_get_service, emoji_command_info):
+    user = _seventv_user(emote_count=0)
+    mock_service = MagicMock()
+    mock_service.get_user_by_twitch = AsyncMock(return_value=user)
+    mock_get_service.return_value = mock_service
+    await copy_7tv_emote(emoji_command_info, "streamer")
+    assert_reply_embed(emoji_command_info)

--- a/tests/integration/commands/fun/test_funcommands.py
+++ b/tests/integration/commands/fun/test_funcommands.py
@@ -1,5 +1,3 @@
-"""Integration tests for commands.fun.funcommands."""
-
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
@@ -7,35 +5,36 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from commands.fun.funcommands import fun_command as command_fn
-from tests.helpers.discord import make_command_info, make_member
-from tests.integration.commands.conftest import embed_from_reply
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_member
+
+pytestmark = pytest.mark.asyncio
+
+FUN_ACTIONS = ["hug", "kiss", "boop", "wave", "slap", "laugh", "tickle", "pat", "poke"]
 
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("action", FUN_ACTIONS)
 @patch("commands.fun.funcommands.utility.getGif", new_callable=AsyncMock)
-async def test_fun_poke(mock_gif):
+async def test_fun_action_with_gif(mock_gif, action, admin_command_info):
     mock_gif.return_value = ["https://example.com/gif.gif"]
-    info = make_command_info()
-    target = make_member(user_id=222, name="Target")
-    await command_fn(info, "poke", target, None)
-    embed_from_reply(info.reply)
+    target = make_member(user_id=222222222, name="Target")
+    await command_fn(admin_command_info, action, target, None)
+    assert_reply_embed(admin_command_info)
 
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("action", FUN_ACTIONS)
 @patch("commands.fun.funcommands.utility.getGif", new_callable=AsyncMock)
-async def test_fun_wave_no_gif(mock_gif):
+async def test_fun_action_no_gif(mock_gif, action, admin_command_info):
     mock_gif.return_value = []
-    info = make_command_info()
-    target = make_member(user_id=222, name="Target")
-    await command_fn(info, "wave", target, "hello")
-    embed_from_reply(info.reply)
+    target = make_member(user_id=222222222, name="Target")
+    await command_fn(admin_command_info, action, target, None)
+    assert_reply_embed(admin_command_info)
 
 
-@pytest.mark.asyncio
+@pytest.mark.parametrize("action", FUN_ACTIONS)
 @patch("commands.fun.funcommands.utility.getGif", new_callable=AsyncMock)
-async def test_fun_with_message(mock_gif):
+async def test_fun_action_with_message(mock_gif, action, admin_command_info):
     mock_gif.return_value = ["https://example.com/g.gif"]
-    info = make_command_info()
     target = make_member()
-    await command_fn(info, "hug", target, "thanks")
-    embed_from_reply(info.reply)
+    await command_fn(admin_command_info, action, target, "hello")
+    assert_reply_embed(admin_command_info)

--- a/tests/integration/commands/fun/test_funcommands.py
+++ b/tests/integration/commands/fun/test_funcommands.py
@@ -38,3 +38,19 @@ async def test_fun_action_with_message(mock_gif, action, admin_command_info):
     target = make_member()
     await command_fn(admin_command_info, action, target, "hello")
     assert_reply_embed(admin_command_info)
+
+
+@patch("commands.fun.funcommands.utility.getGif", new_callable=AsyncMock)
+async def test_fun_action_member_without_admin_permissions(mock_gif, restricted_command_info):
+    mock_gif.return_value = []
+    target = make_member(user_id=222222222, name="Target")
+    await command_fn(restricted_command_info, "hug", target, None)
+    assert_reply_embed(restricted_command_info)
+
+
+@patch("commands.fun.funcommands.utility.getGif", new_callable=AsyncMock)
+async def test_fun_invalid_action_still_replies(mock_gif, admin_command_info):
+    mock_gif.return_value = []
+    target = make_member(user_id=222222222, name="Target")
+    await command_fn(admin_command_info, "invalid_action", target, None)
+    assert_reply_embed(admin_command_info)

--- a/tests/integration/commands/games/test_advanced_tic_tac_toe.py
+++ b/tests/integration/commands/games/test_advanced_tic_tac_toe.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from commands.games.advanced_tic_tac_toe import advanced_tic_tac_toe
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_member
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_advanced_tic_tac_toe_vs_bot(admin_command_info):
+    player = make_member(user_id=admin_command_info.user.id, name="Player")
+    await advanced_tic_tac_toe(admin_command_info, player)
+    admin_command_info.reply.assert_awaited_once()
+    assert admin_command_info.reply.await_args.kwargs.get("embed") is not None
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+async def test_advanced_tic_tac_toe_two_players(admin_command_info):
+    player1 = make_member(user_id=admin_command_info.user.id, name="Player1")
+    player2 = make_member(user_id=222222222, name="Player2")
+    await advanced_tic_tac_toe(admin_command_info, player1, player2)
+    assert_reply_embed(admin_command_info)
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None

--- a/tests/integration/commands/games/test_battleship.py
+++ b/tests/integration/commands/games/test_battleship.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from commands.games.battleship import battleship
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_member
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_battleship_vs_bot(admin_command_info):
+    player = make_member(user_id=admin_command_info.user.id, name="Player")
+    await battleship(admin_command_info, player)
+    admin_command_info.reply.assert_awaited_once()
+    assert admin_command_info.reply.await_args.kwargs.get("embed") is not None
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+async def test_battleship_two_players(admin_command_info):
+    player1 = make_member(user_id=admin_command_info.user.id, name="Player1")
+    player2 = make_member(user_id=222222222, name="Player2")
+    await battleship(admin_command_info, player1, player2)
+    assert_reply_embed(admin_command_info)
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None

--- a/tests/integration/commands/games/test_memory.py
+++ b/tests/integration/commands/games/test_memory.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from commands.games.memory import memory
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_member
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_memory_starts_game(admin_command_info):
+    player = make_member(user_id=admin_command_info.user.id, name="Player")
+    await memory(admin_command_info, player)
+    admin_command_info.reply.assert_awaited_once()
+    assert admin_command_info.reply.await_args.kwargs.get("embed") is not None
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+async def test_memory_embed_content(admin_command_info):
+    player = make_member(user_id=admin_command_info.user.id, name="Player")
+    await memory(admin_command_info, player)
+    assert_reply_embed(admin_command_info)

--- a/tests/integration/commands/logs/blacklist_category/test_blacklist_category.py
+++ b/tests/integration/commands/logs/blacklist_category/test_blacklist_category.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.logs.blacklist_category.blacklist_category import blacklist_category as command_fn
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_category(channel_id: int = 555555555) -> MagicMock:
+    channel = MagicMock()
+    channel.id = channel_id
+    return channel
+
+
+async def test_missing_permission(restricted_command_info):
+    await command_fn(restricted_command_info, _make_category())
+    assert_reply_embed(restricted_command_info)
+
+
+@patch("commands.logs.blacklist_category.blacklist_category.is_log_entity_blacklisted", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_category.blacklist_category.add_log_blacklist", new_callable=AsyncMock)
+async def test_success(mock_add, mock_is, admin_command_info):
+    mock_is.return_value = False
+    await command_fn(admin_command_info, _make_category())
+    assert_reply_embed(admin_command_info)
+    mock_add.assert_awaited_once()
+
+
+@patch("commands.logs.blacklist_category.blacklist_category.is_log_entity_blacklisted", new_callable=AsyncMock)
+async def test_already_blacklisted(mock_is, admin_command_info):
+    mock_is.return_value = True
+    await command_fn(admin_command_info, _make_category())
+    assert_reply_embed(admin_command_info)

--- a/tests/integration/commands/logs/blacklist_category/test_blacklist_list_category.py
+++ b/tests/integration/commands/logs/blacklist_category/test_blacklist_list_category.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.logs.blacklist_category.blacklist_list_category import blacklist_list_category
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+@patch("commands.logs.blacklist_category.blacklist_list_category.get_log_blacklist", new_callable=AsyncMock)
+async def test_missing_permission(mock_get, restricted_command_info):
+    await blacklist_list_category(restricted_command_info)
+    assert_reply_embed(restricted_command_info)
+    mock_get.assert_not_called()
+
+
+@patch("commands.logs.blacklist_category.blacklist_list_category.get_log_blacklist", new_callable=AsyncMock)
+async def test_empty(mock_get, admin_command_info):
+    mock_get.return_value = []
+    await blacklist_list_category(admin_command_info)
+    assert_reply_embed(admin_command_info)
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+@patch("commands.logs.blacklist_category.blacklist_list_category.get_log_blacklist", new_callable=AsyncMock)
+async def test_with_entries(mock_get, admin_command_info):
+    mock_get.return_value = ["111111111", "222222222"]
+    await blacklist_list_category(admin_command_info)
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.logs.blacklist_category.blacklist_list_category.remove_log_blacklist", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_category.blacklist_list_category.get_log_blacklist", new_callable=AsyncMock)
+async def test_remove_button(mock_get, mock_remove, admin_command_info):
+    mock_get.return_value = ["111111111"]
+    await blacklist_list_category(admin_command_info)
+    view = admin_command_info.reply.await_args.kwargs["view"]
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view.remove_category(interaction, MagicMock())
+    mock_remove.assert_awaited_once()
+
+
+@patch("commands.logs.blacklist_category.blacklist_list_category.add_log_blacklist", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_category.blacklist_list_category.get_log_blacklist", new_callable=AsyncMock)
+async def test_add_via_select(mock_get, mock_add, admin_command_info):
+    mock_get.return_value = []
+    await blacklist_list_category(admin_command_info)
+    view = admin_command_info.reply.await_args.kwargs["view"]
+    interaction = MagicMock()
+    interaction.data = {"component_type": 8, "values": ["333333333"]}
+    interaction.response.edit_message = AsyncMock()
+    await view.interaction_check(interaction)
+    mock_add.assert_awaited_once()

--- a/tests/integration/commands/logs/blacklist_category/test_blacklist_remove_category.py
+++ b/tests/integration/commands/logs/blacklist_category/test_blacklist_remove_category.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from commands.logs.blacklist_category.blacklist_remove_category import blacklist_remove_category
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_permissions
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_category() -> MagicMock:
+    channel = MagicMock()
+    channel.id = 555555555
+    return channel
+
+
+@patch("commands.logs.blacklist_category.blacklist_remove_category.isinstance")
+async def test_missing_permission(mock_isinstance, admin_command_info):
+    mock_isinstance.side_effect = lambda obj, cls: cls is discord.Member or cls is discord.abc.GuildChannel
+    admin_command_info.channel.permissions_for = MagicMock(return_value=make_permissions(administrator=False))
+    await blacklist_remove_category(admin_command_info, _make_category())
+    assert_reply_embed(admin_command_info)
+
+
+@patch(
+    "commands.logs.blacklist_category.blacklist_remove_category.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=False,
+)
+async def test_not_blacklisted(mock_is, admin_command_info):
+    await blacklist_remove_category(admin_command_info, _make_category())
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.logs.blacklist_category.blacklist_remove_category.remove_log_blacklist", new_callable=AsyncMock)
+@patch(
+    "commands.logs.blacklist_category.blacklist_remove_category.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+async def test_success(mock_is, mock_remove, admin_command_info):
+    await blacklist_remove_category(admin_command_info, _make_category())
+    assert_reply_embed(admin_command_info)
+    mock_remove.assert_awaited_once()

--- a/tests/integration/commands/logs/blacklist_user/test_blacklist_remove_user.py
+++ b/tests/integration/commands/logs/blacklist_user/test_blacklist_remove_user.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from commands.logs.blacklist_user.blacklist_remove_user import blacklist_remove_user
+from tests.helpers.assertions import assert_reply_embed
+from tests.helpers.discord import make_permissions
+from tests.integration.commands.conftest import make_user
+
+pytestmark = pytest.mark.asyncio
+
+
+@patch("commands.logs.blacklist_user.blacklist_remove_user.isinstance")
+async def test_missing_permission(mock_isinstance, admin_command_info):
+    mock_isinstance.side_effect = lambda obj, cls: cls is discord.Member or cls is discord.abc.GuildChannel
+    admin_command_info.channel.permissions_for = MagicMock(return_value=make_permissions(administrator=False))
+    await blacklist_remove_user(admin_command_info, make_user())
+    assert_reply_embed(admin_command_info)
+
+
+@patch(
+    "commands.logs.blacklist_user.blacklist_remove_user.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=False,
+)
+async def test_not_blacklisted(mock_is, admin_command_info):
+    await blacklist_remove_user(admin_command_info, make_user())
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.logs.blacklist_user.blacklist_remove_user.remove_log_blacklist", new_callable=AsyncMock)
+@patch(
+    "commands.logs.blacklist_user.blacklist_remove_user.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+async def test_success(mock_is, mock_remove, admin_command_info):
+    await blacklist_remove_user(admin_command_info, make_user())
+    assert_reply_embed(admin_command_info)
+    mock_remove.assert_awaited_once()

--- a/tests/integration/commands/logs/blacklist_voice/test_blacklist_list_voice.py
+++ b/tests/integration/commands/logs/blacklist_voice/test_blacklist_list_voice.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.logs.blacklist_voice.blacklist_list_voice import blacklist_list_voice
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.get_log_blacklist", new_callable=AsyncMock)
+async def test_missing_permission(mock_get, restricted_command_info):
+    await blacklist_list_voice(restricted_command_info)
+    assert_reply_embed(restricted_command_info)
+    mock_get.assert_not_called()
+
+
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.get_log_blacklist", new_callable=AsyncMock)
+async def test_empty(mock_get, admin_command_info):
+    mock_get.return_value = []
+    await blacklist_list_voice(admin_command_info)
+    assert_reply_embed(admin_command_info)
+    assert admin_command_info.reply.await_args.kwargs.get("view") is not None
+
+
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.get_log_blacklist", new_callable=AsyncMock)
+async def test_with_entries(mock_get, admin_command_info):
+    mock_get.return_value = ["777777777", "888888888"]
+    await blacklist_list_voice(admin_command_info)
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.remove_log_blacklist", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.get_log_blacklist", new_callable=AsyncMock)
+async def test_remove_button(mock_get, mock_remove, admin_command_info):
+    mock_get.return_value = ["777777777"]
+    await blacklist_list_voice(admin_command_info)
+    view = admin_command_info.reply.await_args.kwargs["view"]
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    await view.remove_channel(interaction, MagicMock())
+    mock_remove.assert_awaited_once()
+
+
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.add_log_blacklist", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_voice.blacklist_list_voice.get_log_blacklist", new_callable=AsyncMock)
+async def test_add_via_select(mock_get, mock_add, admin_command_info):
+    mock_get.return_value = []
+    await blacklist_list_voice(admin_command_info)
+    view = admin_command_info.reply.await_args.kwargs["view"]
+    interaction = MagicMock()
+    interaction.data = {"component_type": 8, "values": ["999999999"]}
+    interaction.response.edit_message = AsyncMock()
+    await view.interaction_check(interaction)
+    mock_add.assert_awaited_once()

--- a/tests/integration/commands/logs/blacklist_voice/test_blacklist_remove_voice.py
+++ b/tests/integration/commands/logs/blacklist_voice/test_blacklist_remove_voice.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.logs.blacklist_voice.blacklist_remove_voice import blacklist_remove_voice
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_voice_channel() -> MagicMock:
+    channel = MagicMock()
+    channel.id = 666666666
+    return channel
+
+
+async def test_missing_permission(restricted_command_info):
+    await blacklist_remove_voice(restricted_command_info, _make_voice_channel())
+    assert_reply_embed(restricted_command_info)
+
+
+@patch(
+    "commands.logs.blacklist_voice.blacklist_remove_voice.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=False,
+)
+async def test_not_blacklisted(mock_is, admin_command_info):
+    await blacklist_remove_voice(admin_command_info, _make_voice_channel())
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.logs.blacklist_voice.blacklist_remove_voice.remove_log_blacklist", new_callable=AsyncMock)
+@patch(
+    "commands.logs.blacklist_voice.blacklist_remove_voice.is_log_entity_blacklisted",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+async def test_success(mock_is, mock_remove, admin_command_info):
+    await blacklist_remove_voice(admin_command_info, _make_voice_channel())
+    assert_reply_embed(admin_command_info)
+    mock_remove.assert_awaited_once()

--- a/tests/integration/commands/logs/blacklist_voice/test_blacklist_voice.py
+++ b/tests/integration/commands/logs/blacklist_voice/test_blacklist_voice.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from commands.logs.blacklist_voice.blacklist_voice import blacklist_voice as command_fn
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_voice_channel(channel_id: int = 666666666) -> MagicMock:
+    channel = MagicMock()
+    channel.id = channel_id
+    return channel
+
+
+async def test_missing_permission(restricted_command_info):
+    await command_fn(restricted_command_info, _make_voice_channel())
+    assert_reply_embed(restricted_command_info)
+
+
+@patch("commands.logs.blacklist_voice.blacklist_voice.is_log_entity_blacklisted", new_callable=AsyncMock)
+@patch("commands.logs.blacklist_voice.blacklist_voice.add_log_blacklist", new_callable=AsyncMock)
+async def test_success(mock_add, mock_is, admin_command_info):
+    mock_is.return_value = False
+    await command_fn(admin_command_info, _make_voice_channel())
+    assert_reply_embed(admin_command_info)
+    mock_add.assert_awaited_once()
+
+
+@patch("commands.logs.blacklist_voice.blacklist_voice.is_log_entity_blacklisted", new_callable=AsyncMock)
+async def test_already_blacklisted(mock_is, admin_command_info):
+    mock_is.return_value = True
+    await command_fn(admin_command_info, _make_voice_channel())
+    assert_reply_embed(admin_command_info)

--- a/tests/integration/commands/utility/brawlstars/test_link.py
+++ b/tests/integration/commands/utility/brawlstars/test_link.py
@@ -71,3 +71,11 @@ async def test_link_adds_hash_prefix(mock_service, admin_command_info):
             await link(admin_command_info, "ABC123")
             mock_add.assert_awaited_once()
             assert mock_add.await_args.args[1] == "#ABC123"
+
+
+def test_bshelper_emoji_helpers_return_strings() -> None:
+    from commands.utility.brawlstars.bshelper import getLevelEmoji, getStarPowerEmoji, parseName
+
+    assert isinstance(getLevelEmoji(1), str)
+    assert isinstance(getStarPowerEmoji(1), str)
+    assert parseName("test-name") == "Test Name"

--- a/tests/integration/commands/utility/brawlstars/test_link.py
+++ b/tests/integration/commands/utility/brawlstars/test_link.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.brawlstars import BrawlStarsClub, BrawlStarsPlayer
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _player(**kwargs):
+    defaults = {
+        "tag": "#ABC123",
+        "name": "TestPlayer",
+        "trophies": 5000,
+        "highest_trophies": 6000,
+        "exp_level": 50,
+        "x3vs3_victories": 100,
+        "solo_victories": 50,
+        "duo_victories": 25,
+        "club": BrawlStarsClub(tag="#CLUB1", name="TestClub"),
+        "brawlers": [],
+        "name_color": None,
+    }
+    defaults.update(kwargs)
+    return BrawlStarsPlayer(**defaults)
+
+
+@patch("commands.utility.brawlstars.link.get_brawlstars_linked_account", new_callable=AsyncMock)
+@patch("commands.utility.brawlstars.link.add_brawlstars_linked_account", new_callable=AsyncMock)
+@patch("commands.utility.brawlstars.link.get_brawlstars_service")
+async def test_link_success(mock_service, mock_add, mock_linked, admin_command_info):
+    from commands.utility.brawlstars.link import link
+
+    mock_linked.return_value = None
+    mock_service.return_value.get_player = AsyncMock(return_value=_player())
+    await link(admin_command_info, "ABC123")
+    assert_reply_embed(admin_command_info)
+    mock_add.assert_awaited_once()
+
+
+@patch("commands.utility.brawlstars.link.get_brawlstars_service")
+async def test_link_not_found(mock_service, admin_command_info):
+    from commands.utility.brawlstars.link import link
+
+    mock_service.return_value.get_player = AsyncMock(return_value=None)
+    await link(admin_command_info, "INVALID")
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.link.get_brawlstars_linked_account", new_callable=AsyncMock)
+@patch("commands.utility.brawlstars.link.get_brawlstars_service")
+async def test_link_already_linked(mock_service, mock_linked, admin_command_info):
+    from commands.utility.brawlstars.link import link
+
+    mock_linked.return_value = "#EXISTING"
+    mock_service.return_value.get_player = AsyncMock(return_value=_player())
+    await link(admin_command_info, "ABC123")
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.link.get_brawlstars_service")
+async def test_link_adds_hash_prefix(mock_service, admin_command_info):
+    from commands.utility.brawlstars.link import link
+
+    mock_service.return_value.get_player = AsyncMock(return_value=_player())
+    with patch("commands.utility.brawlstars.link.get_brawlstars_linked_account", new=AsyncMock(return_value=None)):
+        with patch("commands.utility.brawlstars.link.add_brawlstars_linked_account", new=AsyncMock()) as mock_add:
+            await link(admin_command_info, "ABC123")
+            mock_add.assert_awaited_once()
+            assert mock_add.await_args.args[1] == "#ABC123"

--- a/tests/integration/commands/utility/brawlstars/test_playerinfo.py
+++ b/tests/integration/commands/utility/brawlstars/test_playerinfo.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.brawlstars import BrawlStarPlayerBrawler, BrawlStarsClub, BrawlStarsPlayer
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+def _player(**kwargs):
+    defaults = {
+        "tag": "#ABC123",
+        "name": "TestPlayer",
+        "trophies": 5000,
+        "highest_trophies": 6000,
+        "exp_level": 50,
+        "x3vs3_victories": 100,
+        "solo_victories": 50,
+        "duo_victories": 25,
+        "club": BrawlStarsClub(tag="#CLUB1", name="TestClub"),
+        "brawlers": [],
+        "name_color": None,
+    }
+    defaults.update(kwargs)
+    return BrawlStarsPlayer(**defaults)
+
+
+@patch("commands.utility.brawlstars.playerinfo.get_brawlstars_linked_account", new_callable=AsyncMock)
+async def test_playerinfo_not_linked(mock_linked, admin_command_info):
+    from commands.utility.brawlstars.playerinfo import player_info
+
+    mock_linked.return_value = None
+    await player_info(admin_command_info)
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.playerinfo.get_brawlstars_service")
+async def test_playerinfo_not_found(mock_service, admin_command_info):
+    from commands.utility.brawlstars.playerinfo import player_info
+
+    mock_service.return_value.get_player = AsyncMock(return_value=None)
+    await player_info(admin_command_info, "#INVALID")
+    admin_command_info.reply.assert_awaited_once()
+
+
+@patch("commands.utility.brawlstars.playerinfo.get_brawlstars_service")
+async def test_playerinfo_success(mock_service, admin_command_info):
+    from commands.utility.brawlstars.playerinfo import player_info
+
+    mock_service.return_value.get_player = AsyncMock(return_value=_player())
+    mock_service.return_value.get_brawler_list = AsyncMock(return_value=[BrawlStarPlayerBrawler(id=1, name="Shelly")])
+    await player_info(admin_command_info, "#ABC123")
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.playerinfo.get_brawlstars_linked_account", new_callable=AsyncMock)
+async def test_playerinfo_mention_not_linked(mock_linked, admin_command_info):
+    from commands.utility.brawlstars.playerinfo import player_info
+
+    mock_linked.return_value = None
+    await player_info(admin_command_info, "<@222222222>")
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.playerinfo.get_brawlstars_service")
+async def test_playerinfo_adds_hash_prefix(mock_service, admin_command_info):
+    from commands.utility.brawlstars.playerinfo import player_info
+
+    mock_service.return_value.get_player = AsyncMock(return_value=_player())
+    mock_service.return_value.get_brawler_list = AsyncMock(return_value=[])
+    await player_info(admin_command_info, "ABC123")
+    mock_service.return_value.get_player.assert_awaited_once_with("#ABC123")

--- a/tests/integration/commands/utility/brawlstars/test_unlink.py
+++ b/tests/integration/commands/utility/brawlstars/test_unlink.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.helpers.assertions import assert_reply_embed
+
+pytestmark = pytest.mark.asyncio
+
+
+@patch("commands.utility.brawlstars.unlink.get_brawlstars_linked_account", new_callable=AsyncMock)
+async def test_unlink_not_linked(mock_linked, admin_command_info):
+    from commands.utility.brawlstars.unlink import unlink
+
+    mock_linked.return_value = None
+    await unlink(admin_command_info)
+    assert_reply_embed(admin_command_info)
+
+
+@patch("commands.utility.brawlstars.unlink.remove_brawlstars_linked_account", new_callable=AsyncMock)
+@patch("commands.utility.brawlstars.unlink.get_brawlstars_linked_account", new_callable=AsyncMock)
+async def test_unlink_success(mock_linked, mock_remove, admin_command_info):
+    from commands.utility.brawlstars.unlink import unlink
+
+    mock_linked.return_value = "#ABC123"
+    await unlink(admin_command_info)
+    assert_reply_embed(admin_command_info)
+    mock_remove.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add dedicated integration tests for 14 previously untested command modules
- Logs blacklist category/voice/user remove commands with permission + success paths
- Brawl Stars link/playerinfo/unlink, copy_7tv_emote, memory/battleship/advanced tic-tac-toe
- Expand fun commands to parametrize all 9 actions × 3 scenarios (27 tests)

## Test plan
- [x] `pytest tests/integration/commands/logs/blacklist_category/ tests/integration/commands/logs/blacklist_voice/ tests/integration/commands/utility/brawlstars/test_link.py tests/integration/commands/fun/test_funcommands.py` (120 tests)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for admin commands including 7TV emote copying, fun actions, advanced tic-tac-toe, battleship, memory game, and blacklist management across multiple categories.
  * Added integration tests for Brawl Stars utility commands (link, playerinfo, unlink) with comprehensive scenario coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->