### PR TITLE
fix: retry DB transaction on 'restart transaction' error (issue #2790)

### DIFF
--- a/api.py
+++ b/api.py
@@ -286,7 +286,7 @@ async def _execute_with_retry(
             err_str = str(e).lower()
             if is_write and ("duplicate column" in err_str or "duplicate key name" in err_str):
                 raise
-            retryable = "deadlock" in err_str or "abort" in err_str
+            retryable = "deadlock" in err_str or "abort" in err_str or "restart transaction" in err_str
             if not is_write:
                 retryable = retryable or "connection" in err_str or "timeout" in err_str
             if attempt < _MAX_DB_RETRIES - 1 and retryable:


### PR DESCRIPTION
Fixes the OperationalError (#2790) where MariaDB error 1020 'Record has changed since last read in table; try restarting transaction' would immediately raise instead of being retried.

**Root cause:** `_execute_with_retry` for write operations only retries on 'deadlock' or 'abort' in the error message. The serialization failure error (1020) explicitly recommends 'restart transaction' but this wasn't matched.

**Fix:** Added `'restart transaction'` to the retryable error conditions for write operations, so the conflict gets retried instead of raising immediately.

Fixes #2790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for write operations to automatically retry on additional transient database conditions, reducing unexpected failures and improving overall system stability in edge cases that previously caused immediate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->