### PR TITLE
fix: Crowdin CSV parser for locale metadata

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           ref: development
 
+      - name: Prepare Crowdin CSV files
+        run: python scripts/crowdin_locale_csv.py to-csv
+
       - name: Upload source files to Crowdin
         uses: crowdin/github-action@v2
         with:
@@ -65,12 +68,26 @@ jobs:
           download_translations: true
           crowdin_branch_name: development
           config: crowdin.yml
-          create_pull_request: true
-          pull_request_title: 'New Crowdin updates'
-          pull_request_body: 'Automated translation updates from Crowdin.'
-          pull_request_labels: 'translations'
-          pull_request_base_branch_name: development
+          create_pull_request: false
         env:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore locale JSON from Crowdin CSV
+        if: ${{ !inputs.upload_only }}
+        run: python scripts/crowdin_locale_csv.py to-json
+
+      - name: Open translation pull request
+        if: ${{ !inputs.upload_only }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: crowdin-translations
+          base: development
+          title: New Crowdin updates
+          body: Automated translation updates from Crowdin.
+          labels: translations
+          commit-message: New Crowdin updates
+          add-paths: |
+            locales/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cover/
 # Translations
 *.mo
 *.pot
+locales/*.csv
 
 # Django stuff:
 *.log

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -3,11 +3,12 @@
 #
 # This project uses Crowdin for translation management.
 #
-# Locale files use Crowdin's multilingual JSON format (array of objects with
-# identifier, source_string, translation, context, labels, max_length).
-# Do not set `type` here — the file type is configured in the Crowdin project
-# (must match the format used by bundle 4 / the existing en.json file entry).
-#   /locales/<language_code>.json
+# Runtime locale files are JSON arrays (identifier, source_string, translation,
+# context, labels, max_length). Crowdin sync uses CSV with a column scheme so
+# only source_phrase is translated (generic JSON would import every field).
+# CI converts JSON <-> CSV around crowdin/github-action (see crowdin_locale_csv.py).
+#   /locales/<language_code>.json  (bot)
+#   /locales/<language_code>.csv   (Crowdin upload/download, gitignored)
 #
 # Each file contains an array of translation entries with the following fields:
 #   identifier    - Unique dot-separated key for the translation string
@@ -43,9 +44,12 @@ base_url: "https://api.crowdin.com"
 preserve_hierarchy: true
 
 files:
-  - source: "/locales/en.json"
-    translation: "/locales/%locale%.json"
-    dest: "/locales/en.json"
+  - source: "/locales/en.csv"
+    translation: "/locales/%locale%.csv"
+    dest: "/locales/en.csv"
+    type: csv
+    first_line_contains_header: true
+    scheme: "identifier,source_phrase,translation,context,labels,max_length"
     languages_mapping:
       locale:
         bg: bg
@@ -72,8 +76,8 @@ files:
 # Bundle configuration
 # Bundle ID 4 defines the files and languages synced through
 # Crowdin's GitHub integration (configured at https://crowdin.com/):
-#   - Source file: /locales/en.json
-#   - Translation files: /locales/<locale>.json (e.g. de, fi, es-419, zh-CN)
+#   - Source file: /locales/en.csv (from en.json via CI)
+#   - Translation files: /locales/<locale>.csv (converted back to .json in CI)
 #   - Languages: all locales listed in health/checks/locales.py
 #   - Label filter: (none — all strings included)
 #

--- a/scripts/crowdin_locale_csv.py
+++ b/scripts/crowdin_locale_csv.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+LOCALE_DIR = Path(__file__).resolve().parent.parent / "locales"
+CSV_FIELDS = ("identifier", "source_phrase", "translation", "context", "labels", "max_length")
+JSON_TO_CSV = {
+    "identifier": "identifier",
+    "source_string": "source_phrase",
+    "translation": "translation",
+    "context": "context",
+    "labels": "labels",
+    "max_length": "max_length",
+}
+
+
+def json_row_to_csv(row: dict[str, object]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for json_key, csv_key in JSON_TO_CSV.items():
+        value = row.get(json_key, "")
+        if value is None:
+            out[csv_key] = ""
+        else:
+            out[csv_key] = str(value)
+    return out
+
+
+def csv_row_to_json(row: dict[str, str]) -> dict[str, object]:
+    max_length_raw = row.get("max_length", "").strip()
+    max_length: int | None
+    if not max_length_raw:
+        max_length = None
+    elif max_length_raw.isdigit():
+        max_length = int(max_length_raw)
+    else:
+        max_length = None
+    return {
+        "identifier": row.get("identifier", ""),
+        "source_string": row.get("source_phrase", ""),
+        "translation": row.get("translation", ""),
+        "context": row.get("context", ""),
+        "labels": row.get("labels", ""),
+        "max_length": max_length,
+    }
+
+
+def to_csv(locales: list[str] | None) -> int:
+    paths = [LOCALE_DIR / f"{code}.json" for code in locales] if locales else sorted(LOCALE_DIR.glob("*.json"))
+    count = 0
+    for json_path in paths:
+        if not json_path.exists():
+            continue
+        with json_path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, list):
+            raise ValueError(f"{json_path} must be a JSON array")
+        csv_path = json_path.with_suffix(".csv")
+        with csv_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=CSV_FIELDS)
+            writer.writeheader()
+            for row in data:
+                if isinstance(row, dict):
+                    writer.writerow(json_row_to_csv(row))
+        count += 1
+    return count
+
+
+def to_json(locales: list[str] | None) -> int:
+    paths = [LOCALE_DIR / f"{code}.csv" for code in locales] if locales else sorted(LOCALE_DIR.glob("*.csv"))
+    count = 0
+    for csv_path in paths:
+        if not csv_path.exists():
+            continue
+        with csv_path.open(encoding="utf-8", newline="") as handle:
+            rows = list(csv.DictReader(handle))
+        json_path = csv_path.with_suffix(".json")
+        payload = [csv_row_to_json(row) for row in rows]
+        json_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        count += 1
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name, func in (("to-csv", to_csv), ("to-json", to_json)):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("--locale", action="append", help="Locale code (e.g. en, de). Default: all locale files.")
+    args = parser.parse_args()
+    locales = args.locale if hasattr(args, "locale") else None
+    if args.command == "to-csv":
+        n = to_csv(locales)
+    else:
+        n = to_json(locales)
+    print(n)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Configure Crowdin to import `locales/*.csv` with a column scheme so only `source_phrase` is translated; `identifier`, `context`, `labels`, and `max_length` map to Crowdin metadata instead of separate strings.
- Add `scripts/crowdin_locale_csv.py` to convert locale JSON (runtime format) to CSV before upload and back to JSON after download.
- Update the Crowdin GitHub workflow to run conversion around sync and open a PR with updated `locales/*.json` files.

## Test plan

- [ ] Merge and run Crowdin Sync workflow (or `workflow_dispatch`) on `development`
- [ ] In Crowdin, confirm strings use dot-keys (e.g. `admin.addrole.params.role.description`) with context/labels/max length on the string, not keys like `0.max_length`
- [ ] Re-upload or replace the existing `en.json` file entry in Crowdin if it was previously parsed as generic JSON

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced translation synchronization workflow with explicit preprocessing for improved handling of locale updates.

* **Chores**
  * Updated Crowdin configuration to use CSV-based file formats for more reliable translation synchronization.
  * Added automation tooling for converting between JSON and CSV locale file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->