### PR TITLE
fix: update test_returns_false_on_exception for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -4,6 +4,7 @@ Replaces the previous existence-only tests with proper behavioral tests
 that verify SQL query generation, return types, error handling, and edge cases.
 """
 
+import os
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, TypeVar
@@ -277,12 +278,21 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
 
 


### PR DESCRIPTION
Fixes the CI failure in the Test workflow caused by commit b412bd5 which refactored `check_pool_health` to use a standalone `asyncmy.connect` instead of the shared pool cursor.

The old test patched `cursor.execute` on the pool cursor, but the new implementation doesn't use the pool cursor when no DB env vars are set — it short-circuits returning `pool is not None` → `True`.

**Fix:** Set DB env vars and patch `asyncmy.connect` to raise an exception, properly testing the standalone connection failure path.

**Resolves:** CI failure in Test workflow (run #137)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration tests for database health checks with improved environment variable handling and connection failure validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->