### PR TITLE
fix: prevent duplicate app command registration on reconnect

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 
+from utils.app_command_tree import make_add_command_idempotent
 from utils.exception_reporter import handle_asyncio_exception, install_exception_reporter
 
 install_exception_reporter()
@@ -139,6 +140,7 @@ intents.invites = True
 intents.presences = False
 
 bot = commands.AutoShardedBot(prefix, intents=intents, application_id=config.applicationId)  # type: ignore[arg-type]
+make_add_command_idempotent(bot.tree)
 
 
 def _bot_ready_path() -> Path:

--- a/tests/unit/utils/test_app_command_tree.py
+++ b/tests/unit/utils/test_app_command_tree.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from utils.app_command_tree import make_add_command_idempotent
+
+
+def test_add_command_skips_when_already_registered() -> None:
+    tree = MagicMock()
+    existing = MagicMock()
+    tree.get_command.return_value = existing
+    calls: list[MagicMock] = []
+
+    def original_add(command, /, *, guild=..., guilds=..., override=False):
+        calls.append(command)
+
+    tree.add_command = original_add
+    make_add_command_idempotent(tree)
+
+    command = MagicMock()
+    command.root_parent = None
+    command.name = "levelcommands_name"
+
+    tree.add_command(command)
+
+    tree.get_command.assert_called_once_with("levelcommands_name", guild=None)
+    assert calls == []
+
+
+def test_add_command_registers_when_missing() -> None:
+    tree = MagicMock()
+    tree.get_command.return_value = None
+    calls: list[MagicMock] = []
+
+    def original_add(command, /, *, guild=..., guilds=..., override=False):
+        calls.append(command)
+
+    tree.add_command = original_add
+    make_add_command_idempotent(tree)
+
+    command = MagicMock()
+    command.root_parent = None
+    command.name = "levelcommands_name"
+
+    tree.add_command(command)
+
+    assert calls == [command]

--- a/utils/app_command_tree.py
+++ b/utils/app_command_tree.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def make_add_command_idempotent(tree: Any) -> None:
+    original_add_command = tree.add_command
+
+    def add_command(command: Any, /, **kwargs: Any) -> None:
+        if not kwargs.get("override", False):
+            root = getattr(command, "root_parent", None) or command
+            lookup_guild = kwargs.get("guild") if "guild" in kwargs else None
+            if tree.get_command(root.name, guild=lookup_guild) is not None:
+                return
+        original_add_command(command, **kwargs)
+
+    tree.add_command = add_command


### PR DESCRIPTION
## Summary
- Wrap `bot.tree.add_command` at startup so already-registered slash command groups are skipped instead of raising `CommandAlreadyRegistered`
- Fixes startup errors in extensions (`level`, `image`, `math`, `channel`, `games`, etc.) when `on_ready` runs more than once after a gateway reconnect or redeploy
- Adds a small unit test for the idempotent registration helper

## Test plan
- [x] `pytest tests/unit/utils/test_app_command_tree.py`
- [ ] Restart bot and confirm no `CommandAlreadyRegistered` errors in logs on startup
- [ ] Run `sync` and verify slash commands appear in Discord


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot now automatically prevents duplicate command registrations through idempotent command tree handling.

* **Tests**
  * Added unit tests verifying idempotent command registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->