### PR TITLE
fix: remove unreachable isinstance guard in _find_group_classes (#3038)

### DIFF
--- a/diagnostics/discovery.py
+++ b/diagnostics/discovery.py
@@ -52,9 +52,7 @@ def _instantiate_group(group_cls: type) -> Optional[Any]:
 
 def _find_group_classes(module: Any) -> list[type]:
     classes: list[type] = []
-    group_base = app_commands.Group
-    if not isinstance(group_base, type):
-        return classes
+    group_base: type = app_commands.Group
     for _name, obj in inspect.getmembers(module, inspect.isclass):
         try:
             if not issubclass(obj, group_base):


### PR DESCRIPTION
Closes #3038

Removed the dead `isinstance(group_base, type)` guard in `_find_group_classes` since `app_commands.Group` is always a concrete class type, making the check always True. This fixes the mypy unreachable code warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code clarity and maintainability in the discovery system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->