### PR TITLE
fix: normalize command name translations in all locale files

### DIFF
--- a/locales/bg.json
+++ b/locales/bg.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/da.json
+++ b/locales/da.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -11129,8 +11129,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13913,8 +13913,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13993,8 +13993,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14473,8 +14473,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -23185,8 +23185,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23241,8 +23241,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23289,8 +23289,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23337,8 +23337,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23393,8 +23393,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23441,8 +23441,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23489,8 +23489,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23537,8 +23537,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -24313,8 +24313,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -24329,8 +24329,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -24681,8 +24681,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -30473,8 +30473,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30489,16 +30489,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30513,8 +30513,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30529,16 +30529,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -30553,8 +30553,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30569,16 +30569,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30593,8 +30593,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30609,16 +30609,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33033,8 +33033,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,16 +33049,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33073,8 +33073,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,8 +33089,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,8 +33209,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -34505,8 +34505,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/el.json
+++ b/locales/el.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -11129,8 +11129,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13913,8 +13913,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13993,8 +13993,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14473,8 +14473,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -23185,8 +23185,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23241,8 +23241,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23289,8 +23289,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23337,8 +23337,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23393,8 +23393,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23441,8 +23441,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23489,8 +23489,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23537,8 +23537,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -24313,8 +24313,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -24329,8 +24329,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -24681,8 +24681,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -30473,8 +30473,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30489,16 +30489,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30513,8 +30513,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30529,16 +30529,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -30553,8 +30553,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30569,16 +30569,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30593,8 +30593,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30609,16 +30609,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33033,8 +33033,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,16 +33049,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33073,8 +33073,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,8 +33089,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,8 +33209,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -34505,8 +34505,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -5081,8 +5081,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9881,8 +9881,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9961,8 +9961,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12561,8 +12561,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14969,8 +14969,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16361,8 +16361,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16409,8 +16409,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16457,8 +16457,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16505,8 +16505,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16553,8 +16553,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16601,8 +16601,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16649,8 +16649,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16697,8 +16697,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16745,8 +16745,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22065,8 +22065,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28921,8 +28921,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28937,8 +28937,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -29121,16 +29121,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -29241,8 +29241,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29257,8 +29257,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29393,16 +29393,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29457,8 +29457,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29481,8 +29481,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29497,8 +29497,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29513,8 +29513,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29545,8 +29545,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29561,8 +29561,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29577,8 +29577,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29665,24 +29665,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29697,8 +29697,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29721,8 +29721,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29785,8 +29785,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33585,16 +33585,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33777,16 +33777,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33809,24 +33809,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33849,16 +33849,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33873,16 +33873,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33905,8 +33905,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -34089,8 +34089,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -34105,16 +34105,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -34129,16 +34129,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -34153,8 +34153,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -34329,8 +34329,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -4994,7 +4994,7 @@
   {
     "identifier": "commands.logs.blacklist.add.name",
     "source_string": "add",
-    "translation": "Ajouter",
+    "translation": "ajouter",
     "context": "Slash subcommand or option name for `/logs blacklist` (add).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -5018,7 +5018,7 @@
   {
     "identifier": "commands.logs.blacklist.remove.name",
     "source_string": "Remove",
-    "translation": "Supprimer",
+    "translation": "supprimer",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -5042,7 +5042,7 @@
   {
     "identifier": "commands.logs.blacklist.show.name",
     "source_string": "show",
-    "translation": "Afficher",
+    "translation": "afficher",
     "context": "Name of the reply embed for `/logs blacklist` when display or list view.",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14418,7 +14418,7 @@
   {
     "identifier": "admin.addrole.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/addrole` (shown in Discord's slash command option list). Used in `extensions/admin.py`.",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14434,7 +14434,7 @@
   {
     "identifier": "admin.addrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/addrole` (shown in Discord's slash command option list). Used in `extensions/admin.py`.",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14466,7 +14466,7 @@
   {
     "identifier": "admin.removerole.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/removerole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14482,7 +14482,7 @@
   {
     "identifier": "admin.removerole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/removerole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14514,7 +14514,7 @@
   {
     "identifier": "admin.createrole.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/createrole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14594,7 +14594,7 @@
   {
     "identifier": "admin.createrole.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/createrole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14642,7 +14642,7 @@
   {
     "identifier": "admin.deleterole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/deleterole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14658,7 +14658,7 @@
   {
     "identifier": "admin.deleterole.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/deleterole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14690,7 +14690,7 @@
   {
     "identifier": "admin.moverole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14786,7 +14786,7 @@
   {
     "identifier": "admin.kick.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/kick` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14802,7 +14802,7 @@
   {
     "identifier": "admin.kick.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/kick` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14834,7 +14834,7 @@
   {
     "identifier": "admin.ban.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/ban` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14850,7 +14850,7 @@
   {
     "identifier": "admin.ban.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/ban` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14914,7 +14914,7 @@
   {
     "identifier": "admin.unban.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/unban` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14946,7 +14946,7 @@
   {
     "identifier": "admin.timeout.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/timeout` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14962,7 +14962,7 @@
   {
     "identifier": "admin.timeout.params.duration.name",
     "source_string": "duration",
-    "translation": "Durée",
+    "translation": "durée",
     "context": "Display name of the `duration` option on `/timeout` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -14978,7 +14978,7 @@
   {
     "identifier": "admin.timeout.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/timeout` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15010,7 +15010,7 @@
   {
     "identifier": "admin.removetimeout.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/removetimeout` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15026,7 +15026,7 @@
   {
     "identifier": "admin.removetimeout.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/removetimeout` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15042,7 +15042,7 @@
   {
     "identifier": "admin.purge.name",
     "source_string": "delete",
-    "translation": "Supprimer",
+    "translation": "supprimer",
     "context": "Slash command name for `/purge` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -15074,7 +15074,7 @@
   {
     "identifier": "admin.purge.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/purge` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15202,7 +15202,7 @@
   {
     "identifier": "admin.nickname.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/nickname` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15266,7 +15266,7 @@
   {
     "identifier": "admin.slowmode.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/slowmode` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15298,7 +15298,7 @@
   {
     "identifier": "admin.lock.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/lock` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15330,7 +15330,7 @@
   {
     "identifier": "admin.unlock.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/unlock` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15346,7 +15346,7 @@
   {
     "identifier": "admin.warn.add.name",
     "source_string": "add",
-    "translation": "Ajouter",
+    "translation": "ajouter",
     "context": "Slash command name for `/warn` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -15378,7 +15378,7 @@
   {
     "identifier": "admin.warn.view.name",
     "source_string": "show",
-    "translation": "Afficher",
+    "translation": "afficher",
     "context": "Slash command name for `/warn` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -15402,7 +15402,7 @@
   {
     "identifier": "admin.warn.config.name",
     "source_string": "configure",
-    "translation": "Configurer",
+    "translation": "configurer",
     "context": "Slash command name for `/warn` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -15434,7 +15434,7 @@
   {
     "identifier": "admin.nuke.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/nuke` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15466,7 +15466,7 @@
   {
     "identifier": "admin.say.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/say` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15482,7 +15482,7 @@
   {
     "identifier": "admin.say.params.message.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/say` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15514,7 +15514,7 @@
   {
     "identifier": "admin.embed.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/embed` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15562,7 +15562,7 @@
   {
     "identifier": "admin.createemoji.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/createemoji` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15650,7 +15650,7 @@
   {
     "identifier": "admin.createticket.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/createticket` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15666,7 +15666,7 @@
   {
     "identifier": "admin.createticket.params.description.name",
     "source_string": "description",
-    "translation": "Description",
+    "translation": "description",
     "context": "Display name of the `description` option on `/createticket` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15682,7 +15682,7 @@
   {
     "identifier": "admin.createticket.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/createticket` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15762,7 +15762,7 @@
   {
     "identifier": "admin.copyrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/copyrole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15810,7 +15810,7 @@
   {
     "identifier": "admin.rps.setchannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/rps` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15858,7 +15858,7 @@
   {
     "identifier": "admin.rps.showreports.params.user.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `user` option on `/rps` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15890,7 +15890,7 @@
   {
     "identifier": "admin.triggermessages.params.message.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/triggermessages` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -15906,7 +15906,7 @@
   {
     "identifier": "admin.tm.configure.name",
     "source_string": "configure",
-    "translation": "Configurer",
+    "translation": "configurer",
     "context": "Slash command name for `/tm` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -15922,7 +15922,7 @@
   {
     "identifier": "admin.tm.add.name",
     "source_string": "add",
-    "translation": "Ajouter",
+    "translation": "ajouter",
     "context": "Slash command name for `/tm` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -16002,7 +16002,7 @@
   {
     "identifier": "admin.jtc.setchannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/jtc` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16034,7 +16034,7 @@
   {
     "identifier": "admin.jtc.removechannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/jtc` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16082,7 +16082,7 @@
   {
     "identifier": "fun.hug.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16130,7 +16130,7 @@
   {
     "identifier": "fun.kiss.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16178,7 +16178,7 @@
   {
     "identifier": "fun.boop.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16226,7 +16226,7 @@
   {
     "identifier": "fun.wave.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16274,7 +16274,7 @@
   {
     "identifier": "fun.laugh.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16322,7 +16322,7 @@
   {
     "identifier": "fun.pat.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16370,7 +16370,7 @@
   {
     "identifier": "fun.poke.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16418,7 +16418,7 @@
   {
     "identifier": "fun.slap.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16466,7 +16466,7 @@
   {
     "identifier": "fun.tickle.params.member.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `member` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16514,7 +16514,7 @@
   {
     "identifier": "fun.action.params.action.name",
     "source_string": "action",
-    "translation": "Action",
+    "translation": "action",
     "context": "Display name of the `action` option on `/fun action` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16730,7 +16730,7 @@
   {
     "identifier": "math.num2word.params.locale.name",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Display name of the `locale` option on `/math num2word` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -16954,7 +16954,7 @@
   {
     "identifier": "utility.avatar.params.user.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `user` option on `/utility avatar` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -16986,7 +16986,7 @@
   {
     "identifier": "utility.banner.params.user.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `user` option on `/utility banner` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17018,7 +17018,7 @@
   {
     "identifier": "utility.avatardecoration.params.user.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `user` option on `/utility avatardecoration` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17066,7 +17066,7 @@
   {
     "identifier": "utility.afk.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/utility afk` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17098,7 +17098,7 @@
   {
     "identifier": "utility.report.params.user.name",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Display name of the `user` option on `/utility report` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17114,7 +17114,7 @@
   {
     "identifier": "utility.report.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/utility report` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17194,7 +17194,7 @@
   {
     "identifier": "utility.autopublish.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility autopublish` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17226,7 +17226,7 @@
   {
     "identifier": "utility.autopublish.remove.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility autopublish` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17274,7 +17274,7 @@
   {
     "identifier": "utility.claimboosterrole.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/utility claimboosterrole` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17354,7 +17354,7 @@
   {
     "identifier": "utility.setupboosterrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/utility setupboosterrole` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17402,7 +17402,7 @@
   {
     "identifier": "utility.claimboosterchannel.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/utility claimboosterchannel` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17450,7 +17450,7 @@
   {
     "identifier": "utility.setupboosterchannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility setupboosterchannel` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17498,7 +17498,7 @@
   {
     "identifier": "utility.scheduledmessage.params.content.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `content` option on `/utility scheduledmessage` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17530,7 +17530,7 @@
   {
     "identifier": "utility.scheduledmessage.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility scheduledmessage` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17658,7 +17658,7 @@
   {
     "identifier": "utility.schedulemessage.params.content.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `content` option on `/utility schedulemessage` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17690,7 +17690,7 @@
   {
     "identifier": "utility.schedulemessage.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility schedulemessage` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -17978,7 +17978,7 @@
   {
     "identifier": "utility.twitch.add.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/utility twitch` (shown in Discord's slash command option list).",
     "labels": "utility, command_option_name",
     "max_length": 32
@@ -19218,7 +19218,7 @@
   {
     "identifier": "minigames.setcountingchallengeprogress.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcountingchallengeprogress` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19362,7 +19362,7 @@
   {
     "identifier": "minigames.setwordcainch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setwordcainch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19394,7 +19394,7 @@
   {
     "identifier": "minigames.removewordchch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames removewordchch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19426,7 +19426,7 @@
   {
     "identifier": "minigames.setcountingch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcountingch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19458,7 +19458,7 @@
   {
     "identifier": "minigames.removecountingch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames removecountingch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19490,7 +19490,7 @@
   {
     "identifier": "minigames.setcprogress.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcprogress` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19538,7 +19538,7 @@
   {
     "identifier": "minigames.setcchallengech.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcchallengech` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19570,7 +19570,7 @@
   {
     "identifier": "minigames.rcchallengech.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames rcchallengech` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19602,7 +19602,7 @@
   {
     "identifier": "minigames.setcchallengechannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcchallengechannel` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19634,7 +19634,7 @@
   {
     "identifier": "minigames.setcmodesch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcmodesch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19666,7 +19666,7 @@
   {
     "identifier": "minigames.removecmodesch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames removecmodesch` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19698,7 +19698,7 @@
   {
     "identifier": "minigames.setcchallengep.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcchallengep` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19746,7 +19746,7 @@
   {
     "identifier": "minigames.setcmodesprogress.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/minigames setcmodesprogress` (shown in Discord's slash command option list).",
     "labels": "minigames, command_option_name",
     "max_length": 32
@@ -19794,7 +19794,7 @@
   {
     "identifier": "games.ttt.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/games ttt` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -19978,7 +19978,7 @@
   {
     "identifier": "games.wordle.params.language.name",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Display name of the `language` option on `/games wordle` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -20186,7 +20186,7 @@
   {
     "identifier": "games.hangman.params.language.name",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Display name of the `language` option on `/games hangman` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -20410,7 +20410,7 @@
   {
     "identifier": "games.rps.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/games rps` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -20442,7 +20442,7 @@
   {
     "identifier": "games.battleship.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/games battleship` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -20474,7 +20474,7 @@
   {
     "identifier": "level.leaderboard.params.page.name",
     "source_string": "page",
-    "translation": "Page",
+    "translation": "page",
     "context": "Display name of the `page` option on `/level leaderboard` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20506,7 +20506,7 @@
   {
     "identifier": "level.setvoicecooldown.params.cooldown.name",
     "source_string": "cooldown",
-    "translation": "Recharge",
+    "translation": "recharge",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20538,7 +20538,7 @@
   {
     "identifier": "level.settextcooldown.params.cooldown.name",
     "source_string": "cooldown",
-    "translation": "Recharge",
+    "translation": "recharge",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20570,7 +20570,7 @@
   {
     "identifier": "level.givexp.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level givexp` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20618,7 +20618,7 @@
   {
     "identifier": "level.takexp.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level takexp` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20666,7 +20666,7 @@
   {
     "identifier": "level.setxp.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level setxp` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20714,7 +20714,7 @@
   {
     "identifier": "level.rank.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level rank` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20794,7 +20794,7 @@
   {
     "identifier": "level.blacklist.removec.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20826,7 +20826,7 @@
   {
     "identifier": "level.blacklist.addr.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20842,7 +20842,7 @@
   {
     "identifier": "level.blacklist.addr.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20874,7 +20874,7 @@
   {
     "identifier": "level.blacklist.remover.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20906,7 +20906,7 @@
   {
     "identifier": "level.blacklist.addu.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20922,7 +20922,7 @@
   {
     "identifier": "level.blacklist.addu.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20954,7 +20954,7 @@
   {
     "identifier": "level.blacklist.addc.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -20970,7 +20970,7 @@
   {
     "identifier": "level.blacklist.addc.params.reason.name",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Display name of the `reason` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21002,7 +21002,7 @@
   {
     "identifier": "level.blacklist.removeu.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level blacklist` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21178,7 +21178,7 @@
   {
     "identifier": "level.setlevelupchannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level setlevelupchannel` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21306,7 +21306,7 @@
   {
     "identifier": "level.addlevelrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level addlevelrole` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21354,7 +21354,7 @@
   {
     "identifier": "level.removelevelrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level removelevelrole` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21434,7 +21434,7 @@
   {
     "identifier": "level.boosts.calculate_user.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21466,7 +21466,7 @@
   {
     "identifier": "level.boosts.calculate.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21482,7 +21482,7 @@
   {
     "identifier": "level.boosts.calculate.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21514,7 +21514,7 @@
   {
     "identifier": "level.boosts.addrole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21578,7 +21578,7 @@
   {
     "identifier": "level.boosts.addchannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21642,7 +21642,7 @@
   {
     "identifier": "level.boosts.adduser.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21706,7 +21706,7 @@
   {
     "identifier": "level.boosts.removerole.params.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Display name of the `role` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21738,7 +21738,7 @@
   {
     "identifier": "level.boosts.removechannel.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21770,7 +21770,7 @@
   {
     "identifier": "level.boosts.removeuser.params.user.name",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Display name of the `user` option on `/level boosts` (shown in Discord's slash command option list).",
     "labels": "leveling, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -21850,7 +21850,7 @@
   {
     "identifier": "giveaway.start.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/giveaway start` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -22130,7 +22130,7 @@
   {
     "identifier": "ai.createcustom.params.name.name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Display name of the `name` option on `/ai createcustom` (shown in Discord's slash command option list).",
     "labels": "ai, command_option_name",
     "max_length": 32
@@ -25770,7 +25770,7 @@
   {
     "identifier": "image.blur.params.type.name",
     "source_string": "type",
-    "translation": "Type",
+    "translation": "type",
     "context": "Display name of the `type` option on `/image blur` (shown in Discord's slash command option list).",
     "labels": "command_option_name",
     "max_length": 32
@@ -26234,7 +26234,7 @@
   {
     "identifier": "channel.media.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (media params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26266,7 +26266,7 @@
   {
     "identifier": "channel.mediaremove.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (mediaremove params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26298,7 +26298,7 @@
   {
     "identifier": "channel.w.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (w params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26314,7 +26314,7 @@
   {
     "identifier": "channel.w.params.message.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/channel` (w params message name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26394,7 +26394,7 @@
   {
     "identifier": "channel.farewell.set.ch.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (farewell set ch params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26410,7 +26410,7 @@
   {
     "identifier": "channel.farewell.set.ch.params.message.name",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/channel` (farewell set ch params message name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26490,7 +26490,7 @@
   {
     "identifier": "channel.ds.add.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (ds add params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -26570,7 +26570,7 @@
   {
     "identifier": "channel.ds.remove.params.channel.name",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Display name of the `channel` option on `/channel` (ds remove params channel name) (shown in Discord's slash command option list).",
     "labels": "channel, command_option_name",
     "max_length": 32
@@ -28626,7 +28626,7 @@
   {
     "identifier": "cooldown",
     "source_string": "cooldown",
-    "translation": "Recharge",
+    "translation": "recharge",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"cooldown\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28666,7 +28666,7 @@
   {
     "identifier": "user",
     "source_string": "user",
-    "translation": "Utilisateur",
+    "translation": "utilisateur",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"user\".",
     "labels": "command_name",
     "max_length": 32
@@ -28674,7 +28674,7 @@
   {
     "identifier": "role",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"role\".",
     "labels": "command_name",
     "max_length": 32
@@ -28682,7 +28682,7 @@
   {
     "identifier": "name",
     "source_string": "name",
-    "translation": "Nom",
+    "translation": "nom",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"name\".",
     "labels": "command_name",
     "max_length": 32
@@ -28722,7 +28722,7 @@
   {
     "identifier": "reason",
     "source_string": "reason",
-    "translation": "Raison",
+    "translation": "raison",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"reason\".",
     "labels": "command_name",
     "max_length": 32
@@ -28770,7 +28770,7 @@
   {
     "identifier": "member",
     "source_string": "member",
-    "translation": "Membre",
+    "translation": "membre",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"member\".",
     "labels": "command_name",
     "max_length": 32
@@ -28810,7 +28810,7 @@
   {
     "identifier": "message",
     "source_string": "message",
-    "translation": "Message",
+    "translation": "message",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"message\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28882,7 +28882,7 @@
   {
     "identifier": "locale",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"language\".",
     "labels": "command_name",
     "max_length": 32
@@ -28922,7 +28922,7 @@
   {
     "identifier": "duration",
     "source_string": "duration",
-    "translation": "Durée",
+    "translation": "durée",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"duration\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29114,15 +29114,15 @@
   {
     "identifier": "help",
     "source_string": "Help",
-    "translation": "Aide",
+    "translation": "aide",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29330,7 +29330,7 @@
   {
     "identifier": "description",
     "source_string": "description",
-    "translation": "Description",
+    "translation": "description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29450,7 +29450,7 @@
   {
     "identifier": "category",
     "source_string": "category",
-    "translation": "Catégorie",
+    "translation": "catégorie",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"category\".",
     "labels": "command_name",
     "max_length": 32
@@ -29490,7 +29490,7 @@
   {
     "identifier": "page",
     "source_string": "page",
-    "translation": "Page",
+    "translation": "page",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"page\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -29626,7 +29626,7 @@
   {
     "identifier": "admin.role.name",
     "source_string": "role",
-    "translation": "Rôle",
+    "translation": "rôle",
     "context": "Slash command name for `/role` (lowercase, no spaces; registered via locale_str). Discord shows this in the command list. Used in `extensions/admin.py`.",
     "labels": "admin, command_name",
     "max_length": 32
@@ -29778,7 +29778,7 @@
   {
     "identifier": "channel",
     "source_string": "channel",
-    "translation": "Salon",
+    "translation": "salon",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29930,7 +29930,7 @@
   {
     "identifier": "language",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"language\".",
     "labels": "command_name",
     "max_length": 32
@@ -29946,7 +29946,7 @@
   {
     "identifier": "type",
     "source_string": "type",
-    "translation": "Type",
+    "translation": "type",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"type\".",
     "labels": "command_name",
     "max_length": 32
@@ -30362,7 +30362,7 @@
   {
     "identifier": "admin.setlocale.params.locale.name",
     "source_string": "language",
-    "translation": "Langue",
+    "translation": "langue",
     "context": "Display name of the `locale` option on `/setlocale` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/id.json
+++ b/locales/id.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/it.json
+++ b/locales/it.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -5081,8 +5081,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9881,8 +9881,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9961,8 +9961,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12561,8 +12561,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14969,8 +14969,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16361,8 +16361,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16409,8 +16409,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16457,8 +16457,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16505,8 +16505,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16553,8 +16553,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16601,8 +16601,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16649,8 +16649,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16697,8 +16697,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16745,8 +16745,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22065,8 +22065,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28921,8 +28921,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28937,8 +28937,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -29121,16 +29121,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -29241,8 +29241,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29257,8 +29257,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29393,16 +29393,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29457,8 +29457,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29481,8 +29481,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29497,8 +29497,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29513,8 +29513,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29545,8 +29545,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29561,8 +29561,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29577,8 +29577,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29665,24 +29665,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29697,8 +29697,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29721,8 +29721,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29785,8 +29785,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33585,16 +33585,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33777,16 +33777,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33809,24 +33809,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33849,16 +33849,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33873,16 +33873,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33905,8 +33905,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -34089,8 +34089,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -34105,16 +34105,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -34129,16 +34129,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -34153,8 +34153,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -34329,8 +34329,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -10889,8 +10889,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13521,8 +13521,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13601,8 +13601,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14081,8 +14081,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -22441,8 +22441,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22497,8 +22497,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22545,8 +22545,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22593,8 +22593,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22649,8 +22649,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22697,8 +22697,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22745,8 +22745,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22793,8 +22793,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -22841,8 +22841,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23569,8 +23569,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -23937,8 +23937,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -29457,8 +29457,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -29473,16 +29473,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -29497,8 +29497,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -29513,16 +29513,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -29537,8 +29537,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -29553,16 +29553,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -29577,8 +29577,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -29593,16 +29593,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32017,8 +32017,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -32033,16 +32033,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -32057,8 +32057,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -32073,8 +32073,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -32193,8 +32193,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -33497,8 +33497,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -5017,8 +5017,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -9657,8 +9657,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -9737,8 +9737,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -12313,8 +12313,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -14705,8 +14705,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -16097,8 +16097,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16145,8 +16145,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16193,8 +16193,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16241,8 +16241,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16289,8 +16289,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16337,8 +16337,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16385,8 +16385,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16433,8 +16433,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -16481,8 +16481,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -21801,8 +21801,8 @@
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28641,8 +28641,8 @@
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28657,8 +28657,8 @@
   },
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
@@ -28841,16 +28841,16 @@
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
@@ -28961,8 +28961,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -28977,8 +28977,8 @@
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29001,8 +29001,8 @@
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29113,16 +29113,16 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
@@ -29161,8 +29161,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29177,8 +29177,8 @@
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
@@ -29201,8 +29201,8 @@
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
@@ -29233,8 +29233,8 @@
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29265,8 +29265,8 @@
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29281,8 +29281,8 @@
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -29297,8 +29297,8 @@
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
@@ -29385,24 +29385,24 @@
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
@@ -29417,8 +29417,8 @@
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -29441,8 +29441,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -29505,8 +29505,8 @@
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -32825,16 +32825,16 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -33017,16 +33017,16 @@
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,24 +33049,24 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,16 +33089,16 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33113,16 +33113,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33145,8 +33145,8 @@
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33345,16 +33345,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33369,16 +33369,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -33393,8 +33393,8 @@
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -33569,8 +33569,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -11129,8 +11129,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13913,8 +13913,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13993,8 +13993,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14473,8 +14473,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -23185,8 +23185,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23241,8 +23241,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23289,8 +23289,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23337,8 +23337,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23393,8 +23393,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23441,8 +23441,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23489,8 +23489,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23537,8 +23537,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -24313,8 +24313,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -24329,8 +24329,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -24681,8 +24681,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -30473,8 +30473,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30489,16 +30489,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30513,8 +30513,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30529,16 +30529,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -30553,8 +30553,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30569,16 +30569,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30593,8 +30593,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30609,16 +30609,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33033,8 +33033,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,16 +33049,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33073,8 +33073,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,8 +33089,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,8 +33209,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -34505,8 +34505,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -11129,8 +11129,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13913,8 +13913,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13993,8 +13993,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14473,8 +14473,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -23185,8 +23185,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23241,8 +23241,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23289,8 +23289,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23337,8 +23337,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23393,8 +23393,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23441,8 +23441,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23489,8 +23489,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23537,8 +23537,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -24313,8 +24313,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -24329,8 +24329,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -24681,8 +24681,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -30473,8 +30473,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30489,16 +30489,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30513,8 +30513,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30529,16 +30529,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -30553,8 +30553,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30569,16 +30569,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30593,8 +30593,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30609,16 +30609,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33033,8 +33033,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,16 +33049,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33073,8 +33073,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,8 +33089,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,8 +33209,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -34505,8 +34505,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "Manage the server",
-    "translation": "Manage the server",
+    "source_string": "manage_the_server",
+    "translation": "manage_the_server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "Chat GPT ask something",
-    "translation": "Chat GPT ask something",
+    "source_string": "chat_gpt_ask_something",
+    "translation": "chat_gpt_ask_something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "Request a user-defined situation",
-    "translation": "Request a user-defined situation",
+    "source_string": "request_a_user-defined_situation",
+    "translation": "request_a_user-defined_situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "Awst Tanjuwun somethim uwu",
-    "translation": "Awst Tanjuwun somethim uwu",
+    "source_string": "awst_tanjuwun_somethim_uwu",
+    "translation": "awst_tanjuwun_somethim_uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "Blacklist commands",
-    "translation": "Blacklist commands",
+    "source_string": "blacklist_commands",
+    "translation": "blacklist_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "Fun commands",
-    "translation": "Fun commands",
+    "source_string": "fun_commands",
+    "translation": "fun_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "Get help with the bot",
-    "translation": "Get help with the bot",
+    "source_string": "get_help_with_the_bot",
+    "translation": "get_help_with_the_bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "Giveaway commands",
-    "translation": "Giveaway commands",
+    "source_string": "giveaway_commands",
+    "translation": "giveaway_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "Level commands",
-    "translation": "Level commands",
+    "source_string": "level_commands",
+    "translation": "level_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "Manage channel",
-    "translation": "Manage channel",
+    "source_string": "manage_channel",
+    "translation": "manage_channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "Join To Create Manage channels",
-    "translation": "Join To Create Manage channels",
+    "source_string": "join_to_create_manage_channels",
+    "translation": "join_to_create_manage_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "Manage reports",
-    "translation": "Manage reports",
+    "source_string": "manage_reports",
+    "translation": "manage_reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "Manage trigger messages",
-    "translation": "Manage trigger messages",
+    "source_string": "manage_trigger_messages",
+    "translation": "manage_trigger_messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "Manage warnings",
-    "translation": "Manage warnings",
+    "source_string": "manage_warnings",
+    "translation": "manage_warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "Math is fun!",
-    "translation": "Math is fun!",
+    "source_string": "math_is_fun",
+    "translation": "math_is_fun",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "Minigame commands",
-    "translation": "Minigame commands",
+    "source_string": "minigame_commands",
+    "translation": "minigame_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "The frequency penalty setting",
-    "translation": "The frequency penalty setting",
+    "source_string": "the_frequency_penalty_setting",
+    "translation": "the_frequency_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "The personality description",
-    "translation": "The personality description",
+    "source_string": "the_personality_description",
+    "translation": "the_personality_description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "The presence penalty setting",
-    "translation": "The presence penalty setting",
+    "source_string": "the_presence_penalty_setting",
+    "translation": "the_presence_penalty_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "The temperature setting",
-    "translation": "The temperature setting",
+    "source_string": "the_temperature_setting",
+    "translation": "the_temperature_setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "Various commands",
-    "translation": "Various commands",
+    "source_string": "various_commands",
+    "translation": "various_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -1113,8 +1113,8 @@
   },
   {
     "identifier": "admin.moverole.params.targetrole.name",
-    "source_string": "target role",
-    "translation": "target role",
+    "source_string": "target_role",
+    "translation": "target_role",
     "context": "Display name of the `targetrole` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -11129,8 +11129,8 @@
   },
   {
     "identifier": "commands.giveaway.builder.sponsor.select.name",
-    "source_string": "Select sponsor",
-    "translation": "Select sponsor",
+    "source_string": "select_sponsor",
+    "translation": "select_sponsor",
     "context": "Slash subcommand or option name for `/giveaway builder` (sponsor select).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -13913,8 +13913,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level settextcooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -13993,8 +13993,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.params.cooldown.name",
-    "source_string": "cooldown time",
-    "translation": "cooldown time",
+    "source_string": "cooldown_time",
+    "translation": "cooldown_time",
     "context": "Display name of the `cooldown` option on `/level setvoicecooldown` (params cooldown name) (shown in Discord's slash command option list).",
     "labels": "commands, command_option_name",
     "max_length": 32
@@ -14473,8 +14473,8 @@
   },
   {
     "identifier": "commands.logs.blacklist.remove.name",
-    "source_string": "Remove",
-    "translation": "Remove",
+    "source_string": "remove",
+    "translation": "remove",
     "context": "Slash subcommand or option name for `/logs blacklist` (remove).",
     "labels": "commands, command_name",
     "max_length": 32
@@ -23185,8 +23185,8 @@
   },
   {
     "identifier": "fun.boop.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun boop` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23241,8 +23241,8 @@
   },
   {
     "identifier": "fun.hug.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun hug` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23289,8 +23289,8 @@
   },
   {
     "identifier": "fun.kiss.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun kiss` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23337,8 +23337,8 @@
   },
   {
     "identifier": "fun.laugh.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun laugh` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23393,8 +23393,8 @@
   },
   {
     "identifier": "fun.pat.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun pat` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23441,8 +23441,8 @@
   },
   {
     "identifier": "fun.poke.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun poke` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23489,8 +23489,8 @@
   },
   {
     "identifier": "fun.slap.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun slap` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23537,8 +23537,8 @@
   },
   {
     "identifier": "fun.tickle.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun tickle` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -23585,8 +23585,8 @@
   },
   {
     "identifier": "fun.wave.params.message.name",
-    "source_string": "Message",
-    "translation": "Message",
+    "source_string": "message",
+    "translation": "message",
     "context": "Display name of the `message` option on `/fun wave` (shown in Discord's slash command option list).",
     "labels": "fun, command_option_name",
     "max_length": 32
@@ -24313,8 +24313,8 @@
   },
   {
     "identifier": "games_memory_description",
-    "source_string": "Play a memory matching game",
-    "translation": "Play a memory matching game",
+    "source_string": "play_a_memory_matching_game",
+    "translation": "play_a_memory_matching_game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
     "max_length": 32
@@ -24329,8 +24329,8 @@
   },
   {
     "identifier": "games_memory_params_user_description",
-    "source_string": "The user to play against",
-    "translation": "The user to play against",
+    "source_string": "the_user_to_play_against",
+    "translation": "the_user_to_play_against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
     "max_length": 32
@@ -24681,8 +24681,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "Help",
-    "translation": "Help",
+    "source_string": "help",
+    "translation": "help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -30473,8 +30473,8 @@
   },
   {
     "identifier": "logs_blacklistcat_add_description",
-    "source_string": "Blacklist a category from logs",
-    "translation": "Blacklist a category from logs",
+    "source_string": "blacklist_a_category_from_logs",
+    "translation": "blacklist_a_category_from_logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30489,16 +30489,16 @@
   },
   {
     "identifier": "logs_blacklistcat_add_params_channel_description",
-    "source_string": "The category to blacklist",
-    "translation": "The category to blacklist",
+    "source_string": "the_category_to_blacklist",
+    "translation": "the_category_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_description",
-    "source_string": "Manage the category blacklist for logging",
-    "translation": "Manage the category blacklist for logging",
+    "source_string": "manage_the_category_blacklist_fo",
+    "translation": "manage_the_category_blacklist_fo",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30513,8 +30513,8 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_description",
-    "source_string": "Remove a category from the log blacklist",
-    "translation": "Remove a category from the log blacklist",
+    "source_string": "remove_a_category_from_the_log_b",
+    "translation": "remove_a_category_from_the_log_b",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30529,16 +30529,16 @@
   },
   {
     "identifier": "logs_blacklistcat_remove_params_channel_description",
-    "source_string": "The category to remove from blacklist",
-    "translation": "The category to remove from blacklist",
+    "source_string": "the_category_to_remove_from_blac",
+    "translation": "the_category_to_remove_from_blac",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistcat_show_description",
-    "source_string": "Show blacklisted categories",
-    "translation": "Show blacklisted categories",
+    "source_string": "show_blacklisted_categories",
+    "translation": "show_blacklisted_categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
     "max_length": 32
@@ -30553,8 +30553,8 @@
   },
   {
     "identifier": "logs_blacklistv_add_description",
-    "source_string": "Blacklist a voice channel from logs",
-    "translation": "Blacklist a voice channel from logs",
+    "source_string": "blacklist_a_voice_channel_from_l",
+    "translation": "blacklist_a_voice_channel_from_l",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
     "labels": "command_name",
     "max_length": 32
@@ -30569,16 +30569,16 @@
   },
   {
     "identifier": "logs_blacklistv_add_params_channel_description",
-    "source_string": "The voice channel to blacklist",
-    "translation": "The voice channel to blacklist",
+    "source_string": "the_voice_channel_to_blacklist",
+    "translation": "the_voice_channel_to_blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_description",
-    "source_string": "Manage the voice channel blacklist for logging",
-    "translation": "Manage the voice channel blacklist for logging",
+    "source_string": "manage_the_voice_channel_blackli",
+    "translation": "manage_the_voice_channel_blackli",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -30593,8 +30593,8 @@
   },
   {
     "identifier": "logs_blacklistv_remove_description",
-    "source_string": "Remove a voice channel from the log blacklist",
-    "translation": "Remove a voice channel from the log blacklist",
+    "source_string": "remove_a_voice_channel_from_the_",
+    "translation": "remove_a_voice_channel_from_the_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
     "labels": "command_name",
     "max_length": 32
@@ -30609,16 +30609,16 @@
   },
   {
     "identifier": "logs_blacklistv_remove_params_channel_description",
-    "source_string": "The voice channel to remove from blacklist",
-    "translation": "The voice channel to remove from blacklist",
+    "source_string": "the_voice_channel_to_remove_from",
+    "translation": "the_voice_channel_to_remove_from",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "logs_blacklistv_show_description",
-    "source_string": "Show blacklisted voice channels",
-    "translation": "Show blacklisted voice channels",
+    "source_string": "show_blacklisted_voice_channels",
+    "translation": "show_blacklisted_voice_channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
     "max_length": 32
@@ -33033,8 +33033,8 @@
   },
   {
     "identifier": "setup_booster_description",
-    "source_string": "Interactive wizard for booster perks configuration",
-    "translation": "Interactive wizard for booster perks configuration",
+    "source_string": "interactive_wizard_for_booster_p",
+    "translation": "interactive_wizard_for_booster_p",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33049,16 +33049,16 @@
   },
   {
     "identifier": "setup_description",
-    "source_string": "Interactive setup wizards",
-    "translation": "Interactive setup wizards",
+    "source_string": "interactive_setup_wizards",
+    "translation": "interactive_setup_wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup_giveaway_description",
-    "source_string": "Interactive wizard to create a giveaway",
-    "translation": "Interactive wizard to create a giveaway",
+    "source_string": "interactive_wizard_to_create_a_g",
+    "translation": "interactive_wizard_to_create_a_g",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33073,8 +33073,8 @@
   },
   {
     "identifier": "setup_level_description",
-    "source_string": "Interactive wizard to configure the leveling system",
-    "translation": "Interactive wizard to configure the leveling system",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33089,8 +33089,8 @@
   },
   {
     "identifier": "setup_logs_description",
-    "source_string": "Interactive wizard to configure logging",
-    "translation": "Interactive wizard to configure logging",
+    "source_string": "interactive_wizard_to_configure_",
+    "translation": "interactive_wizard_to_configure_",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,8 +33209,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger news",
-    "translation": "trigger news",
+    "source_string": "trigger_news",
+    "translation": "trigger_news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -34505,8 +34505,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "Ai commands",
-    "translation": "Ai commands",
+    "source_string": "ai_commands",
+    "translation": "ai_commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32

--- a/scripts/fix_discord_command_name_translations.py
+++ b/scripts/fix_discord_command_name_translations.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Normalize command/option name translations for Discord slash command rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+LOCALE_DIR = Path(__file__).resolve().parent.parent / "locales"
+NAME_LABELS = frozenset({"command_name", "command_option_name"})
+
+
+def normalize_discord_command_name(name: str) -> str | None:
+    normalized = re.sub(r"\s+", "_", name.strip().lower())
+    normalized = re.sub(r"[^\w\-]", "", normalized, flags=re.UNICODE)
+    if not normalized:
+        return None
+    return normalized[:32]
+
+
+def fix_locale_file(path: Path, *, dry_run: bool) -> int:
+    data: list[dict[str, object]] = json.loads(path.read_text(encoding="utf-8"))
+    changed = 0
+
+    for entry in data:
+        labels_raw = entry.get("labels") or ""
+        labels = {part.strip() for part in str(labels_raw).split(",") if part.strip()}
+        if not labels & NAME_LABELS:
+            continue
+
+        translation = str(entry.get("translation", ""))
+        normalized = normalize_discord_command_name(translation)
+        if normalized is None or normalized == translation:
+            continue
+
+        if not dry_run:
+            entry["translation"] = normalized
+            source = entry.get("source_string")
+            if source is not None and str(source) == translation:
+                entry["source_string"] = normalized
+
+        changed += 1
+
+    if changed and not dry_run:
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    return changed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Report changes without writing files")
+    args = parser.parse_args()
+
+    total = 0
+    for path in sorted(LOCALE_DIR.glob("*.json")):
+        count = fix_locale_file(path, dry_run=args.dry_run)
+        if count:
+            print(f"{path.name}: {count}")
+            total += count
+
+    print(f"total: {total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/core/test_localizer.py
+++ b/tests/unit/core/test_localizer.py
@@ -603,6 +603,7 @@ class TestTanjunTranslator:
     def test_normalize_discord_command_name(self) -> None:
         assert _normalize_discord_command_name("Utilisateur") == "utilisateur"
         assert _normalize_discord_command_name("cooldown time") == "cooldown_time"
+        assert _normalize_discord_command_name("Math is fun!") == "math_is_fun"
         assert _normalize_discord_command_name("  ") is None
 
     def test_translate_normalizes_command_names(self, service: LocalizerService, locale_dir: Path) -> None:

--- a/translator.py
+++ b/translator.py
@@ -13,6 +13,7 @@ _DISCORD_NAME_LOCATION_NAMES = frozenset({"command_name", "group_name", "paramet
 
 def _normalize_discord_command_name(name: str) -> str | None:
     normalized = re.sub(r"\s+", "_", name.strip().lower())
+    normalized = re.sub(r"[^\w\-]", "", normalized, flags=re.UNICODE)
     if not normalized:
         return None
     return normalized[:32]


### PR DESCRIPTION
## Summary
- Normalized **1,345** `command_name` / `command_option_name` translations across all locale files (lowercase, spaces to `_`, invalid punctuation removed, max 32 chars).
- French fixes include cases like `Utilisateur` → `utilisateur`, `Salon` → `salon`, and `cooldown time` → `cooldown_time`.
- Added `scripts/fix_discord_command_name_translations.py` to re-apply after future Crowdin syncs.
- Extended runtime normalization in `translator.py` to strip punctuation such as `!` (complements #3021).

## Test plan
- [x] `pytest tests/unit/core/test_localizer.py::TestTanjunTranslator -q`
- [ ] Restart bot and run command sync; confirm no `name_localizations.fr: Command name is invalid` errors
- [ ] Spot-check a few French slash commands (e.g. `/admin`, `/utility avatar`) show localized option names


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated command display names, option labels, and category names across 20+ supported languages to standardized identifier format.
  * Improved consistency in command browser labels and interactive setup descriptions.

* **Chores**
  * Added automated tool for normalizing command translation strings.
  * Enhanced command name sanitization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->