### PR TITLE
fix: restore CommandInfo.reply dropped in utility refactor

### DIFF
--- a/tests/unit/core/test_utility.py
+++ b/tests/unit/core/test_utility.py
@@ -85,6 +85,7 @@ class TestCommandInfo:
         command = MagicMock()
         message = make_message()
         perms = MagicMock()
+        reply = AsyncMock()
         info = CommandInfo(
             user=make_member(),
             channel=channel,
@@ -93,12 +94,14 @@ class TestCommandInfo:
             locale="de",
             message=message,
             permissions=perms,
+            reply=reply,
             client=client,
         )
         assert info.channel is channel
         assert info.command is command
         assert info.message is message
         assert info.permissions is perms
+        assert info.reply is reply
         assert info.client is client
 
 

--- a/utility.py
+++ b/utility.py
@@ -128,6 +128,7 @@ class CommandInfo:
         self.locale = kwargs.get("locale")
         self.message = kwargs.get("message")
         self.permissions = kwargs.get("permissions")
+        self.reply = kwargs.get("reply")
         self.client = kwargs.get("client")
 
 


### PR DESCRIPTION
## Summary
- Restores the `reply` attribute on `CommandInfo`, which was accidentally dropped when `utility.py` was split into `utils/*` modules
- Fixes `AttributeError: 'CommandInfo' object has no attribute 'reply'` for deferred slash commands (image filters, admin commands, minigames, etc.) that pass `reply=interaction.followup.send`
- Adds test coverage asserting `reply` is stored on `CommandInfo`

## Test plan
- [x] `pytest tests/unit/core/test_utility.py::TestCommandInfo -q`
- [ ] Verify an image command (e.g. `/image findedges`) completes successfully after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command information now captures and stores reply metadata, enabling improved handling and tracking of command replies throughout the system.

* **Tests**
  * Expanded test suite to comprehensively verify that reply information is properly stored and accessible alongside other command metadata fields, ensuring reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->