### PR TITLE
Fix mypy typing errors - batch 1: remove unused ignores and redundant casts

### DIFF
--- a/commands/games/advanced_tic_tac_toe.py
+++ b/commands/games/advanced_tic_tac_toe.py
@@ -18,7 +18,7 @@ class AdvancedTicTacToe:
 
     def __init__(self, player1: discord.Member, player2: discord.Member | None = None) -> None:
         self.player1 = player1
-        self.player2 = player2 or "tanjun"  # type: ignore[assignment]
+        self.player2 = player2 or "tanjun"
         # boards[meta_row][meta_col] is a 3x3 list of sub-board cells
         self.boards: list[list[list[list[str]]]] = [
             [  # meta_row
@@ -128,10 +128,10 @@ class AdvancedTicTacToe:
         return True
 
     def toggle_turn(self) -> None:
-        if self.player2 == "tanjun" or (hasattr(self.player2, "bot") and self.player2.bot):  # type: ignore[union-attr]
+        if self.player2 == "tanjun" or (hasattr(self.player2, "bot") and self.player2.bot):
             self.current_player = self.player1
         else:
-            self.current_player = self.player2 if self.current_player == self.player1 else self.player1  # type: ignore[assignment]
+            self.current_player = self.player2 if self.current_player == self.player1 else self.player1
 
     def get_valid_moves(self) -> list[tuple[int, int, int, int]]:
         """Return list of (meta_row, meta_col, sub_row, sub_col) valid moves."""
@@ -265,7 +265,7 @@ class AdvancedTicTacToe:
             await interaction.followup.edit_message(
                 message_id=interaction.message.id,
                 view=view,
-                embed=embed,  # type: ignore[union-attr]
+                embed=embed,
             )
 
     def get_board_view(self, timeout: int = 3600, disable_on_timeout: bool = True) -> discord.ui.View:
@@ -397,7 +397,7 @@ class AdvancedTicTacToe:
                     if not self.game_over and (
                         self.player2 == "tanjun"
                         or (
-                            hasattr(self.player2, "bot") and self.player2.bot  # type: ignore[union-attr]
+                            hasattr(self.player2, "bot") and self.player2.bot
                         )
                     ):
                         bot_m = self.bot_move()
@@ -437,7 +437,7 @@ async def advanced_tic_tac_toe(
     player2: discord.Member | None = None,
 ) -> None:
     if player2 is None:
-        player2 = "tanjun"  # type: ignore[assignment]
+        player2 = "tanjun"
 
     game = AdvancedTicTacToe(player1, player2)
-    await game.update_board(command_info, initial=True)  # type: ignore[arg-type]
+    await game.update_board(command_info, initial=True)

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -22,7 +22,7 @@ def check_metrics_health() -> bool:
     url = f"http://127.0.0.1:{METRICS_PORT}/health"
     try:
         with urllib.request.urlopen(url, timeout=5) as response:
-            return response.status == 200
+            return bool(response.status == 200)
     except (urllib.error.URLError, TimeoutError, OSError):
         return False
 

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -162,7 +162,7 @@ class ReportService:
         )
         if not current:
             return None
-        old_status = current[0][0]  # type: ignore[no-any-return]
+        old_status = current[0][0]
 
         query = (
             "UPDATE reports SET status = %s, status_updated_at = NOW(), "

--- a/tests/helpers/discord.py
+++ b/tests/helpers/discord.py
@@ -184,34 +184,34 @@ class MockAttachment:
 def _ensure_discord_types() -> None:
     import discord
 
-    discord.Member = MockMember  # type: ignore[misc, assignment]
-    discord.Guild = MockGuild  # type: ignore[misc, assignment]
-    discord.TextChannel = MockTextChannel  # type: ignore[misc, assignment]
-    discord.Role = MockRole  # type: ignore[misc, assignment]
-    discord.VoiceChannel = MockVoiceChannel  # type: ignore[misc, assignment]
+    discord.Member = MockMember
+    discord.Guild = MockGuild
+    discord.TextChannel = MockTextChannel
+    discord.Role = MockRole
+    discord.VoiceChannel = MockVoiceChannel
     if not hasattr(discord, "abc") or discord.abc is None:
-        discord.abc = MagicMock()  # type: ignore[misc, assignment]
-    discord.abc.GuildChannel = MockGuild  # type: ignore[misc, assignment]
-    discord.Forbidden = Forbidden  # type: ignore[misc, assignment]
-    discord.HTTPException = HTTPException  # type: ignore[misc, assignment]
-    discord.NotFound = NotFound  # type: ignore[misc, assignment]
-    discord.Embed = FakeEmbed  # type: ignore[misc, assignment]
+        discord.abc = MagicMock()
+    discord.abc.GuildChannel = MockGuild
+    discord.Forbidden = Forbidden
+    discord.HTTPException = HTTPException
+    discord.NotFound = NotFound
+    discord.Embed = FakeEmbed
     if not hasattr(discord, "utils") or discord.utils is None:
-        discord.utils = MagicMock()  # type: ignore[misc, assignment]
-    discord.utils.utcnow = lambda: datetime.now(UTC)  # type: ignore[misc, assignment]
-    discord.utils.get = _mock_discord_get  # type: ignore[misc, assignment]
+        discord.utils = MagicMock()
+    discord.utils.utcnow = lambda: datetime.now(UTC)
+    discord.utils.get = _mock_discord_get
     if not hasattr(discord, "ui") or discord.ui is None:
-        discord.ui = MagicMock()  # type: ignore[misc, assignment]
-    discord.ui.View = MockView  # type: ignore[misc, assignment]
-    discord.ui.Modal = MockModal  # type: ignore[misc, assignment]
-    discord.ui.button = _ui_button  # type: ignore[misc, assignment]
-    discord.ui.TextInput = _ui_item(type("TextInput", (), {}))  # type: ignore[misc, assignment]
-    discord.ui.RoleSelect = _ui_item(type("RoleSelect", (), {}))  # type: ignore[misc, assignment]
-    discord.ui.UserSelect = _ui_item(type("UserSelect", (), {}))  # type: ignore[misc, assignment]
-    discord.ui.Button = _ui_item(type("Button", (), {}))  # type: ignore[misc, assignment]
-    discord.Attachment = MockAttachment  # type: ignore[misc, assignment]
-    discord.Color = MockColor  # type: ignore[misc, assignment]
-    discord.Thread = type("Thread", (), {})  # type: ignore[misc, assignment]
+        discord.ui = MagicMock()
+    discord.ui.View = MockView
+    discord.ui.Modal = MockModal
+    discord.ui.button = _ui_button
+    discord.ui.TextInput = _ui_item(type("TextInput", (), {}))
+    discord.ui.RoleSelect = _ui_item(type("RoleSelect", (), {}))
+    discord.ui.UserSelect = _ui_item(type("UserSelect", (), {}))
+    discord.ui.Button = _ui_item(type("Button", (), {}))
+    discord.Attachment = MockAttachment
+    discord.Color = MockColor
+    discord.Thread = type("Thread", (), {})
 
 
 _ensure_discord_types()

--- a/tests/helpers/extension_loader.py
+++ b/tests/helpers/extension_loader.py
@@ -40,7 +40,7 @@ def make_bot_for_extensions(pool: MagicMock | None = None) -> MagicMock:
     bot._pool = pool or MagicMock()
     bot._pool_ready = asyncio.Event()
     bot._pool_ready.set()
-    bot._tree_commands = []  # type: ignore[misc]
+    bot._tree_commands = []
 
     def _add_command(cmd: Any) -> None:
         bot._tree_commands.append(cmd)
@@ -52,7 +52,7 @@ def make_bot_for_extensions(pool: MagicMock | None = None) -> MagicMock:
     bot.tree.walk_commands = MagicMock(return_value=[])
     bot.tree.on_error = None
     bot.load_extension = AsyncMock()
-    bot.cogs = {}  # type: ignore[misc]
+    bot.cogs = {}
     bot.loop = MagicMock()
     bot.loop.create_task = MagicMock(return_value=MagicMock(done=lambda: False))
 

--- a/tests/helpers/factories.py
+++ b/tests/helpers/factories.py
@@ -41,7 +41,7 @@ def giveaway_row(**overrides: int | tuple) -> tuple:
         return base
     data = list(base)
     for idx, val in overrides.items():
-        data[int(idx)] = val  # type: ignore[call-overload]
+        data[int(idx)] = val
     return tuple(data)
 
 
@@ -51,7 +51,7 @@ def warning_row(**overrides: int | tuple) -> tuple:
         return base
     data = list(base)
     for idx, val in overrides.items():
-        data[int(idx)] = val  # type: ignore[call-overload]
+        data[int(idx)] = val
     return tuple(data)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,7 @@ def pytest_configure(config: pytest.Config) -> None:
     def _choice(**kwargs: object) -> object:
         return type("Choice", (), kwargs)()
 
-    discord.app_commands.Choice = _choice  # type: ignore[attr-defined]
+    discord.app_commands.Choice = _choice
     _ensure_discord_types()
 
 
@@ -25,4 +25,4 @@ def _reset_discord_types() -> None:
     def _choice(**kwargs: object) -> object:
         return type("Choice", (), kwargs)()
 
-    discord.app_commands.Choice = _choice  # type: ignore[attr-defined]
+    discord.app_commands.Choice = _choice

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -20,7 +20,7 @@ _REQUIRED_COMMAND_GROUPS = {
 }
 
 
-async def test_commands(self: commands.Cog, ctx: commands.Context) -> None:  # type: ignore[type-arg]
+async def test_commands(self: commands.Cog, ctx: commands.Context) -> None:
     """Verify critical commands are registered on the bot's tree."""
     tree = ctx.bot.tree
     if tree is None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 __test__ = False
 
 
-async def test_database(self: commands.Cog, ctx: commands.Context) -> None:  # type: ignore[type-arg]
+async def test_database(self: commands.Cog, ctx: commands.Context) -> None:
     """Verify the bot can query the database."""
     pool = getattr(ctx.bot, "_pool", None)
     if pool is None:

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 __test__ = False
 
 
-async def test_ping(self: commands.Cog, ctx: commands.Context) -> None:  # type: ignore[type-arg]
+async def test_ping(self: commands.Cog, ctx: commands.Context) -> None:
     """Verify the bot responds to a basic ping."""
     start = time.time()
     msg = await ctx.send("ping")

--- a/utils/embeds.py
+++ b/utils/embeds.py
@@ -350,7 +350,7 @@ class TanjunEmbed(BaseModel):
         return self._colour
 
     @colour.setter
-    def colour(self, value: int | discord.Colour | EmbedColor | None) -> None:  # type: ignore[assignment]
+    def colour(self, value: int | discord.Colour | EmbedColor | None) -> None:
         if value is None:
             self._colour = EmbedColor.BRAND.value
         elif isinstance(value, (discord.Colour, EmbedColor)):

--- a/utils/math.py
+++ b/utils/math.py
@@ -130,7 +130,7 @@ class NumericStringParser:
         elif op_token in self.fn:
             fn_val = self.fn[op_token]
             if callable(fn_val):
-                return fn_val(self.evaluate_stack(s))  # type: ignore[operator]
+                return fn_val(self.evaluate_stack(s))
             return fn_val  # float constant
         elif op_token[0].isalpha():
             raise Exception(f"Invalid identifier: {op_token}")
@@ -156,7 +156,7 @@ _operators: _OperatorsT = {
     ast.Div: op.truediv,
     ast.FloorDiv: op.floordiv,
     ast.Pow: op.pow,
-    ast.BitXor: op.xor,  # type: ignore[arg-type]
+    ast.BitXor: op.xor,
     ast.USub: op.neg,
     ast.Mod: op.mod,
 }
@@ -239,7 +239,7 @@ def _eval_ast(node: ast.AST, variables: Mapping[str, float]) -> float:
                 return log_n(*args)
             elif node.func.id == "abs":
                 args = [_eval_ast(arg, variables) for arg in node.args]
-                return cast(float, abs(*args))
+                return abs(*args)
         raise TypeError(f"Unsupported function call: {node.func}")
     elif isinstance(node, ast.Name):
         if node.id in variables:
@@ -277,7 +277,7 @@ def _invert_get_level_for_xp(xp: int, scaling: str) -> int:
     if xp <= 0:
         return 0
     level_func: Callable[[int], int] = _LEVEL_INVERSES.get(scaling, lambda _: 0)
-    level = cast(int, level_func(xp))
+    level = level_func(xp)
     if level < 0:
         return 0
     while get_xp_for_level(level + 1, scaling) <= xp and level < 10000:


### PR DESCRIPTION
Fixes #1862

This batch addresses the first wave of mypy typing errors reported by the automated workflow:

- **unused-ignore:** Removes unused `type: ignore` comments across test files, utils, and services
- **redundant-cast:** Removes redundant `cast(float, ...)` and `cast(int, ...)` calls
- **no-any-return:** Wraps return value in `bool()` for healthcheck metrics

All changes are non-functional (type annotation/ignore cleanup only).

Closes #1862 partially - more batches needed for the remaining ~4300 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality and consistency across multiple modules through internal code refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->