### PR TITLE
fix: dedupe bot exception issues and stale missing localization reports

### DIFF
--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -143,6 +143,18 @@ class TestSyncHelpers:
 
         mock_github.assert_not_called()
 
+    def test_sync_create_missing_localization_issue_skips_when_translation_exists(self):
+        from utils.github import _sync_create_missing_localization_issue
+
+        with (
+            patch("utils.github.GithubAuthToken", "token"),
+            patch("utils.github.Github") as mock_github,
+            patch("utils.github._missing_localization_resolved", return_value=True),
+        ):
+            _sync_create_missing_localization_issue("fr", "admin.emoji.name")
+
+        mock_github.assert_not_called()
+
     def test_sync_create_feedback_issue(self):
         from utils.github import _sync_create_feedback_issue
 

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -8,12 +8,20 @@ import discord
 import pytest
 
 from utils.github import (
+    _recent_reports,
     addFeedback,
     missingLocalization,
     report_bot_exception,
     report_bot_exception_sync,
     should_report_exception,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_exception_dedup_cache() -> None:
+    _recent_reports.clear()
+    yield
+    _recent_reports.clear()
 
 
 class TestShouldReportException:
@@ -38,18 +46,36 @@ class TestReportBotException:
     def test_sync_reports_when_token_present(self):
         with patch("utils.github.GithubAuthToken", "token"), patch("utils.github.Github") as mock_github:
             mock_repo = MagicMock()
-            mock_github.return_value.get_repo.return_value = mock_repo
+            mock_g = MagicMock()
+            mock_g.get_repo.return_value = mock_repo
+            mock_g.search_issues.return_value.totalCount = 0
+            mock_github.return_value = mock_g
             report_bot_exception_sync(RuntimeError("boom"), source="test", context={"command": "/ping"})
             mock_repo.create_issue.assert_called_once()
+            body = mock_repo.create_issue.call_args[1]["body"]
+            assert "**Fingerprint:**" in body
 
     def test_dedup_prevents_duplicate_reports(self):
         with patch("utils.github.GithubAuthToken", "token"), patch("utils.github.Github") as mock_github:
             mock_repo = MagicMock()
-            mock_github.return_value.get_repo.return_value = mock_repo
+            mock_g = MagicMock()
+            mock_g.get_repo.return_value = mock_repo
+            mock_g.search_issues.return_value.totalCount = 0
+            mock_github.return_value = mock_g
             exc = RuntimeError("same error")
             report_bot_exception_sync(exc, source="first")
             report_bot_exception_sync(exc, source="second")
             assert mock_repo.create_issue.call_count == 1
+
+    def test_sync_skips_when_open_issue_exists_on_github(self):
+        with patch("utils.github.GithubAuthToken", "token"), patch("utils.github.Github") as mock_github:
+            mock_repo = MagicMock()
+            mock_g = MagicMock()
+            mock_g.get_repo.return_value = mock_repo
+            mock_g.search_issues.return_value.totalCount = 1
+            mock_github.return_value = mock_g
+            report_bot_exception_sync(RuntimeError("boom"), source="test")
+            mock_repo.create_issue.assert_not_called()
 
 
 class TestMissingLocalization:

--- a/utils/github.py
+++ b/utils/github.py
@@ -62,6 +62,26 @@ def _exception_fingerprint(exc: BaseException) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
+def _bot_exception_title_prefix(exc_name: str, source: str) -> str:
+    return f"[Bot Exception] {exc_name} in {source}:"
+
+
+def _open_bot_exception_issue_exists(
+    g: Github,
+    fingerprint: str,
+    exc_name: str,
+    source: str,
+) -> bool:
+    fingerprint_query = f'repo:{_REPO} is:issue is:open label:"bot exception" "{fingerprint}"'
+    if g.search_issues(fingerprint_query).totalCount > 0:
+        return True
+
+    title_prefix = _bot_exception_title_prefix(exc_name, source)
+    escaped_prefix = title_prefix.replace('"', '\\"')
+    title_query = f'repo:{_REPO} is:issue is:open in:title "{escaped_prefix}"'
+    return g.search_issues(title_query).totalCount > 0
+
+
 def _dedup_allows_report(fingerprint: str) -> bool:
     now = time.monotonic()
     expired = [key for key, seen_at in _recent_reports.items() if now - seen_at >= _DEDUP_TTL_SEC]
@@ -113,13 +133,14 @@ def _sync_create_bot_exception_issue(
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     exc_name = type(exc).__name__
     exc_message = str(exc) or "(no message)"
-    title = f"[Bot Exception] {exc_name} in {source}: {exc_message}"
+    title = f"{_bot_exception_title_prefix(exc_name, source)} {exc_message}"
     if len(title) > 240:
         title = title[:237] + "..."
 
     environment = sentry_environment or "unknown"
     body = f"""## Bot Exception Report
 
+**Fingerprint:** `{fingerprint}`
 **Source:** `{source}`
 **Exception:** `{exc_name}: {exc_message}`
 **Version:** `{version}`
@@ -136,6 +157,9 @@ def _sync_create_bot_exception_issue(
 
     try:
         g = Github(GithubAuthToken)
+        if _open_bot_exception_issue_exists(g, fingerprint, exc_name, source):
+            return
+
         repo = g.get_repo(_REPO)
         labels = _resolve_labels(repo)
         repo.create_issue(title=title, body=body, labels=labels)

--- a/utils/github.py
+++ b/utils/github.py
@@ -201,8 +201,19 @@ def _missing_localization_issue_exists(g: Github, locale: str, key: str) -> bool
     return g.search_issues(query).totalCount > 0
 
 
+def _missing_localization_resolved(locale: str, key: str) -> bool:
+    from localizer import tanjunLocalizer
+
+    entries = tanjunLocalizer.load_translations(locale)
+    entry = tanjunLocalizer.get_translation(entries, key)
+    return entry is not None and bool(entry.translation.strip())
+
+
 def _sync_create_missing_localization_issue(locale: str, key: str) -> None:
     if not GithubAuthToken:
+        return
+
+    if _missing_localization_resolved(locale, key):
         return
 
     title = _missing_localization_issue_title(locale, key)


### PR DESCRIPTION
## Summary

- Before creating a bot exception GitHub issue, check open issues for an existing match (fingerprint in body or legacy title prefix) and keep the in-memory TTL cache for bursts.
- Skip missing-localization GitHub issues when the key already resolves in locale files (including underscore/dot aliases), so reports filed before translations landed do not keep recurring.
- Open bot issues in this batch are stale: translations are present on `development`, and DB query timeouts after retry exhaustion return `None` instead of raising (see #2839).

## Test plan

- [x] `pytest tests/unit/utils/test_github.py`
- [ ] Merge to `development` and deploy so production stops opening duplicate exception/localization issues

Closes #2463
Closes #2464
Closes #2465
Closes #2466
Closes #2467
Closes #2468
Closes #2469
Closes #2470
Closes #2471
Closes #2472
Closes #2473
Closes #2474
Closes #2475
Closes #2476
Closes #2477
Closes #2478
Closes #2479
Closes #2480
Closes #2481
Closes #2482
Closes #2483
Closes #2484
Closes #2485
Closes #2486
Closes #2487
Closes #2488
Closes #2489
Closes #2490
Closes #2491
Closes #2492
Closes #2493
Closes #2494
Closes #2496
Closes #2497
Closes #2498
Closes #2499
Closes #2500
Closes #2501
Closes #2502
Closes #2503
Closes #2504
Closes #2505
Closes #2506
Closes #2507
Closes #2508
Closes #2509
Closes #2510
Closes #2511
Closes #2512
Closes #2513
Closes #2514
Closes #2515
Closes #2516
Closes #2517
Closes #2519
Closes #2520
Closes #2521
Closes #2522
Closes #2523
Closes #2524
Closes #2525
Closes #2526
Closes #2527
Closes #2528
Closes #2529
Closes #2530
Closes #2531
Closes #2532
Closes #2533
Closes #2534
Closes #2535
Closes #2536
Closes #2537
Closes #2538
Closes #2539
Closes #2540
Closes #2541
Closes #2542
Closes #2543
Closes #2544
Closes #2545
Closes #2546
Closes #2547
Closes #2548
Closes #2549
Closes #2550
Closes #2551
Closes #2552
Closes #2553
Closes #2554
Closes #2555
Closes #2556
Closes #2557
Closes #2558
Closes #2707
Closes #2708
Closes #2709
Closes #2710
Closes #2711
Closes #2712
Closes #2713
Closes #2714
Closes #2715
Closes #2716
Closes #2717
Closes #2718
Closes #2719
Closes #2720
Closes #2721
Closes #2722
Closes #2723
Closes #2724
Closes #2725
Closes #2726
Closes #2727
Closes #2729
Closes #2730
Closes #2731
Closes #2732
Closes #2733
Closes #2734
Closes #2735
Closes #2736
Closes #2737
Closes #2738
Closes #2739
Closes #2740
Closes #2741
Closes #2742
Closes #2743
Closes #2744
Closes #2745
Closes #2746
Closes #2747
Closes #2748
Closes #2749
Closes #2750
Closes #2751
Closes #2752
Closes #2753
Closes #2754
Closes #2755
Closes #2756
Closes #2757
Closes #2758
Closes #2759
Closes #2760
Closes #2761
Closes #2762
Closes #2763
Closes #2764
Closes #2765
Closes #2769
Closes #2770
Closes #2771
Closes #2772
Closes #2773
Closes #2774
Closes #2776
Closes #2778
Closes #2779
Closes #2780
Closes #2781
Closes #2794
Closes #2796
Closes #2798
Closes #2801
Closes #2802
Closes #2803
Closes #2809
Closes #2813
Closes #2818
Closes #2823
Closes #2827
Closes #2829
Closes #2832
Closes #2836
Closes #2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate bot exception issues by detecting existing open issues before creating new ones.
  * Include a fingerprint marker in bot-exception issue bodies for clearer tracking.
  * Skip creating "missing localization" issues when the translation is already present.

* **Tests**
  * Test suite updated to isolate exception-reporting state between tests to avoid cross-test interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->