### PR TITLE
feat: auto-create GitHub issues for unhandled bot exceptions

### DIFF
--- a/extensions/error_handler.py
+++ b/extensions/error_handler.py
@@ -15,6 +15,8 @@ from discord.ext import commands
 from config import sentry_dsn
 from localizer import tanjunLocalizer
 from utility import ErrorEmbedCategory
+from utils.exception_reporter import handle_discord_event_error
+from utils.github import report_bot_exception
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +94,25 @@ class ErrorHandlerCog(commands.Cog):
         """Replace the default tree.on_error with our handler once the bot is ready."""
         self.bot.tree.on_error = self._on_app_command_error
         logger.info("Global app command error handler registered on ready.")
+
+    @commands.Cog.listener()
+    async def on_error(self, event: str, *_args: Any, **_kwargs: Any) -> None:
+        handle_discord_event_error(event, *_args, **_kwargs)
+
+    @staticmethod
+    def _interaction_context(interaction: discord.Interaction) -> dict[str, str]:
+        context: dict[str, str] = {
+            "interaction_id": str(interaction.id),
+            "channel_id": str(interaction.channel_id),
+            "user": str(interaction.user),
+            "user_id": str(interaction.user.id),
+        }
+        if interaction.guild:
+            context["guild"] = interaction.guild.name
+            context["guild_id"] = str(interaction.guild.id)
+        if interaction.command:
+            context["command"] = interaction.command.qualified_name
+        return context
 
     async def _build_error_embed(
         self,
@@ -190,8 +211,12 @@ class ErrorHandlerCog(commands.Cog):
             )
 
         elif isinstance(original, commands.CommandInvokeError):
-            # This shouldn't normally reach here but just in case.
             traceback.print_exception(type(original), original, original.__traceback__)
+            await report_bot_exception(
+                original,
+                source="app_command",
+                context=self._interaction_context(interaction),
+            )
             embed = await self._build_error_embed(
                 interaction,
                 ErrorEmbedCategory.UNEXPECTED,
@@ -255,6 +280,11 @@ class ErrorHandlerCog(commands.Cog):
                 )
 
             traceback.print_exception(type(original), original, original.__traceback__)
+            await report_bot_exception(
+                original,
+                source="app_command",
+                context=self._interaction_context(interaction),
+            )
 
             embed = await self._build_error_embed(
                 interaction,

--- a/extensions/listeners.py
+++ b/extensions/listeners.py
@@ -30,6 +30,7 @@ from minigames.counting_modes import counting as countingModes
 from minigames.wordchain import wordchain
 from services.scheduled_message_service import ScheduledMessageService
 from utils.dispatcher import run_handlers_safe, run_handlers_sequential
+from utils.github import report_bot_exception
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,7 @@ class ListenerCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_interaction(self, interaction: discord.Interaction) -> None:
+        custom_id: str | None = None
         try:
             if not interaction.data:
                 return
@@ -121,8 +123,20 @@ class ListenerCog(commands.Cog):
             locale = interaction.locale  # type: ignore[assignment]
             error_msg = tanjunLocalizer.localize(locale, "listeners.interaction.error.http", status=e.status)
             await self._send_error(interaction, error_msg)
-        except Exception:
+        except Exception as exc:
             logging.exception("Unexpected error in on_interaction listener")
+            await report_bot_exception(
+                exc,
+                source="on_interaction",
+                context={
+                    "custom_id": custom_id,
+                    "interaction_id": str(interaction.id),
+                    "channel_id": str(interaction.channel_id),
+                    "user": str(interaction.user),
+                    "user_id": str(interaction.user.id),
+                    "guild_id": str(interaction.guild_id) if interaction.guild_id else "dm",
+                },
+            )
             locale = interaction.locale  # type: ignore[assignment]
             error_msg = tanjunLocalizer.localize(locale, "listeners.interaction.error.unexpected")
             await self._send_error(interaction, error_msg)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,10 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
+from utils.exception_reporter import handle_asyncio_exception, install_exception_reporter
+
+install_exception_reporter()
+
 import asyncio
 import os
 import sys
@@ -212,6 +216,9 @@ async def _init_database_pool() -> asyncmy.Pool | None:
 async def main() -> None:
     print("starting bot...")
     print("discord.py version: ", discord.__version__)
+
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(handle_asyncio_exception)
 
     # Create pool-ready event before any tasks start
     # so LoopCog.on_ready can wait on it asyncio.Event-style instead of polling

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -4,9 +4,52 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
-from utils.github import addFeedback, missingLocalization
+from utils.github import (
+    addFeedback,
+    missingLocalization,
+    report_bot_exception,
+    report_bot_exception_sync,
+    should_report_exception,
+)
+
+
+class TestShouldReportException:
+    def test_reports_generic_exception(self):
+        assert should_report_exception(RuntimeError("boom")) is True
+
+    def test_skips_forbidden(self):
+        assert should_report_exception(discord.Forbidden(MagicMock(), "missing perms")) is False
+
+    def test_skips_not_found(self):
+        assert should_report_exception(discord.NotFound(MagicMock(), "missing")) is False
+
+
+class TestReportBotException:
+    @pytest.mark.asyncio
+    async def test_reports_via_run_blocking(self):
+        with patch("utils.github.run_blocking", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = None
+            await report_bot_exception(RuntimeError("boom"), source="test")
+            mock_run.assert_called_once()
+
+    def test_sync_reports_when_token_present(self):
+        with patch("utils.github.GithubAuthToken", "token"), patch("utils.github.Github") as mock_github:
+            mock_repo = MagicMock()
+            mock_github.return_value.get_repo.return_value = mock_repo
+            report_bot_exception_sync(RuntimeError("boom"), source="test", context={"command": "/ping"})
+            mock_repo.create_issue.assert_called_once()
+
+    def test_dedup_prevents_duplicate_reports(self):
+        with patch("utils.github.GithubAuthToken", "token"), patch("utils.github.Github") as mock_github:
+            mock_repo = MagicMock()
+            mock_github.return_value.get_repo.return_value = mock_repo
+            exc = RuntimeError("same error")
+            report_bot_exception_sync(exc, source="first")
+            report_bot_exception_sync(exc, source="second")
+            assert mock_repo.create_issue.call_count == 1
 
 
 class TestMissingLocalization:

--- a/utils/exception_reporter.py
+++ b/utils/exception_reporter.py
@@ -1,0 +1,81 @@
+"""Automatic GitHub issue creation for unhandled bot exceptions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Any
+
+from utils.github import report_bot_exception
+
+logger = logging.getLogger(__name__)
+
+_installed = False
+
+
+class GitHubExceptionLogHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno < logging.ERROR or not record.exc_info:
+            return
+
+        _exc_type, exc_value, _tb = record.exc_info
+        if exc_value is None:
+            return
+
+        context: dict[str, Any] = {
+            "logger": record.name,
+            "log_message": record.getMessage(),
+        }
+        _schedule_report(exc_value, source=f"logger:{record.name}", context=context)
+
+
+def _schedule_report(
+    exc: BaseException,
+    *,
+    source: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        from utils.github import report_bot_exception_sync
+
+        report_bot_exception_sync(exc, source=source, context=context)
+        return
+
+    loop.create_task(
+        report_bot_exception(exc, source=source, context=context),
+        name=f"github-report:{source}",
+    )
+
+
+def handle_asyncio_exception(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+    exc = context.get("exception")
+    if isinstance(exc, BaseException):
+        report_context = {
+            "asyncio_message": context.get("message"),
+            "task": repr(context.get("task")),
+        }
+        _schedule_report(exc, source="asyncio", context=report_context)
+        return
+
+    message = context.get("message", "Unknown asyncio error")
+    logger.error("Asyncio error without exception object: %s", message)
+
+
+def handle_discord_event_error(event: str, *_args: Any, **_kwargs: Any) -> None:
+    _exc_type, exc_value, _tb = sys.exc_info()
+    if exc_value is None:
+        return
+    _schedule_report(exc_value, source=f"discord_event:{event}", context={"event": event})
+
+
+def install_exception_reporter() -> None:
+    global _installed
+    if _installed:
+        return
+
+    root = logging.getLogger()
+    root.addHandler(GitHubExceptionLogHandler())
+    _installed = True

--- a/utils/github.py
+++ b/utils/github.py
@@ -3,10 +3,162 @@
 Extracted from ``utility.py`` as part of refactoring (issue #1608).
 """
 
-from github import Github
+from __future__ import annotations
 
-from config import GithubAuthToken
+import hashlib
+import logging
+import time
+import traceback
+from typing import Any
+
+import discord
+from github import Github, GithubException
+
+from config import GithubAuthToken, sentry_environment, version
 from utils.async_io import run_blocking
+
+logger = logging.getLogger(__name__)
+
+_REPO = "TanjunBot/new_tanjun"
+_EXCEPTION_LABELS = ("bug", "bot exception")
+_DEDUP_TTL_SEC = 3600.0
+_recent_reports: dict[str, float] = {}
+
+
+def _is_discord_instance(exc: BaseException, exc_type: Any) -> bool:
+    if not isinstance(exc_type, type):
+        return False
+    return isinstance(exc, exc_type)
+
+
+def should_report_exception(exc: BaseException) -> bool:
+    if _is_discord_instance(exc, discord.Forbidden):
+        return False
+
+    if _is_discord_instance(exc, discord.NotFound):
+        return False
+
+    if _is_discord_instance(exc, discord.HTTPException) and exc.status == 429:
+        return False
+
+    if _is_discord_instance(exc, discord.DiscordException):
+        msg = str(exc).lower()
+        if "10008" in msg and "unknown message" in msg:
+            return False
+
+    return True
+
+
+def _exception_fingerprint(exc: BaseException) -> str:
+    tb_lines = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    location = ""
+    for line in reversed(tb_lines):
+        stripped = line.strip()
+        if stripped.startswith('File "'):
+            location = stripped
+            break
+
+    payload = f"{type(exc).__name__}:{exc!s}:{location}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _dedup_allows_report(fingerprint: str) -> bool:
+    now = time.monotonic()
+    expired = [key for key, seen_at in _recent_reports.items() if now - seen_at >= _DEDUP_TTL_SEC]
+    for key in expired:
+        del _recent_reports[key]
+
+    last_seen = _recent_reports.get(fingerprint)
+    if last_seen is not None and now - last_seen < _DEDUP_TTL_SEC:
+        return False
+
+    _recent_reports[fingerprint] = now
+    return True
+
+
+def _format_context(context: dict[str, Any] | None) -> str:
+    if not context:
+        return "_No additional context._"
+
+    lines = [f"- **{key}:** {value}" for key, value in context.items()]
+    return "\n".join(lines)
+
+
+def _resolve_labels(repo: Any) -> list[Any]:
+    labels = []
+    for label_name in _EXCEPTION_LABELS:
+        try:
+            labels.append(repo.get_label(label_name))
+        except GithubException:
+            continue
+    return labels
+
+
+def _sync_create_bot_exception_issue(
+    exc: BaseException,
+    *,
+    source: str,
+    context: dict[str, Any] | None = None,
+) -> None:
+    if not GithubAuthToken:
+        return
+
+    if not should_report_exception(exc):
+        return
+
+    fingerprint = _exception_fingerprint(exc)
+    if not _dedup_allows_report(fingerprint):
+        return
+
+    tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+    exc_name = type(exc).__name__
+    exc_message = str(exc) or "(no message)"
+    title = f"[Bot Exception] {exc_name} in {source}: {exc_message}"
+    if len(title) > 240:
+        title = title[:237] + "..."
+
+    environment = sentry_environment or "unknown"
+    body = f"""## Bot Exception Report
+
+**Source:** `{source}`
+**Exception:** `{exc_name}: {exc_message}`
+**Version:** `{version}`
+**Environment:** `{environment}`
+
+### Context
+{_format_context(context)}
+
+### Traceback
+```
+{tb}
+```
+"""
+
+    try:
+        g = Github(GithubAuthToken)
+        repo = g.get_repo(_REPO)
+        labels = _resolve_labels(repo)
+        repo.create_issue(title=title, body=body, labels=labels)
+    except Exception as report_error:
+        logger.error("Failed to create GitHub issue for bot exception: %s", report_error)
+
+
+def report_bot_exception_sync(
+    exc: BaseException,
+    *,
+    source: str = "unknown",
+    context: dict[str, Any] | None = None,
+) -> None:
+    _sync_create_bot_exception_issue(exc, source=source, context=context)
+
+
+async def report_bot_exception(
+    exc: BaseException,
+    *,
+    source: str = "unknown",
+    context: dict[str, Any] | None = None,
+) -> None:
+    await run_blocking(_sync_create_bot_exception_issue, exc, source=source, context=context)
 
 
 async def missingLocalization(locale: str, key: str) -> None:  # noqa: N802
@@ -16,7 +168,7 @@ async def missingLocalization(locale: str, key: str) -> None:  # noqa: N802
 
 def _sync_create_missing_localization_issue(locale: str, key: str) -> None:
     g = Github(GithubAuthToken)
-    repo = g.get_repo("TanjunBot/new_tanjun")
+    repo = g.get_repo(_REPO)
     label = repo.get_label("missing localization")
     repo.create_issue(
         title=f"Missing localization: {key} ({locale})",
@@ -32,7 +184,7 @@ async def addFeedback(content: str, author: str) -> None:  # noqa: N802
 
 def _sync_create_feedback_issue(content: str, author: str) -> None:
     g = Github(GithubAuthToken)
-    repo = g.get_repo("TanjunBot/new_tanjun")
+    repo = g.get_repo(_REPO)
     label = repo.get_label("Feedback")
     repo.create_issue(
         title="Feedback",


### PR DESCRIPTION
## Summary
- Automatically files GitHub issues when the bot hits unexpected exceptions, using the existing `GithubAuthToken`
- Covers slash command errors, interaction listener failures, Discord event handler crashes, asyncio task failures, and any `logger.exception(...)` call
- Deduplicates identical errors for 1 hour and skips known Discord noise (403, 404, 429, unknown message races)

## Test plan
- [x] `pytest tests/unit/utils/test_github.py tests/integration/extensions/test_error_handler_comprehensive.py`
- [ ] Deploy with `GithubAuthToken` set and trigger a test exception
- [ ] Confirm a labeled issue appears in `TanjunBot/new_tanjun`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented centralized exception reporting to track unhandled bot errors.
  * Enhanced error handling for Discord interactions and events with structured logging.
  * Added automatic error deduplication to prevent duplicate reports.
  * Improved error filtering to suppress common network-related exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->