### PR TITLE
fix: skip CommandNotFound in bot exception reports

### DIFF
--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -43,6 +43,12 @@ class TestShouldReportException:
     def test_skips_task_already_launched(self):
         assert should_report_exception(RuntimeError("Task is already launched and is not completed.")) is False
 
+    def test_skips_command_not_found(self):
+        class CommandNotFound(Exception):
+            __module__ = "discord.ext.commands.errors"
+
+        assert should_report_exception(CommandNotFound('Command "synnc" is not found')) is False
+
 
 class TestReportBotException:
     @pytest.mark.asyncio

--- a/utils/github.py
+++ b/utils/github.py
@@ -52,6 +52,9 @@ def should_report_exception(exc: BaseException) -> bool:
     if isinstance(exc, RuntimeError) and "task is already launched" in str(exc).lower():
         return False
 
+    if type(exc).__name__ == "CommandNotFound" and (type(exc).__module__ or "").startswith("discord"):
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Summary

- Filter Discord `CommandNotFound` in `should_report_exception` so typoed prefix commands (e.g. `synnc`) no longer open GitHub bot-exception issues.
- Aligns with existing behavior for slash commands in the error handler, which already ignores `app_commands.CommandNotFound`.
- Add unit test for the filter.

## Test plan

- [x] `pytest tests/unit/utils/test_github.py::TestShouldReportException -q`
- [ ] Deploy or run bot locally; invoke unknown prefix command; confirm no new `[Bot Exception] CommandNotFound` issue is created


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting to exclude Discord "command not found" exceptions from GitHub notifications, reducing irrelevant error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->