### PR TITLE
fix: add --cov-fail-under=0 to individual test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - run: pytest tests/unit/ -n auto --cov=. --cov-report=xml:coverage-unit.xml -q
+      - run: pytest tests/unit/ -n auto --cov=. --cov-report=xml:coverage-unit.xml --cov-fail-under=0 -q
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-unit
@@ -105,7 +105,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - run: pytest tests/integration/ -m "not slow and not live_discord" --cov=. --cov-report=xml:coverage-integration.xml -q
+      - run: pytest tests/integration/ -m "not slow and not live_discord" --cov=. --cov-report=xml:coverage-integration.xml --cov-fail-under=0 -q
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-integration


### PR DESCRIPTION
## Summary

The unit and integration test jobs each run their own coverage measurement against the full project source, resulting in low per-job coverage. Since the project's `pyproject.toml` sets `fail_under = 85` globally, these individual jobs fail prematurely.

## Changes

- Added `--cov-fail-under=0` to unit test job pytest invocation
- Added `--cov-fail-under=0` to integration test job pytest invocation

The real coverage gate (85% total + per-file) is enforced by the `test-coverage-gate` job that combines coverage from all jobs. This fix prevents the individual jobs from failing before the combine step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to adjust test coverage reporting configuration for unit and integration test suites, ensuring coverage metrics are collected without blocking builds on threshold requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->