### PR TITLE
feat: add live progress feedback to t.sync command

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import tempfile
+import time
 from typing import Any
 
 import aiohttp
@@ -77,10 +78,71 @@ class AdministrationCog(commands.Cog):
             return
         if not ctx.bot.tree:
             return
-        fmt = await ctx.bot.tree.sync()
-        await ctx.send(
-            embed=success_embed(tanjunLocalizer.localize(self._locale(ctx), "commands.admin.sync.completed", count=len(fmt)))
+
+        locale = self._locale(ctx)
+        command_count = sum(1 for _ in ctx.bot.tree.walk_commands())
+        started = time.monotonic()
+        spinner_frames = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+        tick = 0
+
+        status_msg = await ctx.send(
+            embed=embed_or_wrap(
+                tanjunLocalizer.localize(
+                    locale,
+                    "commands.admin.sync.in_progress",
+                    command_count=command_count,
+                    elapsed=0,
+                    spinner=spinner_frames[0],
+                ),
+                title="Command Sync",
+            )
         )
+
+        sync_task = asyncio.create_task(ctx.bot.tree.sync())
+        try:
+            while not sync_task.done():
+                await asyncio.sleep(2)
+                if sync_task.done():
+                    break
+                tick += 1
+                elapsed = int(time.monotonic() - started)
+                await status_msg.edit(
+                    embed=embed_or_wrap(
+                        tanjunLocalizer.localize(
+                            locale,
+                            "commands.admin.sync.in_progress",
+                            command_count=command_count,
+                            elapsed=elapsed,
+                            spinner=spinner_frames[tick % len(spinner_frames)],
+                        ),
+                        title="Command Sync",
+                    )
+                )
+
+            fmt = await sync_task
+            duration = round(time.monotonic() - started, 1)
+            await status_msg.edit(
+                embed=success_embed(
+                    tanjunLocalizer.localize(
+                        locale,
+                        "commands.admin.sync.completed",
+                        count=len(fmt),
+                        duration=duration,
+                    ),
+                    title="Command Sync",
+                )
+            )
+        except Exception as e:
+            if not sync_task.done():
+                sync_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await sync_task
+            await status_msg.edit(
+                embed=error_embed(
+                    tanjunLocalizer.localize(locale, "commands.admin.sync.failed", error=e),
+                    title="Command Sync",
+                )
+            )
 
     @commands.command()
     async def feedback(self, ctx: commands.Context, *, content: str) -> None:  # type: ignore[type-arg]

--- a/locales/bg.json
+++ b/locales/bg.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Синхронизиране на ${command_count} slash команди с Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} команди синхронизирани за ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Синхронизацията на командите не бе успешна: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Synchronizace ${command_count} slash příkazů s Discordem… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} příkazů synchronizováno za ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Synchronizace příkazů selhala: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/da.json
+++ b/locales/da.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Synkroniserer ${command_count} slash-kommandoer med Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} kommandoer synkroniseret på ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Kommandosynkronisering mislykkedes: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/de.json
+++ b/locales/de.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "${command_count} Slash-Befehle werden mit Discord synchronisiert… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} Befehle in ${duration}s synchronisiert.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Synchronisierung fehlgeschlagen: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/el.json
+++ b/locales/el.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Συγχρονισμός ${command_count} slash εντολών με το Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} εντολές συγχρονίστηκαν σε ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Ο συγχρονισμός εντολών απέτυχε: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/en.json
+++ b/locales/en.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} commands synced in ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Command sync failed: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/es-419.json
+++ b/locales/es-419.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Sincronizando ${command_count} comandos slash con Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} comandos sincronizados en ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Error al sincronizar comandos: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Synkronoidaan ${command_count} slash-komentoa Discordin kanssa… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} komentoa synkronoitu ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Komentojen synkronointi epäonnistui: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Synchronisation de ${command_count} commandes slash avec Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} commandes synchronisées en ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Échec de la synchronisation des commandes : ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Discord के साथ ${command_count} स्लैश कमांड सिंक हो रहे हैं… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${duration}s में ${count} कमांड सिंक हो गईं।",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "कमांड सिंक विफल: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Sinkronizacija ${command_count} slash naredbi s Discordom… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} naredbi sinkronizirano za ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Sinkronizacija naredbi nije uspjela: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "${command_count} slash parancs szinkronizálása a Discordon… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} parancs szinkronizálva ${duration} mp alatt.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "A parancsszinkronizálás sikertelen: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/id.json
+++ b/locales/id.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Menyinkronkan ${command_count} perintah slash dengan Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} perintah disinkronkan dalam ${duration} dtk.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Sinkronisasi perintah gagal: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/it.json
+++ b/locales/it.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Sincronizzazione di ${command_count} comandi slash con Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} comandi sincronizzati in ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Sincronizzazione comandi non riuscita: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Discordと${command_count}件のスラッシュコマンドを同期中… ${spinner}（${elapsed}秒）",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count}件のコマンドを${duration}秒で同期しました。",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "コマンドの同期に失敗しました: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Discord와 ${command_count}개의 슬래시 명령어 동기화 중… ${spinner} (${elapsed}초)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${duration}초 만에 ${count}개 명령어 동기화 완료.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "명령어 동기화 실패: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Sinchronizuojamos ${command_count} slash komandos su Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} komandos sinchronizuotos per ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Komandų sinchronizavimas nepavyko: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "${command_count} slash-commando's synchroniseren met Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "${count} commando's gesynchroniseerd in ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Commandsynchronisatie mislukt: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "Đang đồng bộ ${command_count} lệnh slash với Discord… ${spinner} (${elapsed}s)",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "Đã đồng bộ ${count} lệnh trong ${duration}s.",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "Đồng bộ lệnh thất bại: ${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "正在与 Discord 同步 ${command_count} 个斜杠命令… ${spinner}（${elapsed}秒）",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "已在 ${duration} 秒内同步 ${count} 个命令。",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "命令同步失败：${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -7568,10 +7568,26 @@
     "max_length": 256
   },
   {
+    "identifier": "commands.admin.sync.in_progress",
+    "source_string": "Syncing ${command_count} slash commands with Discord… ${spinner} (${elapsed}s)",
+    "translation": "正在與 Discord 同步 ${command_count} 個斜線指令… ${spinner}（${elapsed}秒）",
+    "context": "User-visible message for `t.sync` while the command tree is being synced. Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
     "identifier": "commands.admin.sync.completed",
-    "source_string": "${count} commands have been synced.",
-    "translation": "${count} commands have been synced.",
-    "context": "User-visible message for `/admin sync` (completed). English: \"${count} commands have been synced.\". Used in `extensions/administration.py`.",
+    "source_string": "${count} commands synced in ${duration}s.",
+    "translation": "已在 ${duration} 秒內同步 ${count} 個指令。",
+    "context": "User-visible message for `t.sync` (completed). Used in `extensions/administration.py`.",
+    "labels": "commands",
+    "max_length": null
+  },
+  {
+    "identifier": "commands.admin.sync.failed",
+    "source_string": "Command sync failed: ${error}",
+    "translation": "指令同步失敗：${error}",
+    "context": "User-visible message for `t.sync` when syncing fails. Used in `extensions/administration.py`.",
     "labels": "commands",
     "max_length": null
   },

--- a/tests/integration/extensions/test_administration_comprehensive.py
+++ b/tests/integration/extensions/test_administration_comprehensive.py
@@ -130,10 +130,28 @@ class TestSync:
 
     async def test_sync_success(self, cog: AdministrationCog, bot: MagicMock) -> None:
         bot.tree = MagicMock()
+        bot.tree.walk_commands = MagicMock(return_value=[MagicMock(), MagicMock(), MagicMock()])
         bot.tree.sync = AsyncMock(return_value=[MagicMock(), MagicMock()])
+        status_msg = MagicMock()
+        status_msg.edit = AsyncMock()
         ctx = make_context(bot)
+        ctx.send = AsyncMock(return_value=status_msg)
         await cog.sync(ctx)
         ctx.send.assert_awaited_once()
+        bot.tree.sync.assert_awaited_once()
+        status_msg.edit.assert_awaited()
+
+    async def test_sync_failure(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        bot.tree = MagicMock()
+        bot.tree.walk_commands = MagicMock(return_value=[])
+        bot.tree.sync = AsyncMock(side_effect=RuntimeError("discord down"))
+        status_msg = MagicMock()
+        status_msg.edit = AsyncMock()
+        ctx = make_context(bot)
+        ctx.send = AsyncMock(return_value=status_msg)
+        await cog.sync(ctx)
+        status_msg.edit.assert_awaited()
+        assert status_msg.edit.await_args.kwargs["embed"] is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `t.sync` now posts a status embed immediately and updates it every 2 seconds with a spinner, elapsed time, and slash command count while Discord sync runs.
- On success, the same message is edited to show how many commands synced and total duration; failures update the embed with an error instead of failing silently.
- Added `commands.admin.sync.in_progress`, `completed`, and `failed` strings in all 21 locale files with per-language translations.

## Test plan
- [ ] Run `t.sync` as an admin and confirm the status embed updates while syncing
- [ ] Confirm the final embed shows command count and duration
- [ ] Run integration tests: `pytest tests/integration/extensions/test_administration_comprehensive.py::TestSync`

Made with [Cursor](https://cursor.com)