### PR TITLE
fix: include translation key in missing localization GitHub issues

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -439,7 +439,7 @@ class AdministrationCog(commands.Cog):
     async def testgithubauthtoken(self, ctx: commands.Context) -> None:  # type: ignore[type-arg]
         if ctx.author.id not in config.adminIds:
             return
-        await missingLocalization("JUSTATEST.IGNORETHIS.JUSTATEST")
+        await missingLocalization("test", "JUSTATEST.IGNORETHIS.JUSTATEST")
         await ctx.send(
             embed=success_embed(
                 tanjunLocalizer.localize(self._locale(ctx), "commands.admin.administration.github_auth_test"),

--- a/localizer.py
+++ b/localizer.py
@@ -16,7 +16,7 @@ TRANSLATION_NOT_FOUND: str = "err: no translation found."
 
 CACHE_TTL: float = 300.0  # 5 minutes
 
-reported_locales: list[str] = []
+reported_missing: set[tuple[str, str]] = set()
 
 
 class TranslationEntry(BaseModel):
@@ -139,31 +139,31 @@ class LocalizerService:
                 return entry
         return None
 
-    def _report_missing(self, locale_str: str) -> None:
-        """Report a missing locale to the bot so developers can add it."""
-        if locale_str in reported_locales:
+    def _report_missing(self, locale_str: str, key: str) -> None:
+        """Report a missing translation key to the bot so developers can add it."""
+        report_id = (locale_str, key)
+        if report_id in reported_missing:
             return
-        reported_locales.append(locale_str)
+        reported_missing.add(report_id)
         try:
-            task = asyncio.create_task(missingLocalization(locale_str))
+            task = asyncio.create_task(missingLocalization(locale_str, key))
 
             def _handle_task_exception(t: asyncio.Task[Any]) -> None:
                 if t.cancelled():
                     return
                 exc = t.exception()
                 if exc is not None:
-                    print(f"Exception in missingLocalization task for locale '{locale_str}': {exc}")
+                    print(f"Exception in missingLocalization task for key '{key}' in locale '{locale_str}': {exc}")
                     import traceback
 
                     traceback.print_exception(type(exc), exc, exc.__traceback__)
 
             task.add_done_callback(_handle_task_exception)
         except RuntimeError:
-            # No running loop — fall back to blocking call
             try:
-                asyncio.run(missingLocalization(locale_str))
+                asyncio.run(missingLocalization(locale_str, key))
             except Exception as e:
-                print(f"Exception in missingLocalization for locale '{locale_str}': {e}")
+                print(f"Exception in missingLocalization for key '{key}' in locale '{locale_str}': {e}")
 
     # ------------------------------------------------------------------
     # Public API
@@ -240,7 +240,7 @@ class LocalizerService:
 
         if entry is None:
             print(f"No translation found for key '{key}' in locale '{locale_str}'.")
-            self._report_missing(locale_str)
+            self._report_missing(locale_str, key)
             return TRANSLATION_NOT_FOUND
 
         template = Template(entry.translation)

--- a/tests/unit/core/test_localizer.py
+++ b/tests/unit/core/test_localizer.py
@@ -441,21 +441,30 @@ class TestCacheManagement:
 
 class TestReportMissing:
     def test_tracks(self, service: LocalizerService):
-        from localizer import reported_locales
+        from localizer import reported_missing
 
-        reported_locales.clear()
+        reported_missing.clear()
         with patch("localizer.missingLocalization", new_callable=AsyncMock):
-            service._report_missing("xx")
-            assert "xx" in reported_locales
+            service._report_missing("xx", "test.key")
+            assert ("xx", "test.key") in reported_missing
 
     def test_dedup(self, service: LocalizerService):
-        from localizer import reported_locales
+        from localizer import reported_missing
 
-        reported_locales.clear()
+        reported_missing.clear()
         with patch("localizer.missingLocalization", new_callable=AsyncMock):
-            service._report_missing("xx")
-            service._report_missing("xx")
-        assert reported_locales.count("xx") == 1
+            service._report_missing("xx", "test.key")
+            service._report_missing("xx", "test.key")
+        assert len(reported_missing) == 1
+
+    def test_dedup_per_key(self, service: LocalizerService):
+        from localizer import reported_missing
+
+        reported_missing.clear()
+        with patch("localizer.missingLocalization", new_callable=AsyncMock):
+            service._report_missing("xx", "test.key.one")
+            service._report_missing("xx", "test.key.two")
+        assert len(reported_missing) == 2
 
 
 # ===================================================================

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -14,10 +14,11 @@ class TestMissingLocalization:
     async def test_creates_issue_via_run_blocking(self):
         with patch("utils.github.run_blocking", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = None
-            await missingLocalization("de-DE")
+            await missingLocalization("de-DE", "test.key")
             mock_run.assert_called_once()
             args = mock_run.call_args[0]
             assert args[1] == "de-DE"
+            assert args[2] == "test.key"
 
 
 class TestAddFeedback:
@@ -43,11 +44,13 @@ class TestSyncHelpers:
         mock_g.get_repo.return_value = mock_repo
 
         with patch("utils.github.Github", return_value=mock_g):
-            _sync_create_missing_localization_issue("fr-FR")
+            _sync_create_missing_localization_issue("fr-FR", "commands.test.title")
 
         mock_repo.create_issue.assert_called_once()
         call_kwargs = mock_repo.create_issue.call_args[1]
         assert "fr-FR" in call_kwargs["body"]
+        assert "commands.test.title" in call_kwargs["body"]
+        assert "commands.test.title" in call_kwargs["title"]
 
     def test_sync_create_feedback_issue(self):
         from utils.github import _sync_create_feedback_issue

--- a/utils/github.py
+++ b/utils/github.py
@@ -9,18 +9,18 @@ from config import GithubAuthToken
 from utils.async_io import run_blocking
 
 
-async def missingLocalization(locale: str) -> None:  # noqa: N802
+async def missingLocalization(locale: str, key: str) -> None:  # noqa: N802
     """Create a GitHub issue reporting a missing localization."""
-    await run_blocking(_sync_create_missing_localization_issue, locale)
+    await run_blocking(_sync_create_missing_localization_issue, locale, key)
 
 
-def _sync_create_missing_localization_issue(locale: str) -> None:
+def _sync_create_missing_localization_issue(locale: str, key: str) -> None:
     g = Github(GithubAuthToken)
     repo = g.get_repo("TanjunBot/new_tanjun")
     label = repo.get_label("missing localization")
     repo.create_issue(
-        title="Missing localization",
-        body=f"Missing localization for {locale}",
+        title=f"Missing localization: {key} ({locale})",
+        body=f"Missing translation for key `{key}` in locale `{locale}`.",
         labels=[label],
     )
 


### PR DESCRIPTION
## Summary
- Pass the missing translation key through `_report_missing` and `missingLocalization` so GitHub issues identify what needs to be added
- Deduplicate reports by `(locale, key)` instead of locale only, so each missing key gets its own issue
- Update issue title/body to include both key and locale (e.g. `Missing localization: setup.booster.name (bg)`)

## Test plan
- [x] `pytest tests/unit/utils/test_github.py tests/unit/core/test_localizer.py::TestReportMissing -q`
- [ ] Verify a missing translation at runtime creates a GitHub issue with the correct key and locale


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved missing translation reporting to track specific missing translations with better deduplication, reducing noise in diagnostic reports.

* **Tests**
  * Updated tests to validate the improved translation tracking mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->