### PR TITLE
fix: add missing twitch.username localization for Korean locale

### DIFF
--- a/locales/ko.json
+++ b/locales/ko.json
@@ -32200,6 +32200,14 @@
     "max_length": 32
   },
   {
+    "identifier": "twitch.username",
+    "source_string": "twitch_username",
+    "translation": "twitch_username",
+    "context": "The twitch_username param in the copy7tv command",
+    "labels": "command_name, unassigned",
+    "max_length": 32
+  },
+  {
     "identifier": "twitchname",
     "source_string": "twitch_name",
     "translation": "twitch_name",


### PR DESCRIPTION
Closes #2322

Adds the `twitch.username` translation entry to `locales/ko.json`. This key corresponds to the `twitch_username` parameter in the copy7tv command, which Discord maps to `twitch.username` (underscore-to-dot conversion) via the TanjunTranslator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added Korean language support for the Twitch username field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->