### PR TITLE
fix(healthcheck): use standalone DB connection instead of pool to prevent connection leak

### DIFF
--- a/api.py
+++ b/api.py
@@ -622,22 +622,44 @@ async def transaction(bot=None):
 
 
 async def check_pool_health(bot=None) -> bool:
-    """Check if the database pool is healthy by running SELECT 1."""
-    pool = _get_pool()
-    if pool is None:
-        return False
-    for attempt in range(_MAX_DB_RETRIES):
+    """Check if the database is responsive.
+
+    Uses a short-lived standalone connection instead of the shared pool
+    so that repeated health checks cannot exhaust the connection pool.
+    Previously, this function acquired from the pool with a timeout;
+    if the pool was full, the timeout leaked connections until the pool
+    was completely drained.
+    """
+    try:
+        import asyncmy
+        import os
+
+        host = os.environ.get("MARIADB_HOST") or os.environ.get("MYSQL_HOST")
+        port = int(os.environ.get("MARIADB_PORT") or os.environ.get("MYSQL_PORT", "3306"))
+        user = os.environ.get("MARIADB_USER") or os.environ.get("MYSQL_USER")
+        password = os.environ.get("MARIADB_PASSWORD") or os.environ.get("MYSQL_PASSWORD")
+        db = os.environ.get("MARIADB_DATABASE") or os.environ.get("MYSQL_DATABASE")
+
+        if not all((host, user, password, db)):
+            # No DB config available — just verify pool was initialized
+            pool = _get_pool()
+            return pool is not None
+
+        conn = await asyncio.wait_for(
+            asyncmy.connect(
+                host=host, port=port, user=user, password=password, db=db,
+                connect_timeout=5,
+            ),
+            timeout=8,
+        )
         try:
-            conn = await asyncio.wait_for(pool.acquire(), timeout=_POOL_ACQUIRE_TIMEOUT)
-            async with conn, conn.cursor() as cursor:
-                await asyncio.wait_for(cursor.execute("SELECT 1"), timeout=_QUERY_TIMEOUT)
+            async with conn.cursor() as cursor:
+                await asyncio.wait_for(cursor.execute("SELECT 1"), timeout=5)
             return True
-        except Exception:
-            if attempt < _MAX_DB_RETRIES - 1:
-                await asyncio.sleep(0.5 * (attempt + 1))
-                continue
-            return False
-    return False
+        finally:
+            conn.close()
+    except Exception:
+        return False
 
 
 async def bulk_update_user_xp(


### PR DESCRIPTION
The healthcheck was using `pool.acquire()` to verify DB connectivity. When the pool was fully utilized, the 10s timeout would cancel the acquire coroutine, but asyncmy may have already reserved the connection internally, causing it to leak. Over time, repeated health checks would drain all 20 pool slots and the bot could no longer acquire any database connection.

**Fix:** Use a short-lived standalone `asyncmy.connect()` for the health check instead of acquiring from the shared pool. This way, health checks never consume or leak pool connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved database health check: now uses short-lived connections with explicit timeouts and proper cleanup, reliably reports failures instead of retrying indefinitely, and falls back to reporting pool initialization when connection settings are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->