### PR TITLE
fix: update test assertion for get_command without guild kwarg

### DIFF
--- a/tests/unit/utils/test_app_command_tree.py
+++ b/tests/unit/utils/test_app_command_tree.py
@@ -23,7 +23,7 @@ def test_add_command_skips_when_already_registered() -> None:
 
     tree.add_command(command)
 
-    tree.get_command.assert_called_once_with("levelcommands_name", guild=None)
+    tree.get_command.assert_called_once_with("levelcommands_name")
     assert calls == []
 
 


### PR DESCRIPTION
Fixes the test assertion in `test_add_command_skips_when_already_registered` to match the actual behavior of `make_add_command_idempotent`, which calls `get_command(name)` without `guild=None` when no guild argument is provided during invocation.

This aligns the unit test with the current implementation and resolves the CI failures on the development branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains internal test updates with no user-facing changes.

* **Tests**
  * Updated test assertions for command registration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->