### PR TITLE
fix: update check_pool_health tests for standalone connection

### DIFF
--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from typing import Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import os
+
 import pytest
 
 import tests.mock_config as mock_config
@@ -262,13 +264,29 @@ class TestCheckPoolHealth:
     """Tests for check_pool_health."""
 
     @pytest.mark.asyncio
-    async def test_returns_true_on_successful_ping(self, bot_with_pool):
-        """Should return True when SELECT 1 succeeds."""
-        _, cursor = bot_with_pool
-        cursor.execute = AsyncMock()
+    async def test_returns_true_on_successful_ping(self):
+        """Should return True when SELECT 1 succeeds on standalone connection."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        mock_cursor = AsyncMock()
+        mock_cursor.execute.return_value = None
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__aenter__.return_value = mock_cursor
+        mock_conn.__aenter__.return_value = mock_conn
+        asyncmy_connect = AsyncMock(return_value=mock_conn)
 
-        result = await check_pool_health()
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is True
+        mock_cursor.execute.assert_awaited_once_with("SELECT 1")
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_pool(self):
@@ -277,13 +295,23 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
-
-        result = await check_pool_health()
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection throws."""
+        env_patch = patch.dict(
+            os.environ,
+            {
+                "MARIADB_HOST": "localhost",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test_user",
+                "MARIADB_PASSWORD": "test_pass",
+                "MARIADB_DATABASE": "test_db",
+            },
+        )
+        asyncmy_connect = AsyncMock(side_effect=Exception("Connection refused"))
+        with env_patch, patch("asyncmy.connect", new=asyncmy_connect):
+            result = await check_pool_health()
         assert result is False
+        asyncmy_connect.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the failing test `test_returns_false_on_exception` on the development branch caused by the `check_pool_health` refactor (commit b412bd5) which changed the function to use standalone DB connections instead of the pool.

## Changes
- `test_returns_true_on_successful_ping`: updated to mock `asyncmy.connect` with DB env vars instead of using the pool fixture
- `test_returns_false_on_exception`: updated to mock `asyncmy.connect` to raise an exception and assert `False` is returned
- Both tests now exercise the standalone connection path matching the new `check_pool_health` implementation

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced API health check validation with improved test coverage for both success and failure scenarios during database connectivity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->