### PR TITLE
fix: update test_returns_false_on_exception for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -4,6 +4,7 @@ Replaces the previous existence-only tests with proper behavioral tests
 that verify SQL query generation, return types, error handling, and edge cases.
 """
 
+import os
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, TypeVar
@@ -277,12 +278,21 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
 
 


### PR DESCRIPTION
## Summary

Fixes the failing CI test on `development`: `tests/integration/api/test_api.py::TestCheckPoolHealth::test_returns_false_on_exception` was asserting `True is False`.

**Root cause:** `check_pool_health` was refactored to use a standalone `asyncmy.connect` instead of the shared pool. The old test mocked the pool cursor, but the new code path ignores the pool when no DB env vars are set and falls back to `_get_pool() is not None` — returning `True` (pool exists via `bot_with_pool` fixture).

**Fix:** Rewrote the test to mock `asyncmy.connect` directly with DB env vars set, testing the actual standalone connection failure path.

## Related

- Fixes CI test failure on development branch
- Closes the failing check identified in workflow run #26722697507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for connection health checks to better validate error handling when database connections fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->