### PR TITLE
fix: improve test_bot diagnostics output and resolve spec failures

### DIFF
--- a/diagnostics/manifest.json
+++ b/diagnostics/manifest.json
@@ -24,6 +24,7 @@
     "math_name",
     "minigame_name",
     "setup_name",
+    "utility_help_name",
     "utility_scheduledmessage_name",
     "utilitycmd_name"
   ],
@@ -220,7 +221,8 @@
     "utilitycmd_name utility_messagetracking_name utility_messageoptout_name",
     "utilitycmd_name utility_report_name",
     "utilitycmd_name utility_twitch_name utility_twitch_add_name",
-    "utilitycmd_name utility_twitch_name utility_twitch_see_name"
+    "utilitycmd_name utility_twitch_name utility_twitch_see_name",
+    "utility_help_name"
   ],
   "minigame_subgroups": [
     "minigames_cchcmds_name",

--- a/diagnostics/mocks.py
+++ b/diagnostics/mocks.py
@@ -91,5 +91,6 @@ def make_interaction(
     interaction.response.send_modal = AsyncMock()
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
+    interaction.original_response = AsyncMock(return_value=MagicMock())
     interaction.edit_original_response = AsyncMock()
     return interaction

--- a/diagnostics/patches.py
+++ b/diagnostics/patches.py
@@ -52,12 +52,3 @@ def extension_patches(extension: str, extra_targets: tuple[str, ...] = ()) -> It
             stack.enter_context(patch(f"{extension}.{target}", mock))
 
         yield mocks
-
-
-@contextmanager
-def utility_permission_patches() -> Iterator[None]:
-    with (
-        patch("utility.require_moderate_members", new_callable=AsyncMock, return_value=False),
-        patch("utility.require_administrator", new_callable=AsyncMock, return_value=False),
-    ):
-        yield

--- a/diagnostics/registry.py
+++ b/diagnostics/registry.py
@@ -52,11 +52,7 @@ async def run_spec(spec: CommandBehaviorSpec, bot: Any) -> CheckOutcome:
     try:
         from contextlib import ExitStack
 
-        from diagnostics.patches import utility_permission_patches
-
         with ExitStack() as stack:
-            if spec.extension == "extensions.utility":
-                stack.enter_context(utility_permission_patches())
             mocks = stack.enter_context(extension_patches(spec.extension, spec.patch_targets))
             interaction = await asyncio.wait_for(
                 invoke_interaction_command(handler, owner=group, extra_kwargs=extra_kwargs),

--- a/diagnostics/runner.py
+++ b/diagnostics/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Any
 
@@ -35,7 +36,6 @@ EXPECTED_COGS = frozenset(
 
 CONCURRENCY = 8
 SPEC_PROGRESS_INTERVAL = 10
-FAIL_FLUSH_SIZE = 10
 
 
 class DiagnosticsRunner:
@@ -59,6 +59,61 @@ class DiagnosticsRunner:
         if len(content) > 1900:
             content = content[:1900] + "…"
         await self.thread.send(content)
+
+    async def _thread_send_lines(self, lines: list[str]) -> None:
+        if not lines:
+            return
+        chunk: list[str] = []
+        size = 0
+        for line in lines:
+            line_len = len(line) + 1
+            if chunk and size + line_len > 1900:
+                await self._thread_send("\n".join(chunk))
+                chunk = []
+                size = 0
+            chunk.append(line)
+            size += line_len
+        if chunk:
+            await self._thread_send("\n".join(chunk))
+
+    def _outcome_label(self, outcome: CheckOutcome) -> str:
+        if outcome.skipped and outcome.passed:
+            return "WARN"
+        if outcome.skipped:
+            return "SKIP"
+        return "PASS" if outcome.passed else "FAIL"
+
+    def _format_outcome_line(self, outcome: CheckOutcome) -> str:
+        label = self._outcome_label(outcome)
+        detail = outcome.message or "OK"
+        return f"{label} `{outcome.check_id}`: {detail}"
+
+    async def _report_phase(self, phase: PhaseResult, *, compact_passed: bool = False) -> None:
+        header = (
+            f"**Phase {phase.phase_id}: {phase.title}** — "
+            f"{phase.passed} passed, {phase.failed} failed, {phase.skipped} skipped"
+        )
+        await self._thread_send(header)
+
+        lines: list[str] = []
+        passed_by_group: dict[str, int] = defaultdict(int)
+
+        for outcome in phase.outcomes:
+            if outcome.passed and not outcome.skipped:
+                if compact_passed:
+                    group = outcome.check_id.split(".", 1)[0]
+                    passed_by_group[group] += 1
+                else:
+                    lines.append(self._format_outcome_line(outcome))
+            else:
+                lines.append(self._format_outcome_line(outcome))
+
+        if compact_passed and passed_by_group:
+            for group in sorted(passed_by_group):
+                count = passed_by_group[group]
+                lines.append(f"PASS `{group}`: {count} spec{'s' if count != 1 else ''}")
+
+        await self._thread_send_lines(lines)
 
     async def _update_parent(self, title: str, description: str) -> None:
         from utility import tanjunEmbed
@@ -89,17 +144,11 @@ class DiagnosticsRunner:
         phase = PhaseResult("A", "Infrastructure")
         await self._thread_send("## Phase A: Infrastructure")
 
-        ping = await check_ping(self.ctx)
-        phase.outcomes.append(ping)
-        if not ping.passed:
-            await self._thread_send(f"FAIL `{ping.check_id}`: {ping.message}")
-
-        db = await check_database(self.bot)
-        phase.outcomes.append(db)
-        if not db.passed:
-            await self._thread_send(f"FAIL `{db.check_id}`: {db.message}")
+        phase.outcomes.append(await check_ping(self.ctx))
+        phase.outcomes.append(await check_database(self.bot))
 
         self.summary.phases.append(phase)
+        await self._report_phase(phase)
         await self._update_parent("Bot Diagnostics", f"Phase A complete — {phase.failed} failed")
 
     async def _run_phase_b_health(self) -> None:
@@ -116,7 +165,6 @@ class DiagnosticsRunner:
                 results = await manager.run_all()
             except Exception as exc:
                 phase.outcomes.append(CheckOutcome("health.manager", False, str(exc)))
-                await self._thread_send(f"FAIL `health.manager`: {exc}")
             else:
                 for result in results:
                     ok = result.status != HealthStatus.CRITICAL
@@ -127,10 +175,9 @@ class DiagnosticsRunner:
                             result.message,
                         )
                     )
-                    if not ok:
-                        await self._thread_send(f"FAIL `health.{result.check_name}`: {result.message}")
 
         self.summary.phases.append(phase)
+        await self._report_phase(phase)
         await self._update_parent("Bot Diagnostics", f"Phase B complete — {phase.failed} failed")
 
     async def _run_phase_c_loops(self) -> None:
@@ -146,13 +193,11 @@ class DiagnosticsRunner:
 
             ok = result.status != HealthStatus.CRITICAL
             phase.outcomes.append(CheckOutcome("loops.background", ok, result.message))
-            if not ok:
-                await self._thread_send(f"FAIL `loops.background`: {result.message}")
         except Exception as exc:
             phase.outcomes.append(CheckOutcome("loops.background", False, str(exc)))
-            await self._thread_send(f"FAIL `loops.background`: {exc}")
 
         self.summary.phases.append(phase)
+        await self._report_phase(phase)
 
     async def _run_phase_d_tree(self) -> None:
         phase = PhaseResult("D", "Command tree manifest")
@@ -162,32 +207,28 @@ class DiagnosticsRunner:
             missing, extra, missing_sub, extra_sub = compare_tree_to_manifest(self.bot)
         except Exception as exc:
             phase.outcomes.append(CheckOutcome("tree.manifest", False, str(exc)))
-            await self._thread_send(f"FAIL `tree.manifest`: {exc}")
         else:
             if missing:
                 for path in sorted(missing):
                     phase.outcomes.append(CheckOutcome(f"tree.missing.{path}", False, "Not registered"))
-                    await self._thread_send(f"FAIL tree missing: `{path}`")
             if extra:
                 for path in sorted(extra):
                     phase.outcomes.append(
                         CheckOutcome(f"tree.extra.{path}", True, "Unexpected command", skipped=True)
                     )
-                    await self._thread_send(f"WARN tree extra: `{path}`")
             if missing_sub:
                 for name in sorted(missing_sub):
                     phase.outcomes.append(CheckOutcome(f"tree.subgroup.missing.{name}", False, "Not registered"))
-                    await self._thread_send(f"FAIL minigame subgroup missing: `{name}`")
             if extra_sub:
                 for name in sorted(extra_sub):
                     phase.outcomes.append(
                         CheckOutcome(f"tree.subgroup.extra.{name}", True, "Unexpected subgroup", skipped=True)
                     )
-                    await self._thread_send(f"WARN minigame subgroup extra: `{name}`")
             if not missing and not extra and not missing_sub and not extra_sub:
                 phase.outcomes.append(CheckOutcome("tree.manifest", True, "Tree matches manifest"))
 
         self.summary.phases.append(phase)
+        await self._report_phase(phase)
 
     async def _run_phase_f_extensions(self) -> None:
         phase = PhaseResult("F", "Extensions loaded")
@@ -197,10 +238,9 @@ class DiagnosticsRunner:
         for cog_name in sorted(EXPECTED_COGS):
             ok = cog_name in loaded
             phase.outcomes.append(CheckOutcome(f"cog.{cog_name}", ok, "loaded" if ok else "missing"))
-            if not ok:
-                await self._thread_send(f"FAIL cog missing: `{cog_name}`")
 
         self.summary.phases.append(phase)
+        await self._report_phase(phase)
 
     async def _run_phase_e_handlers(self) -> None:
         phase = PhaseResult("E", "Handler behaviors")
@@ -215,48 +255,47 @@ class DiagnosticsRunner:
                 return await run_spec(spec, self.bot)
 
         tasks = [asyncio.create_task(_run_one(spec)) for spec in specs]
-        fail_buffer: list[str] = []
-
-        async def _flush_fails() -> None:
-            if not fail_buffer:
-                return
-            await self._thread_send("\n".join(fail_buffer))
-            fail_buffer.clear()
 
         for coro in asyncio.as_completed(tasks):
             outcome = await coro
             phase.outcomes.append(outcome)
             self._spec_done += 1
-            if not outcome.passed and not outcome.skipped:
-                fail_buffer.append(f"FAIL `{outcome.check_id}`: {outcome.message}")
-                if len(fail_buffer) >= FAIL_FLUSH_SIZE:
-                    await _flush_fails()
             if self._spec_done % SPEC_PROGRESS_INTERVAL == 0:
-                await _flush_fails()
                 await self._update_parent(
                     "Bot Diagnostics",
                     f"Phase E: {self._spec_done}/{total} specs ({phase.failed} failed)",
                 )
 
-        await _flush_fails()
         self.summary.phases.append(phase)
+        await self._report_phase(phase, compact_passed=True)
         await self._update_parent("Bot Diagnostics", f"Phase E complete — {phase.failed} failed, {phase.skipped} skipped")
 
     async def _finalize(self) -> None:
         s = self.summary
+        phase_lines = [
+            f"- Phase {p.phase_id}: {p.passed} passed, {p.failed} failed, {p.skipped} skipped"
+            for p in s.phases
+        ]
         lines = [
             "## Summary",
-            f"Passed: {s.total_passed}",
-            f"Failed: {s.total_failed}",
-            f"Skipped: {s.total_skipped}",
-            f"Status: {'OK' if s.ok else 'FAILED'}",
+            *phase_lines,
+            f"**Total:** {s.total_passed} passed, {s.total_failed} failed, {s.total_skipped} skipped",
+            f"**Status:** {'OK' if s.ok else 'FAILED'}",
         ]
         await self._thread_send("\n".join(lines))
 
         from utility import error_embed, success_embed
 
+        summary_body = "\n".join(
+            [
+                f"Passed: {s.total_passed}",
+                f"Failed: {s.total_failed}",
+                f"Skipped: {s.total_skipped}",
+                f"Status: {'OK' if s.ok else 'FAILED'}",
+            ]
+        )
         if s.ok:
-            embed = success_embed("\n".join(lines[1:]), title="Bot Diagnostics")
+            embed = success_embed(summary_body, title="Bot Diagnostics")
         else:
-            embed = error_embed("\n".join(lines[1:]), title="Bot Diagnostics")
+            embed = error_embed(summary_body, title="Bot Diagnostics")
         await self.status_message.edit(embed=embed)

--- a/diagnostics/specs/admin.py
+++ b/diagnostics/specs/admin.py
@@ -14,10 +14,13 @@ _BROKEN_CTX_HANDLERS = (
 
 
 def register() -> None:
-    from diagnostics.assertions import expect_interaction_or_modal
+    from diagnostics.assertions import expect_mock_called
     from diagnostics.specs.overrides import SPEC_CUSTOM_ASSERTIONS
 
-    SPEC_CUSTOM_ASSERTIONS["admin.WarnCommands.config"] = expect_interaction_or_modal
+    async def _assert_warn_config(_interaction: object, mocks: dict[str, object]) -> None:
+        await expect_mock_called("warnConfigCommand", mocks)
+
+    SPEC_CUSTOM_ASSERTIONS["admin.WarnCommands.config"] = _assert_warn_config
     register_skip("admin.AdminPurgeCommands.purge", "Destructive bulk message deletion")
     for spec_id in _BROKEN_CTX_HANDLERS:
         register_skip(spec_id, "Handler parameter/body mismatch (ctx vs interaction)")

--- a/diagnostics/specs/level.py
+++ b/diagnostics/specs/level.py
@@ -98,7 +98,7 @@ def register() -> None:
         {
             "rankcard": "show_rankcard_command",
             "set_background": "set_background_command",
-            "leaderboard": "leaderboard",
+            "leaderboard": "leaderboard_command",
         },
     )
     register_kwargs("level.levelCommands.set_background", default_image_kwargs)

--- a/extensions/level.py
+++ b/extensions/level.py
@@ -23,7 +23,7 @@ from commands.level.enable_levelup_message import (
     enable_levelup_message as enableLevelupMessageCommand,
 )
 from commands.level.give_xp import give_xp_command
-from commands.level.leaderboard import leaderboard
+from commands.level.leaderboard import leaderboard as leaderboard_command
 from commands.level.level_blacklist import (
     add_channel_to_blacklist_command,
     add_role_to_blacklist_command,
@@ -828,7 +828,7 @@ class levelCommands(discord.app_commands.Group):
             reply=interaction.followup.send,
             client=interaction.client,
         )
-        await leaderboard(command_info, page)
+        await leaderboard_command(command_info, page)
 
 
 class levelCog(commands.Cog):


### PR DESCRIPTION
## Summary
- Structure test_bot thread output: each phase reports passed, failed, and skipped checks (Phase E groups passes by extension).
- Remove broken `utility.require_moderate_members` patches that caused 30 utility spec failures.
- Fix admin warn config spec assertion, level leaderboard name shadowing bug, and interaction mock for `original_response`.
- Add `utility_help_name` to the command tree manifest.

## Test plan
- [ ] Run `test_bot` in Discord and confirm phases A–F list PASS lines and summary shows OK
- [ ] Confirm level `/leaderboard` works in production (no self-recursive handler call)


Made with [Cursor](https://cursor.com)