### PR TITLE
fix: update check_pool_health tests to match standalone connection implementation

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -259,30 +259,42 @@ class TestExecuteAction:
 
 
 class TestCheckPoolHealth:
-    """Tests for check_pool_health."""
+    """Tests for check_pool_health.
+
+    The new implementation uses a standalone asyncmy connection when DB env vars
+    are set, falling back to checking pool initialization otherwise.
+    """
 
     @pytest.mark.asyncio
-    async def test_returns_true_on_successful_ping(self, bot_with_pool):
-        """Should return True when SELECT 1 succeeds."""
-        _, cursor = bot_with_pool
-        cursor.execute = AsyncMock()
-
+    async def test_returns_true_when_pool_initialized(self, bot_with_pool):
+        """Should return True when pool is initialized (no env vars = fallback path)."""
         result = await check_pool_health()
         assert result is True
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_pool(self):
-        """Should return False when pool is not available."""
+        """Should return False when pool is not available (no env vars = fallback path)."""
         result = await check_pool_health()
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
+    async def test_returns_false_when_db_env_set_and_connect_fails(self):
+        """Should return False when asyncmy.connect raises an exception."""
+        import os
 
-        result = await check_pool_health()
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
 
 


### PR DESCRIPTION
The new `check_pool_health` implementation (commit b412bd5) uses a standalone asyncmy connection when DB env vars are set, falling back to checking pool initialization otherwise.

The existing tests were still written for the old pool-based implementation, causing them to fail:

- `test_returns_true_on_successful_ping`: Now tests that fallback path returns True when pool is initialized
- `test_returns_false_on_exception`: Now tests that a failed standalone connection returns False (set env vars + mock asyncmy.connect to raise)
- `test_returns_false_when_no_pool`: Updated docstring, logic stays the same

This should fix the failing 'Test' workflow on development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for database connection pool health checks, including scenarios for both default and environment-variable-based configurations and various connection failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->