### PR TITLE
fix: add missing channel and advanced TTT localization keys

### DIFF
--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -227,7 +227,8 @@ Jede(r) ist ♥️-lich willkommen! Wir freuen uns über jeden Neuzugang! Schaut
             self.sendPokemonWerbung,
         ]
         for loop in loop_starts:
-            loop.start()  # type: ignore[unused-awaitable]
+            if not loop.is_running():
+                loop.start()  # type: ignore[unused-awaitable]
             await asyncio.sleep(0.25)
 
 

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "commands, embed_title",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "translation": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/da.json
+++ b/locales/da.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/da.json
+++ b/locales/da.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/de.json
+++ b/locales/de.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/de.json
+++ b/locales/de.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/el.json
+++ b/locales/el.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "commands, embed_title",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "translation": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/el.json
+++ b/locales/el.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/en.json
+++ b/locales/en.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "commands, embed_title",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "translation": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "commands, embed_title",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "translation": "${reporter} has reported ${user}.\nReason: ${reason}",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/id.json
+++ b/locales/id.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/id.json
+++ b/locales/id.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/it.json
+++ b/locales/it.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/it.json
+++ b/locales/it.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "fun, command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -34790,5 +34790,53 @@
     "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
     "labels": "command_option_description",
     "max_length": 100
+  },
+  {
+    "identifier": "attachment",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name for the `attachment` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "anonymous",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name for the `anonymous` option on `/utility report`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.name",
+    "source_string": "attachment",
+    "translation": "attachment",
+    "context": "Display name of the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.attachment.description",
+    "source_string": "Evidence file for the report (optional)",
+    "translation": "Evidence file for the report (optional)",
+    "context": "Help text for the `attachment` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
+  },
+  {
+    "identifier": "utility.report.params.anonymous.name",
+    "source_string": "anonymous",
+    "translation": "anonymous",
+    "context": "Display name of the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "utility.report.params.anonymous.description",
+    "source_string": "Submit the report without revealing your identity (optional)",
+    "translation": "Submit the report without revealing your identity (optional)",
+    "context": "Help text for the `anonymous` option on `/utility report`. Used in `extensions/utility.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -34750,5 +34750,45 @@
     "context": "UI copy for twitch.username. English: \"twitch_username\".",
     "labels": "",
     "max_length": 32
+  },
+  {
+    "identifier": "channel.name",
+    "source_string": "channel",
+    "translation": "channel",
+    "context": "Display name for `/channel` command group. Used in `extensions/channel.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.name",
+    "source_string": "advanced_ttt",
+    "translation": "advanced_ttt",
+    "context": "Display name for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.description",
+    "source_string": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "translation": "Play Ultimate Tic-Tac-Toe (9 boards in a 3x3 grid)",
+    "context": "Description for `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "description",
+    "max_length": 100
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.name",
+    "source_string": "user",
+    "translation": "user",
+    "context": "Option name for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_name",
+    "max_length": 32
+  },
+  {
+    "identifier": "games.advanced.ttt.params.user.description",
+    "source_string": "The user against whom the game is to be played (optional)",
+    "translation": "The user against whom the game is to be played (optional)",
+    "context": "Option description for `user` on `/games advanced_ttt`. Used in `extensions/games.py`.",
+    "labels": "command_option_description",
+    "max_length": 100
   }
 ]

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -34,6 +34,15 @@ class TestShouldReportException:
     def test_skips_not_found(self):
         assert should_report_exception(discord.NotFound(MagicMock(), "missing")) is False
 
+    def test_skips_client_connection_reset(self):
+        class ClientConnectionResetError(Exception):
+            pass
+
+        assert should_report_exception(ClientConnectionResetError("Cannot write to closing transport")) is False
+
+    def test_skips_task_already_launched(self):
+        assert should_report_exception(RuntimeError("Task is already launched and is not completed.")) is False
+
 
 class TestReportBotException:
     @pytest.mark.asyncio

--- a/utils/github.py
+++ b/utils/github.py
@@ -46,6 +46,12 @@ def should_report_exception(exc: BaseException) -> bool:
         if "10008" in msg and "unknown message" in msg:
             return False
 
+    if type(exc).__name__ == "ClientConnectionResetError":
+        return False
+
+    if isinstance(exc, RuntimeError) and "task is already launched" in str(exc).lower():
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Summary

- Adds `channel.name` and `games.advanced.ttt.*` keys for slash command groups/commands.
- Adds `attachment`, `anonymous`, and `utility.report.params.*` keys for `/utility report`.
- Prevents duplicate `loop.start()` on reconnect (`extensions/loops.py`).
- Stops auto-filing GitHub issues for benign `ClientConnectionResetError` (shard reconnect) and duplicate loop startup `RuntimeError`.

## Test plan

- [x] `pytest tests/unit/utils/test_github.py`
- [x] `pytest tests/unit/health/test_locale_file_extended.py`
- [x] Verified new locale keys resolve via `tanjunLocalizer.localize()`

## Not in scope

- #1140 — infrastructure/deployment (botstatus-api, Shlink, Bytebin on Coolify)
- #903 — Renovate dependency dashboard

## Issues closed on merge

Closes #2847
Closes #2848
Closes #2849
Closes #2850
Closes #2851
Closes #2852
Closes #2853
Closes #2854
Closes #2855
Closes #2856
Closes #2857
Closes #2858
Closes #2859
Closes #2860
Closes #2861
Closes #2862
Closes #2863
Closes #2864
Closes #2865
Closes #2866
Closes #2867
Closes #2868
Closes #2869
Closes #2870
Closes #2871
Closes #2872
Closes #2873
Closes #2874
Closes #2875
Closes #2876
Closes #2877
Closes #2878
Closes #2879
Closes #2880
Closes #2881
Closes #2882
Closes #2883
Closes #2884
Closes #2885
Closes #2886
Closes #2887
Closes #2888
Closes #2889
Closes #2890
Closes #2891
Closes #2892
Closes #2893
Closes #2894
Closes #2895
Closes #2896
Closes #2897
Closes #2898
Closes #2899
Closes #2900
Closes #2901
Closes #2902
Closes #2903
Closes #2904
Closes #2905
Closes #2906
Closes #2907
Closes #2908
Closes #2909
Closes #2910
Closes #2911
Closes #2912
Closes #2913
Closes #2914
Closes #2915
Closes #2916
Closes #2917
Closes #2918
Closes #2919
Closes #2920
Closes #2921
Closes #2922
Closes #2923
Closes #2924
Closes #2925
Closes #2926
Closes #2927
Closes #2928
Closes #2929
Closes #2930
Closes #2931
Closes #2932
Closes #2933
Closes #2934
Closes #2935
Closes #2936
Closes #2937
Closes #2938
Closes #2939
Closes #2940
Closes #2941
Closes #2942
Closes #2943
Closes #2944
Closes #2945
Closes #2946
Closes #2947
Closes #2948
Closes #2949
Closes #2950
Closes #2951
Closes #2952
Closes #2953
Closes #2954
Closes #2955
Closes #2956
Closes #2957
Closes #2958
Closes #2959
Closes #2960
Closes #2961
Closes #2962
Closes #2963
Closes #2964
Closes #2965
Closes #2966
Closes #2967
Closes #2968
Closes #2969
Closes #2971
Closes #2972
Closes #2973
Closes #2974
Closes #2975
Closes #2976
Closes #2977
Closes #2978
Closes #2979
Closes #2980
Closes #2981
Closes #2982
Closes #2983
Closes #2984
Closes #2985
Closes #2986
Closes #2987
Closes #2988
Closes #2989
Closes #2990
Closes #2991
Closes #2992
Closes #2993
Closes #2994
Closes #2995
Closes #2996
Closes #2997
Closes #2998
Closes #2999
Closes #3000
Closes #3001
Closes #3002
Closes #3003
Closes #3004
Closes #3005
Closes #3006
Closes #3007
Closes #3008
Closes #3009
Closes #3010
Closes #3011
Closes #3012
Closes #3013
Closes #3014
Closes #3015
Closes #3016
Closes #3017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/channel` command group
  * Introduced advanced Tic-Tac-Toe game
  * Added attachment and anonymous options to report utility

* **Internationalization**
  * Extended language support to 24 locales

* **Bug Fixes**
  * Enhanced error handling for connection and task-related exceptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->