### PR TITLE
fix: update test to match make_add_command_idempotent behavior

### DIFF
--- a/tests/unit/utils/test_app_command_tree.py
+++ b/tests/unit/utils/test_app_command_tree.py
@@ -23,7 +23,7 @@ def test_add_command_skips_when_already_registered() -> None:
 
     tree.add_command(command)
 
-    tree.get_command.assert_called_once_with("levelcommands_name", guild=None)
+    tree.get_command.assert_called_once_with("levelcommands_name")
     assert calls == []
 
 


### PR DESCRIPTION
Fixes CI failure on development branch.

The `make_add_command_idempotent` function was updated to skip the `guild=None` kwarg when calling `get_command`, but the test was still expecting the old call signature.

This updates the test assertion to match the current implementation.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test validation for command registration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->