### PR TITLE
fix: update check_pool_health tests for standalone connection implementation

### DIFF
--- a/locales/da.json
+++ b/locales/da.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Kanalstyring",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "da.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "kanaler",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "da.json",
     "max_length": 32
   },
   {

--- a/locales/el.json
+++ b/locales/el.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Διαχείριση καναλιών",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "el.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "κανάλια",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "el.json",
     "max_length": 32
   },
   {

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -34530,17 +34530,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Gestión de canales",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "es-419.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "canales",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "es-419.json",
     "max_length": 32
   },
   {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Kanavien hallinta",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "fi.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "kanavat",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "fi.json",
     "max_length": 32
   },
   {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Gestion des salons",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "fr.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "salons",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "fr.json",
     "max_length": 32
   },
   {

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "चैनल प्रबंधन",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "hi.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "चैनल",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "hi.json",
     "max_length": 32
   },
   {

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Csatornák kezelése",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "hu.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "csatornák",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "hu.json",
     "max_length": 32
   },
   {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -34530,17 +34530,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "チャンネル管理",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "ja.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "チャンネル",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "ja.json",
     "max_length": 32
   },
   {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -33626,17 +33626,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "Kanaalbeheer",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "nl.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "kanalen",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "nl.json",
     "max_length": 32
   },
   {

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -34514,17 +34514,17 @@
   {
     "identifier": "admin.channels.description",
     "source_string": "Channel management",
-    "translation": "Channel management",
+    "translation": "通道管理",
     "context": "Short description of `/channels` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
-    "labels": "admin, command_description",
+    "labels": "zh-TW.json",
     "max_length": 100
   },
   {
     "identifier": "admin.channels.name",
     "source_string": "channels",
-    "translation": "channels",
+    "translation": "通道",
     "context": "Slash command name for `/channels` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
-    "labels": "admin, command_name",
+    "labels": "zh-TW.json",
     "max_length": 32
   },
   {

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -6,6 +6,7 @@ that verify SQL query generation, return types, error handling, and edge cases.
 
 from collections.abc import Iterator
 from datetime import datetime
+import os
 from typing import Any, TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -259,16 +260,41 @@ class TestExecuteAction:
 
 
 class TestCheckPoolHealth:
-    """Tests for check_pool_health."""
+    """Tests for check_pool_health.
+
+    The function now uses a short-lived standalone connection instead
+    of the shared pool.  When DB env vars are missing it falls back to
+    a simple ``pool is not None`` check.
+    """
 
     @pytest.mark.asyncio
-    async def test_returns_true_on_successful_ping(self, bot_with_pool):
-        """Should return True when SELECT 1 succeeds."""
-        _, cursor = bot_with_pool
-        cursor.execute = AsyncMock()
-
+    async def test_returns_true_on_successful_ping(self):
+        """Should return True when the pool exists and no DB env is set."""
         result = await check_pool_health()
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_with_standalone_connection(self):
+        """Should return True when a standalone connection succeeds."""
+        mock_conn = AsyncMock()
+        mock_conn.__aenter__.return_value = mock_conn
+        mock_cursor = AsyncMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with (
+            patch.dict(os.environ, {
+                "MARIADB_HOST": "127.0.0.1",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test",
+                "MARIADB_PASSWORD": "test",
+                "MARIADB_DATABASE": "tanjun",
+            }),
+            patch("api.asyncmy.connect", AsyncMock(return_value=mock_conn)),
+        ):
+            result = await check_pool_health()
+            assert result is True
+            mock_conn.cursor.assert_awaited_once()
+            mock_cursor.execute.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_pool(self):
@@ -277,13 +303,36 @@ class TestCheckPoolHealth:
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_exception(self, bot_with_pool):
-        """Should return False when the query throws."""
-        _, cursor = bot_with_pool
-        cursor.execute.side_effect = Exception("DB connection lost")
+    async def test_returns_false_on_exception(self):
+        """Should return False when the standalone connection fails."""
+        with (
+            patch.dict(os.environ, {
+                "MARIADB_HOST": "127.0.0.1",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test",
+                "MARIADB_PASSWORD": "test",
+                "MARIADB_DATABASE": "tanjun",
+            }),
+            patch("api.asyncmy.connect", AsyncMock(side_effect=Exception("DB connection lost"))),
+        ):
+            result = await check_pool_health()
+            assert result is False
 
-        result = await check_pool_health()
-        assert result is False
+    @pytest.mark.asyncio
+    async def test_returns_false_on_timeout(self):
+        """Should return False when the standalone connection times out."""
+        with (
+            patch.dict(os.environ, {
+                "MARIADB_HOST": "127.0.0.1",
+                "MARIADB_PORT": "3306",
+                "MARIADB_USER": "test",
+                "MARIADB_PASSWORD": "test",
+                "MARIADB_DATABASE": "tanjun",
+            }),
+            patch("api.asyncmy.connect", AsyncMock(side_effect=TimeoutError("timed out"))),
+        ):
+            result = await check_pool_health()
+            assert result is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The `check_pool_health()` function was changed in commit b412bd5 to use a short-lived standalone connection (via asyncmy.connect) instead of the shared pool. The existing tests were still testing pool-based behavior and were failing in CI.

## Changes
- Updated `test_returns_true_on_successful_ping` — now tests the fallback path (pool existence check) when DB env vars are absent
- Added `test_returns_true_with_standalone_connection` — verifies the standalone connection path works
- Updated `test_returns_false_on_exception` — now tests standalone connection failure by patching env vars and asyncmy.connect
- Added `test_returns_false_on_timeout` — verifies timeout handling for standalone connections
- `test_returns_false_when_no_pool` unchanged — still correctly tests the pool-missing case

## Testing
The failing test `test_returns_false_on_exception` was asserting `True is False` because `check_pool_health` no longer uses the pool cursor. Now all tests properly cover both code paths (env vars present → standalone connection; env vars absent → pool existence check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Enhanced translations for admin channel management commands across Danish, Greek, Spanish, Finnish, French, Hindi, Hungarian, Japanese, Dutch, and Traditional Chinese locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->