### PR TITLE
Fix rank card GIF quantization for RGBA frames (#3029)

### DIFF
--- a/services/pillow_service.py
+++ b/services/pillow_service.py
@@ -146,22 +146,32 @@ def load_font(path: str, size: int) -> ImageFont.FreeTypeFont:
     return ImageFont.truetype(path, size)
 
 
+def _frame_for_palette_quantize(frame: Image.Image) -> Image.Image:
+    """Convert a frame to RGB/L so Pillow can apply a shared palette."""
+    if frame.mode in ("RGB", "L"):
+        return frame
+    if frame.mode == "RGBA":
+        background = Image.new("RGB", frame.size, (0, 0, 0))
+        background.paste(frame, mask=frame.split()[3])
+        return background
+    return frame.convert("RGB")
+
+
 def _quantize_frames(frames: list[Image.Image], palette_size: int = 256) -> list[Image.Image]:
-    """Quantize RGBA frames to an optimised palette for smaller GIF output.
+    """Quantize frames to an optimised palette for smaller GIF output.
 
     When there are frames, convert to 'P' mode with a shared adaptive palette
     so the GIF is smaller and renders consistently across viewers.
-    Uses FASTOCTREE for RGBA-safe quantization.
     """
     if len(frames) <= 1:
         return frames
-    # Build a shared palette from the first frame using FASTOCTREE (RGBA-safe)
-    pal = frames[0].quantize(colors=min(palette_size, 256), method=Image.Quantize.FASTOCTREE)
+    prep = [_frame_for_palette_quantize(f) for f in frames]
+    pal = prep[0].quantize(colors=min(palette_size, 256), method=Image.Quantize.FASTOCTREE)
     palette_data = pal.getpalette()
     if palette_data is None:
         return frames
     quantized: list[Image.Image] = []
-    for frame in frames:
+    for frame in prep:
         q = frame.quantize(colors=min(palette_size, 256), palette=pal, method=Image.Quantize.FASTOCTREE)
         quantized.append(q)
     return quantized

--- a/tests/integration/api/test_pillow_service.py
+++ b/tests/integration/api/test_pillow_service.py
@@ -66,6 +66,12 @@ class TestFrameHelpers:
             result = _quantize_frames(frames)
         assert result == frames
 
+    def test_quantize_rgba_frames(self):
+        frames = [_rgba((20, 20), (255, 0, 0, 255)), _rgba((20, 20), (0, 255, 0, 128))]
+        result = _quantize_frames(frames)
+        assert len(result) == 2
+        assert all(f.mode == "P" for f in result)
+
 
 class TestCircularMask:
     def test_mask_size_matches_input(self):
@@ -198,6 +204,11 @@ class TestOverlayAndGif:
         frames = [Image.new("RGB", (20, 20), (i * 20, 0, 0)) for i in range(1, 5)]
         buf = save_optimized_gif(frames, duration=50, quantize=True, loop=2)
         assert len(buf.getvalue()) > 0
+
+    def test_save_optimized_gif_multi_frame_rgba_quantized(self):
+        frames = [_rgba((20, 20), (255, 0, 0, 255)), _rgba((20, 20), (0, 255, 0, 200))]
+        buf = save_optimized_gif(frames, duration=50, quantize=True)
+        assert buf.getvalue().startswith(b"GIF")
 
     def test_save_optimized_gif_extends_short_frame_list(self):
         frames = [_rgba(), _rgba((30, 30), (0, 255, 0, 255))]


### PR DESCRIPTION
## Summary
- Fixes `ValueError: only RGB or L mode images can be quantized to a palette` when generating animated rank cards via `level_rank_name`
- Converts RGBA frames to RGB before shared-palette GIF quantization (Pillow requirement when reusing a palette)
- Adds regression tests for RGBA multi-frame quantization

## Test plan
- [x] `pytest tests/integration/api/test_pillow_service.py`
- [ ] Verify animated rank card with custom GIF background renders without error

Fixes #3029

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized GIF color palette generation for multi-frame animations with improved color consistency across frames
  * Enhanced handling of transparent (RGBA format) images when saving as GIFs with automatic color space conversion
  * Increased robustness with graceful fallback handling when palette generation encounters issues

* **Tests**
  * Added integration tests validating GIF quantization and optimization features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->