### PR TITLE
fix: update test_returns_false_on_exception for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -4,6 +4,8 @@ Replaces the previous existence-only tests with proper behavioral tests
 that verify SQL query generation, return types, error handling, and edge cases.
 """
 
+import os
+
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, TypeVar
@@ -277,12 +279,21 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
 
 

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -295,6 +295,7 @@ class TestCheckPoolHealth:
         with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
             result = await check_pool_health()
         assert result is False
+        asyncmy_connect.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates the `test_returns_false_on_exception` test to work with the refactored `check_pool_health` function that now uses standalone DB connections instead of the pool.

The old test relied on patching the pool cursor, but the new implementation creates a short-lived asyncmy connection when env vars are set. The test now patches the environment and asyncmy.connect to verify the standalone connection failure path correctly returns False.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration tests for database connection failure handling by simulating environment-based connection errors and verifying health-check behavior returns failure in standalone connection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->