### PR TITLE
fix: repair test_bot admin command runtime checks

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -30,7 +30,9 @@ from minigames.counting_modes import get_correct_next_number, get_first_number
 
 # Import test functions only if they exist
 try:
-    from tests import test_commands, test_database, test_ping
+    from tests.test_commands import test_commands
+    from tests.test_database import test_database
+    from tests.test_ping import test_ping
 
     TEST_FUNCTIONS_AVAILABLE = True
 except ImportError:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,16 +8,22 @@ from discord.ext import commands
 
 __test__ = False
 
-
-# Critical command groups that must be registered
-_REQUIRED_COMMAND_GROUPS = {
-    "image",
-    "games",
-    "counting",
-    "counting challenge",
-    "counting modes",
-    "giveaway",
+_REQUIRED_ROOT_GROUPS = {
+    "image_name",
+    "games_name",
+    "minigame_name",
+    "giveaway_name",
 }
+
+_MINIGAME_SUBGROUPS = {
+    "minigames_countingcmds_name",
+    "minigames_cchcmds_name",
+    "minigames_cmodescmds_name",
+}
+
+
+def _command_names(commands_list: list[object]) -> set[str]:
+    return {getattr(cmd, "name", str(cmd)) for cmd in commands_list}
 
 
 async def test_commands(self: commands.Cog, ctx: commands.Context) -> None:
@@ -26,11 +32,20 @@ async def test_commands(self: commands.Cog, ctx: commands.Context) -> None:
     if tree is None:
         raise RuntimeError("Command tree not available")
 
-    commands_list = tree.get_commands()
-    command_names = {cmd.name for cmd in commands_list}
+    root_commands = tree.get_commands()
+    root_names = _command_names(root_commands)
 
-    missing = _REQUIRED_COMMAND_GROUPS - command_names
-    if missing:
-        raise AssertionError(f"Missing required command groups: {', '.join(sorted(missing))}")
+    missing_roots = _REQUIRED_ROOT_GROUPS - root_names
+    if missing_roots:
+        raise AssertionError(f"Missing required command groups: {', '.join(sorted(missing_roots))}")
 
-    await ctx.send(f"✅ All {len(_REQUIRED_COMMAND_GROUPS)} critical command groups registered")
+    minigame_group = next(cmd for cmd in root_commands if getattr(cmd, "name", None) == "minigame_name")
+    sub_names = _command_names(list(getattr(minigame_group, "commands", [])))
+    missing_subs = _MINIGAME_SUBGROUPS - sub_names
+    if missing_subs:
+        raise AssertionError(f"Missing required minigame subcommands: {', '.join(sorted(missing_subs))}")
+
+    await ctx.send(
+        f"✅ All {len(_REQUIRED_ROOT_GROUPS)} critical command groups and "
+        f"{len(_MINIGAME_SUBGROUPS)} minigame subcommands registered"
+    )

--- a/tests/unit/test_bot_runtime_checks.py
+++ b/tests/unit/test_bot_runtime_checks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.test_commands import test_commands as verify_command_tree
+
+
+@pytest.mark.asyncio
+async def test_verify_command_tree_passes_when_required_groups_present() -> None:
+    minigame = MagicMock(name="minigame_name")
+    minigame.name = "minigame_name"
+    counting = MagicMock()
+    counting.name = "minigames_countingcmds_name"
+    challenge = MagicMock()
+    challenge.name = "minigames_cchcmds_name"
+    modes = MagicMock()
+    modes.name = "minigames_cmodescmds_name"
+    minigame.commands = [counting, challenge, modes]
+
+    image = MagicMock()
+    image.name = "image_name"
+    games = MagicMock()
+    games.name = "games_name"
+    giveaway = MagicMock()
+    giveaway.name = "giveaway_name"
+
+    ctx = MagicMock()
+    ctx.bot.tree = MagicMock()
+    ctx.bot.tree.get_commands.return_value = [image, games, minigame, giveaway]
+    ctx.send = AsyncMock()
+
+    await verify_command_tree(MagicMock(), ctx)
+
+    ctx.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_command_tree_fails_when_root_group_missing() -> None:
+    ctx = MagicMock()
+    ctx.bot.tree = MagicMock()
+    ctx.bot.tree.get_commands.return_value = []
+    ctx.send = AsyncMock()
+
+    with pytest.raises(AssertionError, match="Missing required command groups"):
+        await verify_command_tree(MagicMock(), ctx)


### PR DESCRIPTION
## Summary
- Fix `test_bot` importing test modules instead of callable functions, which caused `'module' object is not callable` on the Ping step.
- Update the commands health check to use slash command locale keys (`image_name`, `minigame_name`, etc.) and verify minigame counting subgroups.
- Add unit tests for the command tree verification helper.

## Test plan
- [x] `pytest tests/unit/test_bot_runtime_checks.py`
- [x] `pytest tests/integration/extensions/test_administration_comprehensive.py::TestTestBot`
- [ ] Run `t.test_bot` on a live bot after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced command validation tests to verify both root and nested command structure.
  * Added new unit tests for runtime command tree verification with success and failure scenarios.

* **Chores**
  * Reorganized internal test imports for improved modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->