### PR TITLE
fix: skip guild kwarg when resolving duplicate app commands

### DIFF
--- a/utils/app_command_tree.py
+++ b/utils/app_command_tree.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from discord.utils import MISSING
-
 
 def make_add_command_idempotent(tree: Any) -> None:
     original_add_command = tree.add_command
@@ -11,10 +9,12 @@ def make_add_command_idempotent(tree: Any) -> None:
     def add_command(command: Any, /, **kwargs: Any) -> None:
         if not kwargs.get("override", False):
             root = getattr(command, "root_parent", None) or command
-            lookup_guild = kwargs.get("guild", MISSING)
-            if lookup_guild is MISSING:
-                lookup_guild = None
-            if tree.get_command(root.name, guild=lookup_guild) is not None:
+            lookup_guild = kwargs.get("guild")
+            if lookup_guild is not None and hasattr(lookup_guild, "id"):
+                existing = tree.get_command(root.name, guild=lookup_guild)
+            else:
+                existing = tree.get_command(root.name)
+            if existing is not None:
                 return
         original_add_command(command, **kwargs)
 


### PR DESCRIPTION
## Summary
- Harden idempotent app command registration against `discord.utils.MISSING`
- Only pass `guild` to `CommandTree.get_command` when the value has an `id` attribute (real Snowflake)
- Avoids startup crash when loading cogs such as `extensions.utility`

## Context
The previous fix compared against `MISSING`, but deployed containers were still crashing with the old line numbers. This approach omits the guild kwarg entirely for sentinel/None values, which matches discord.py's global command lookup path.

## Test plan
- [x] Verified `tree.add_command(..., guild=MISSING)` calls `get_command(name)` without guild kwarg
- [ ] Force-rebuild deploy image from latest `ver/1.2` and confirm all extensions load


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command detection logic to improve reliability of command registration tracking in different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->