### PR TITLE
fix: update check_pool_health test for standalone connection implementation

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -4,6 +4,7 @@ Replaces the previous existence-only tests with proper behavioral tests
 that verify SQL query generation, return types, error handling, and edge cases.
 """
 
+import os
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, TypeVar
@@ -277,12 +278,21 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the query throws (standalone connection path)."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
 
 


### PR DESCRIPTION
Fixes the integration test `test_returns_false_on_exception` that broke after commit b412bd5 refactored `check_pool_health` to use a standalone asyncmy connection instead of the shared pool.

The old test relied on the pool-based mock fixture (`bot_with_pool`) and patching `cursor.execute`. The new implementation bypasses the pool entirely, so the test now mocks `asyncmy.connect` directly via `unittest.mock.patch` with DB env variables set.

Also adds `import os` to the test file imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved exception handling coverage for database health checks, including a new test case for standalone connection failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->