### PR TITLE
fix: treat discord MISSING sentinel as None in app command lookup

### DIFF
--- a/utils/app_command_tree.py
+++ b/utils/app_command_tree.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from discord.utils import MISSING
+
 
 def make_add_command_idempotent(tree: Any) -> None:
     original_add_command = tree.add_command
@@ -9,7 +11,9 @@ def make_add_command_idempotent(tree: Any) -> None:
     def add_command(command: Any, /, **kwargs: Any) -> None:
         if not kwargs.get("override", False):
             root = getattr(command, "root_parent", None) or command
-            lookup_guild = kwargs.get("guild") if "guild" in kwargs else None
+            lookup_guild = kwargs.get("guild", MISSING)
+            if lookup_guild is MISSING:
+                lookup_guild = None
             if tree.get_command(root.name, guild=lookup_guild) is not None:
                 return
         original_add_command(command, **kwargs)


### PR DESCRIPTION
## Summary
- Cherry-pick deployment startup fix from development into ver/1.2
- Prevents crash when loading cogs caused by passing `discord.utils.MISSING` as a guild to `CommandTree.get_command`

## Test plan
- [ ] Redeploy ver/1.2 and confirm container passes healthcheck


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command handling logic to correctly process guild argument scenarios, ensuring proper idempotency checks are applied in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->