### PR TITLE
fix: stop false critical database health alerts when pool is busy

### DIFF
--- a/health/checks/database.py
+++ b/health/checks/database.py
@@ -2,9 +2,8 @@
 
 Validates:
 1. Pool exists: bot._pool is not None
-2. Connection works: pool.acquire() succeeds
-3. Query executes: SELECT 1 returns results
-4. Pool utilization: Not near maxsize (warn if >80% utilized)
+2. Database reachable: standalone connection + SELECT 1 (does not use the pool)
+3. Pool utilization: warn if >80% of maxsize connections are active
 """
 
 from __future__ import annotations
@@ -18,6 +17,32 @@ if TYPE_CHECKING:
     from asyncmy import Pool
 
 
+async def _ping_database() -> None:
+    import asyncmy
+
+    from config import settings
+
+    conn = await asyncio.wait_for(
+        asyncmy.connect(
+            host=settings.database_ip,
+            port=settings.database_port,
+            user=settings.database_user,
+            password=settings.database_password.get_secret_value(),
+            db=settings.database_schema,
+            connect_timeout=5,
+        ),
+        timeout=8,
+    )
+    try:
+        async with conn.cursor() as cursor:
+            await asyncio.wait_for(cursor.execute("SELECT 1"), timeout=5)
+            result = await cursor.fetchone()
+            if not result or result[0] != 1:
+                raise ValueError("SELECT 1 returned unexpected result")
+    finally:
+        conn.close()
+
+
 class DatabaseHealthCheck(HealthCheck):
     """Health check for the MySQL database connection pool."""
 
@@ -27,7 +52,7 @@ class DatabaseHealthCheck(HealthCheck):
 
     @property
     def critical(self) -> bool:
-        return True  # Bot cannot function without DB
+        return True
 
     async def run(self) -> HealthCheckResult:
         pool = self._get_pool()
@@ -39,80 +64,56 @@ class DatabaseHealthCheck(HealthCheck):
             )
 
         details: dict[str, object] = {}
+        pool_size = pool.size
+        pool_maxsize = pool.maxsize
+        pool_freesize = pool.freesize
+        active = max(0, pool_size - pool_freesize)
+
+        details["pool_size"] = pool_size
+        details["pool_maxsize"] = pool_maxsize
+        details["pool_freesize"] = pool_freesize
+        details["pool_active"] = active
+
+        utilization = (active / pool_maxsize) * 100 if pool_maxsize > 0 else 0
+        details["utilization_pct"] = round(utilization, 1)
 
         try:
-            # First acquire and release a connection to verify pool is functional
-            try:
-                conn = await asyncio.wait_for(pool.acquire(), timeout=5.0)
-                pool.release(conn)
-            except TimeoutError:
-                raise  # Propagate to outer handler
-
-            # Now read pool properties after confirming pool is functional
-            pool_size = pool.size
-            pool_maxsize = pool.maxsize
-            pool_freesize = pool.freesize
-            active = max(0, pool_size - pool_freesize)
-
-            details["pool_size"] = pool_size
-            details["pool_maxsize"] = pool_maxsize
-            details["pool_freesize"] = pool_freesize
-            details["pool_active"] = active
-
-            utilization = (active / pool_maxsize) * 100 if pool_maxsize > 0 else 0
-
-            # Acquire a connection and run SELECT 1
-            try:
-                conn = await asyncio.wait_for(pool.acquire(), timeout=5.0)
-            except TimeoutError:
-                raise  # Propagate to outer handler
-
-            async with conn, conn.cursor() as cursor:
-                await cursor.execute("SELECT 1")
-                result = await cursor.fetchone()
-                if not result or result[0] != 1:
-                    return HealthCheckResult(
-                        check_name=self.name,
-                        status=HealthStatus.CRITICAL,
-                        message="SELECT 1 returned unexpected result.",
-                        details=details,
-                    )
-
-            details["utilization_pct"] = round(utilization, 1)
-
-            if utilization > 80:
-                return HealthCheckResult(
-                    check_name=self.name,
-                    status=HealthStatus.DEGRADED,
-                    message=(
-                        f"Database pool utilization is high ({utilization:.1f}%): {active}/{pool_maxsize} connections active."
-                    ),
-                    details=details,
-                )
-
-            return HealthCheckResult(
-                check_name=self.name,
-                status=HealthStatus.HEALTHY,
-                message="Database pool is connected and queries execute successfully.",
-                details=details,
-            )
-
+            await _ping_database()
         except TimeoutError:
             return HealthCheckResult(
                 check_name=self.name,
                 status=HealthStatus.CRITICAL,
-                message="Timed out acquiring database connection.",
+                message="Timed out connecting to database.",
+                details=details,
             )
         except Exception as e:
             return HealthCheckResult(
                 check_name=self.name,
                 status=HealthStatus.CRITICAL,
                 message=f"Database connection failed: {e}",
+                details=details,
             )
+
+        if utilization > 80:
+            return HealthCheckResult(
+                check_name=self.name,
+                status=HealthStatus.DEGRADED,
+                message=(
+                    f"Database pool utilization is high ({utilization:.1f}%): "
+                    f"{active}/{pool_maxsize} connections active."
+                ),
+                details=details,
+            )
+
+        return HealthCheckResult(
+            check_name=self.name,
+            status=HealthStatus.HEALTHY,
+            message="Database is reachable and the connection pool is initialized.",
+            details=details,
+        )
 
     @staticmethod
     def _get_pool() -> Pool | None:
-        """Get the database pool from the bot instance."""
         from api import _get_pool
 
         return _get_pool()

--- a/tests/unit/health/test_database_health_check.py
+++ b/tests/unit/health/test_database_health_check.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from health.checks.database import DatabaseHealthCheck
+from health.checks.database import DatabaseHealthCheck, _ping_database
 
 from health.checks import HealthStatus
 
@@ -14,30 +14,12 @@ def _make_pool(
     size: int = 5,
     maxsize: int = 10,
     freesize: int = 8,
-    select_result: tuple = (1,),
-    acquire_timeout: bool = False,
 ):
     pool = MagicMock()
     pool.size = size
     pool.maxsize = maxsize
     pool.freesize = freesize
-    pool.release = MagicMock()
-
-    conn = MagicMock()
-    cursor = AsyncMock()
-    cursor.execute = AsyncMock()
-    cursor.fetchone = AsyncMock(return_value=select_result)
-    conn.cursor = MagicMock(return_value=AsyncMock())
-    conn.cursor.return_value.__aenter__.return_value = cursor
-    conn.__aenter__ = AsyncMock(return_value=conn)
-    conn.__aexit__ = AsyncMock(return_value=None)
-
-    if acquire_timeout:
-        pool.acquire = AsyncMock(side_effect=TimeoutError)
-    else:
-        pool.acquire = AsyncMock(return_value=conn)
-
-    return pool, conn, cursor
+    return pool
 
 
 class TestDatabaseHealthCheck:
@@ -58,40 +40,64 @@ class TestDatabaseHealthCheck:
 
     @pytest.mark.asyncio
     async def test_healthy_pool(self, check: DatabaseHealthCheck):
-        pool, _, cursor = _make_pool()
-        with patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool):
+        pool = _make_pool()
+        with (
+            patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool),
+            patch("health.checks.database._ping_database", new=AsyncMock()),
+        ):
             result = await check.run()
         assert result.status == HealthStatus.HEALTHY
-        cursor.execute.assert_awaited_with("SELECT 1")
 
     @pytest.mark.asyncio
     async def test_high_utilization_degraded(self, check: DatabaseHealthCheck):
-        pool, _, _ = _make_pool(size=10, maxsize=10, freesize=1)
-        with patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool):
+        pool = _make_pool(size=10, maxsize=10, freesize=1)
+        with (
+            patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool),
+            patch("health.checks.database._ping_database", new=AsyncMock()),
+        ):
             result = await check.run()
         assert result.status == HealthStatus.DEGRADED
         assert "utilization" in result.message.lower()
 
     @pytest.mark.asyncio
-    async def test_acquire_timeout_critical(self, check: DatabaseHealthCheck):
-        pool, _, _ = _make_pool(acquire_timeout=True)
-        with patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool):
+    async def test_connect_timeout_critical(self, check: DatabaseHealthCheck):
+        pool = _make_pool()
+        with (
+            patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool),
+            patch(
+                "health.checks.database._ping_database",
+                new=AsyncMock(side_effect=TimeoutError),
+            ),
+        ):
             result = await check.run()
         assert result.status == HealthStatus.CRITICAL
-        assert "Timed out" in result.message
-
-    @pytest.mark.asyncio
-    async def test_unexpected_select_result(self, check: DatabaseHealthCheck):
-        pool, _, _ = _make_pool(select_result=(0,))
-        with patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool):
-            result = await check.run()
-        assert result.status == HealthStatus.CRITICAL
+        assert "Timed out connecting" in result.message
 
     @pytest.mark.asyncio
     async def test_connection_exception(self, check: DatabaseHealthCheck):
-        pool = MagicMock()
-        pool.acquire = AsyncMock(side_effect=Exception("connection refused"))
-        with patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool):
+        pool = _make_pool()
+        with (
+            patch.object(DatabaseHealthCheck, "_get_pool", return_value=pool),
+            patch(
+                "health.checks.database._ping_database",
+                new=AsyncMock(side_effect=Exception("connection refused")),
+            ),
+        ):
             result = await check.run()
         assert result.status == HealthStatus.CRITICAL
         assert "connection refused" in result.message
+
+
+class TestPingDatabase:
+    @pytest.mark.asyncio
+    async def test_unexpected_select_result(self):
+        mock_cursor = AsyncMock()
+        mock_cursor.execute = AsyncMock()
+        mock_cursor.fetchone = AsyncMock(return_value=(0,))
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__aenter__.return_value = mock_cursor
+        mock_conn.close = MagicMock()
+
+        with patch("asyncmy.connect", new=AsyncMock(return_value=mock_conn)):
+            with pytest.raises(ValueError, match="unexpected result"):
+                await _ping_database()


### PR DESCRIPTION
## Summary

- Database periodic health checks no longer call `pool.acquire()` on the shared connection pool.
- Connectivity is verified with a standalone `asyncmy` connection (same approach as `check_pool_health` in `api.py`).
- Pool utilization is still reported from pool stats; high utilization remains **degraded**, not **critical**.

## Problem

When all 20 pool connections were in use, the health check timed out after 5s and sent Discord alerts like:

> Timed out acquiring database connection.

MariaDB was often healthy; the pool was just saturated.

## Test plan

- [x] Unit tests updated in `tests/unit/health/test_database_health_check.py`
- [ ] Deploy to staging and confirm no false critical DB alerts under load
- [ ] Confirm real DB outages still produce critical alerts (`Timed out connecting to database` / connection errors)