### PR TITLE
fix: update test_returns_false_on_exception for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -4,6 +4,8 @@ Replaces the previous existence-only tests with proper behavioral tests
 that verify SQL query generation, return types, error handling, and edge cases.
 """
 
+import os
+
 from collections.abc import Iterator
 from datetime import datetime
 from typing import Any, TypeVar
@@ -277,13 +279,23 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
+        asyncmy_connect.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The check_pool_health function was refactored to use standalone DB connections instead of the pool (commit b412bd5). The test test_returns_false_on_exception was still using the old pool-based fixture (`bot_with_pool`), which just checks if a pool exists and returns True.

This update patches the required MARIADB_* env vars and patches `asyncmy.connect` to raise an exception, so the test properly verifies the standalone connection failure path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test coverage for connection failure scenarios with improved mocking of external service calls and environment configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->