### PR TITLE
fix: normalize localized slash command names for Discord

### DIFF
--- a/tests/unit/core/test_localizer.py
+++ b/tests/unit/core/test_localizer.py
@@ -48,6 +48,17 @@ class _TranslatorBase:
         pass
 
 
+class _TranslationContextLocation:
+    command_name = 0
+    command_description = 1
+    group_name = 2
+    group_description = 3
+    parameter_name = 4
+    parameter_description = 5
+    choice_name = 6
+    other = 7
+
+
 # Patch the discord mock BEFORE importing localizer/translator modules
 _orig_discord = __import__("sys").modules.get("discord")
 if _orig_discord is not None:
@@ -56,6 +67,7 @@ if _orig_discord is not None:
         MagicMock() if isinstance(_orig_discord.app_commands, MagicMock) else _orig_discord.app_commands
     )
     _orig_discord.app_commands.Translator = _TranslatorBase
+    _orig_discord.app_commands.TranslationContextLocation = _TranslationContextLocation
 
 import tests.mock_config  # noqa: F401, E402 – side-effect import
 from localizer import (  # noqa: E402
@@ -65,7 +77,7 @@ from localizer import (  # noqa: E402
     TranslationEntry,
     tanjunLocalizer,
 )
-from translator import TanjunTranslator  # noqa: E402
+from translator import TanjunTranslator, _normalize_discord_command_name  # noqa: E402
 
 FAKE_DE = _Locale("de")
 FAKE_EN_US = _Locale("en-US")
@@ -585,6 +597,33 @@ class TestTanjunTranslator:
                 r = loop.run_until_complete(t.translate(s, MagicMock(), MagicMock()))
                 loop.close()
                 assert r is None
+        finally:
+            restore()
+
+    def test_normalize_discord_command_name(self) -> None:
+        assert _normalize_discord_command_name("Utilisateur") == "utilisateur"
+        assert _normalize_discord_command_name("cooldown time") == "cooldown_time"
+        assert _normalize_discord_command_name("  ") is None
+
+    def test_translate_normalizes_command_names(self, service: LocalizerService, locale_dir: Path) -> None:
+        restore = _chdir(locale_dir)
+        try:
+            fr = locale_dir / "fr.json"
+            fr.write_text(
+                json.dumps([{"identifier": "user", "translation": "Utilisateur"}]),
+                encoding="utf-8",
+            )
+            t = TanjunTranslator(localizer=service)
+            s = MagicMock()
+            s.__str__ = lambda self: "user"
+            context = MagicMock()
+            location = MagicMock()
+            location.name = "parameter_name"
+            context.location = location
+            loop = asyncio.new_event_loop()
+            r = loop.run_until_complete(t.translate(s, _Locale("fr"), context))
+            loop.close()
+            assert r == "utilisateur"
         finally:
             restore()
 

--- a/translator.py
+++ b/translator.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import discord
 from discord import app_commands
 
 from localizer import TRANSLATION_NOT_FOUND, LocalizerService, tanjunLocalizer
+
+_DISCORD_NAME_LOCATION_NAMES = frozenset({"command_name", "group_name", "parameter_name"})
+
+
+def _normalize_discord_command_name(name: str) -> str | None:
+    normalized = re.sub(r"\s+", "_", name.strip().lower())
+    if not normalized:
+        return None
+    return normalized[:32]
 
 
 class TanjunTranslator(app_commands.Translator):
@@ -33,4 +43,11 @@ class TanjunTranslator(app_commands.Translator):
 
         if current == TRANSLATION_NOT_FOUND:
             return None
+
+        location_name = getattr(context.location, "name", None)
+        if location_name in _DISCORD_NAME_LOCATION_NAMES:
+            current = _normalize_discord_command_name(current)
+            if current is None:
+                return None
+
         return current


### PR DESCRIPTION
## Summary
- Normalize French and other locale translations for slash command, group, and parameter names before Discord sync (lowercase, spaces to underscores, max 32 chars).
- Fixes widespread `name_localizations.fr: Command name is invalid` errors caused by Crowdin title-case strings like `Utilisateur` and generic keys such as `user` being applied to every `user` parameter.

## Test plan
- [x] `pytest tests/unit/core/test_localizer.py::TestTanjunTranslator -q`
- [ ] Restart bot and run admin sync; confirm French command registration succeeds without name_localizations errors


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of translated Discord command names to ensure compliance with Discord's naming requirements (space normalization, character limits, and format validation).

* **Tests**
  * Added comprehensive test coverage for Discord command name translation and normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->