### PR TITLE
fix: update test_returns_false_on_exception for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -6,6 +6,7 @@ that verify SQL query generation, return types, error handling, and edge cases.
 
 from collections.abc import Iterator
 from datetime import datetime
+import os
 from typing import Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -277,13 +278,23 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
+        asyncmy_connect.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the failing CI test `test_returns_false_on_exception` on development.

## Root Cause
The `check_pool_health` function was refactored in commit `b412bd5` to use standalone `asyncmy.connect` instead of the shared pool. The old test relied on the pool path via `bot_with_pool` fixture and setting `cursor.execute.side_effect`, but the new code returns `True` (pool exists) when env vars are not set, never reaching the exception path.

## Fix
Updated the test to set DB environment variables and patch `asyncmy.connect` to raise an exception, verifying the standalone connection failure path correctly returns `False`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for connection error handling scenarios.

---

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->