### PR TITLE
fix: set --cov-fail-under=0 for individual test jobs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - run: pytest tests/unit/ -n auto --cov=. --cov-report=xml:coverage-unit.xml -q
+      - run: pytest tests/unit/ -n auto --cov=. --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -q
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-unit
@@ -105,7 +105,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - run: pytest tests/integration/ -m "not slow and not live_discord" --cov=. --cov-report=xml:coverage-integration.xml -q
+      - run: pytest tests/integration/ -m "not slow and not live_discord" --cov=. --cov-report=xml:coverage-integration.xml --cov-fail-under=0 -q
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-integration


### PR DESCRIPTION
## Summary

The CI workflow was failing because the  sets `fail_under = 85` in `[tool.coverage.report]`, which pytest-cov picks up automatically. 

The `test-unit` and `test-integration` jobs each only run a subset of tests:
- Unit tests: ~30% coverage
- Integration tests: ~76% coverage

Neither can reach 85% individually. The `test-coverage-gate` job is designed to combine both reports and then check the 85% threshold. Adding `--cov-fail-under=0` to the individual test jobs allows them to pass so the coverage-gate job can do its work.

## Changes
- Added `--cov-fail-under=0` to the `test-unit` pytest command
- Added `--cov-fail-under=0` to the `test-integration` pytest command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline test coverage reporting by generating automated XML coverage reports for unit and integration test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->