### PR TITLE
fix: retry MySQL ER_CHECKREAD (1020) errors in XP transactions (#3026)

### DIFF
--- a/api.py
+++ b/api.py
@@ -214,7 +214,7 @@ def _get_pool() -> Pool | None:
 
 
 # Max retries for transient DB failures
-_MAX_DB_RETRIES = 3
+_MAX_DB_RETRIES = 5
 # Pool acquire timeout in seconds
 _POOL_ACQUIRE_TIMEOUT = 10
 # Query execution timeout in seconds
@@ -286,7 +286,7 @@ async def _execute_with_retry(
             err_str = str(e).lower()
             if is_write and ("duplicate column" in err_str or "duplicate key name" in err_str):
                 raise
-            retryable = "deadlock" in err_str or "abort" in err_str or "restart transaction" in err_str
+            retryable = "deadlock" in err_str or "abort" in err_str or "restart transaction" in err_str or "record has changed" in err_str
             if not is_write:
                 retryable = retryable or "connection" in err_str or "timeout" in err_str
             if attempt < _MAX_DB_RETRIES - 1 and retryable:

--- a/tests/unit/api/test_execute_with_retry.py
+++ b/tests/unit/api/test_execute_with_retry.py
@@ -10,7 +10,7 @@ import tests.mock_config as mock_config
 
 mock_config.patch_config_module()
 
-from api import _execute_with_retry, set_bot  # noqa: E402
+from api import _MAX_DB_RETRIES, _execute_with_retry, set_bot  # noqa: E402
 from tests.helpers.db import make_mock_pool  # noqa: E402
 
 pytestmark = pytest.mark.unit
@@ -68,7 +68,7 @@ class TestExecuteWithRetry:
             result = await _execute_with_retry("test_op", callback, "SELECT 1")
 
         assert result is None
-        assert pool.acquire.await_count == 3
+        assert pool.acquire.await_count == _MAX_DB_RETRIES
         callback.assert_not_awaited()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #3026

## Changes
- Added "record has changed" to the retryable error patterns in `_execute_with_retry` to catch MySQL/MariaDB error 1020 (ER_CHECKREAD)
- Increased `_MAX_DB_RETRIES` from 3 to 5 for better handling of transient contention

## Root Cause
When multiple concurrent minigame XP updates hit the same user on the `level` table, MariaDB raises error 1020 `Record has changed since last read in table 'level'; try restarting transaction`. The existing retry logic only checked for "deadlock", "abort", and "restart transaction" - the latter matched, but 3 retries with 0.5s initial backoff wasn't enough for this specific contention pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database resilience by increasing automatic retry attempts for transient failures.
  * Broader recognition of transient write errors to reduce spurious failures during concurrent database operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->