### PR TITLE
fix: skip guild kwarg when resolving duplicate app commands

### DIFF
--- a/utils/app_command_tree.py
+++ b/utils/app_command_tree.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from discord.utils import MISSING
-
 
 def make_add_command_idempotent(tree: Any) -> None:
     original_add_command = tree.add_command
@@ -11,10 +9,12 @@ def make_add_command_idempotent(tree: Any) -> None:
     def add_command(command: Any, /, **kwargs: Any) -> None:
         if not kwargs.get("override", False):
             root = getattr(command, "root_parent", None) or command
-            lookup_guild = kwargs.get("guild", MISSING)
-            if lookup_guild is MISSING:
-                lookup_guild = None
-            if tree.get_command(root.name, guild=lookup_guild) is not None:
+            lookup_guild = kwargs.get("guild")
+            if lookup_guild is not None and hasattr(lookup_guild, "id"):
+                existing = tree.get_command(root.name, guild=lookup_guild)
+            else:
+                existing = tree.get_command(root.name)
+            if existing is not None:
                 return
         original_add_command(command, **kwargs)
 


### PR DESCRIPTION
## Summary
- Cherry-pick hardened app command tree guild lookup fix into ver/1.2
- Prevents `_MissingSentinel` crash when loading cogs during startup/sync

## Test plan
- [ ] Force-rebuild deploy from ver/1.2 and confirm extensions load


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of guild-specific command additions by refining idempotency checks to perform lookups only when explicitly needed, enhancing efficiency and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->