### PR TITLE
fix: restore individual /fun subcommands

### DIFF
--- a/extensions/fun.py
+++ b/extensions/fun.py
@@ -7,29 +7,19 @@ from discord.ext import commands
 import utility
 from commands.fun.funcommands import fun_command
 
-FUN_ACTIONS = ["hug", "kiss", "boop", "wave", "slap", "laugh", "tickle", "pat", "poke"]
-
 
 class FunCommands(discord.app_commands.Group):
     @app_commands.command(
-        name=app_commands.locale_str("fun_action_name"),
-        description=app_commands.locale_str("fun_action_description"),
+        name=app_commands.locale_str("fun_hug_name"),
+        description=app_commands.locale_str("fun_hug_description"),
     )
     @app_commands.describe(
-        action=app_commands.locale_str("fun_action_params_action_description"),
-        user=app_commands.locale_str("fun_action_params_member_description"),
-        message=app_commands.locale_str("fun_action_params_message_description"),
+        user=app_commands.locale_str("fun_hug_params_member_description"),
+        message=app_commands.locale_str("fun_hug_params_message_description"),
     )
-    @app_commands.choices(
-        action=[
-            app_commands.Choice(name=app_commands.locale_str(f"fun_action_choice_{action}"), value=action)
-            for action in FUN_ACTIONS
-        ]
-    )
-    async def action(
+    async def hug(
         self,
         interaction: discord.Interaction,
-        action: str,
         user: discord.Member,
         message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
     ) -> None:
@@ -45,8 +35,231 @@ class FunCommands(discord.app_commands.Group):
             reply=interaction.followup.send,
             client=interaction.client,
         )
+        await fun_command(command_info, "hug", user, message)
 
-        await fun_command(command_info, action, user, message)
+    @app_commands.command(
+        name=app_commands.locale_str("fun_kiss_name"),
+        description=app_commands.locale_str("fun_kiss_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_kiss_params_member_description"),
+        message=app_commands.locale_str("fun_kiss_params_message_description"),
+    )
+    async def kiss(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "kiss", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_boop_name"),
+        description=app_commands.locale_str("fun_boop_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_boop_params_member_description"),
+        message=app_commands.locale_str("fun_boop_params_message_description"),
+    )
+    async def boop(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "boop", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_wave_name"),
+        description=app_commands.locale_str("fun_wave_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_wave_params_member_description"),
+        message=app_commands.locale_str("fun_wave_params_message_description"),
+    )
+    async def wave(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "wave", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_slap_name"),
+        description=app_commands.locale_str("fun_slap_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_slap_params_member_description"),
+        message=app_commands.locale_str("fun_slap_params_message_description"),
+    )
+    async def slap(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "slap", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_laugh_name"),
+        description=app_commands.locale_str("fun_laugh_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_laugh_params_member_description"),
+        message=app_commands.locale_str("fun_laugh_params_message_description"),
+    )
+    async def laugh(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "laugh", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_tickle_name"),
+        description=app_commands.locale_str("fun_tickle_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_tickle_params_member_description"),
+        message=app_commands.locale_str("fun_tickle_params_message_description"),
+    )
+    async def tickle(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "tickle", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_pat_name"),
+        description=app_commands.locale_str("fun_pat_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_pat_params_member_description"),
+        message=app_commands.locale_str("fun_pat_params_message_description"),
+    )
+    async def pat(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "pat", user, message)
+
+    @app_commands.command(
+        name=app_commands.locale_str("fun_poke_name"),
+        description=app_commands.locale_str("fun_poke_description"),
+    )
+    @app_commands.describe(
+        user=app_commands.locale_str("fun_poke_params_member_description"),
+        message=app_commands.locale_str("fun_poke_params_message_description"),
+    )
+    async def poke(
+        self,
+        interaction: discord.Interaction,
+        user: discord.Member,
+        message: app_commands.Range[str, 0, 2000] = None,  # type: ignore[assignment]
+    ) -> None:
+        await interaction.response.defer()
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+        await fun_command(command_info, "poke", user, message)
 
 
 class FunCog(commands.Cog):


### PR DESCRIPTION
## Summary
- Restores separate `/fun` subcommands (`hug`, `kiss`, `boop`, `wave`, `slap`, `laugh`, `tickle`, `pat`, `poke`) instead of the consolidated `/fun action` dropdown command
- Reuses existing per-action locale keys; no locale file changes needed

## Test plan
- [x] `pytest tests/integration/commands/fun/test_funcommands.py` passes (29 tests)
- [ ] Run admin sync after deploy so Discord registers the restored subcommands

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fun commands now available as individual dedicated slash commands (`/hug`, `/kiss`, `/boop`, `/wave`, `/slap`, `/laugh`, `/tickle`, `/pat`, `/poke`), replacing the previous generic action command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->