### PR TITLE
fix: batch bug fixes (issues #2830, #2831, #2822)

### DIFF
--- a/ai/refill_token.py
+++ b/ai/refill_token.py
@@ -19,7 +19,7 @@ async def refill_ai_token(client: Client) -> None:
             plus_sku = sku
 
     if plus_sku:
-        entitlements = await client.entitlements(skus=[plus_sku]).flatten()
+        entitlements = [e async for e in client.entitlements(skus=[plus_sku])]
         await AiService.refill(entitlements)
     else:
         await AiService.refill()

--- a/extensions/utility.py
+++ b/extensions/utility.py
@@ -887,7 +887,7 @@ class UtilityCog(commands.Cog):
             client=interaction.client,
         )
 
-        await helpCommand(command_info=command_info)
+        await helpCommand(command_info=command_info, ctx=interaction)
         return
 
     @commands.Cog.listener()

--- a/tests/unit/ai/test_refill_token.py
+++ b/tests/unit/ai/test_refill_token.py
@@ -30,9 +30,10 @@ class TestRefillAiToken:
         plus_sku = MagicMock(name="Tanjun Plus")
         plus_sku.name = "Tanjun Plus"
         client = _client_with_skus([plus_sku])
-        entitlements = MagicMock()
-        entitlements.flatten = AsyncMock(return_value=["ent1"])
-        client.entitlements = MagicMock(return_value=entitlements)
+        async def _iter_ents(*args, **kwargs):
+            yield "ent1"
+        client.entitlements = MagicMock()
+        client.entitlements.return_value = _iter_ents()
         with (
             patch("ai.refill_token.datetime") as dt_mod,
             patch("ai.refill_token.AiService.refill", new=AsyncMock()) as refill_mock,
@@ -85,9 +86,11 @@ class TestRefillAiToken:
         plus_sku = MagicMock()
         plus_sku.name = "Tanjun Plus"
         client = _client_with_skus([plus_sku, MagicMock(name="Tanjun Plus 2")])
-        entitlements = MagicMock()
-        entitlements.flatten = AsyncMock(return_value=[])
-        client.entitlements = MagicMock(return_value=entitlements)
+        async def _iter_empty(*args, **kwargs):
+            if False:
+                yield  # pragma: no cover
+        client.entitlements = MagicMock()
+        client.entitlements.return_value = _iter_empty()
         with (
             patch("ai.refill_token.datetime") as dt_mod,
             patch("ai.refill_token.AiService.refill", new=AsyncMock()) as refill_mock,


### PR DESCRIPTION
Fixes three bug issues:

- **#2830 / #2831**: `help()` missing 1 required positional argument: 'ctx' — The `help_slash` command in `extensions/utility.py` was calling `helpCommand()` without the `ctx` parameter. Fixed by passing `interaction` as `ctx`.
- **#2822**: `'async_generator' object has no attribute 'flatten'` — The `entitlements()` method returns an async generator, but `.flatten()` was called on it synchronously. Fixed by using an async list comprehension instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed help command interaction handling so slash command help reliably opens with the correct context when invoked.
  * Improved token refilling process to more robustly detect and apply eligible entitlements for premium access, reducing failures when refreshing service tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->