### PR TITLE
fix: Phase E diagnostics feedback spec and test_bot output

### DIFF
--- a/diagnostics/discovery.py
+++ b/diagnostics/discovery.py
@@ -12,6 +12,7 @@ from diagnostics.models import CommandBehaviorSpec
 from diagnostics.specs.overrides import (
     SPEC_CUSTOM_ASSERTIONS,
     SPEC_OVERRIDES,
+    SPEC_PATCH_EXCLUDE,
     SPEC_PATCH_TARGETS,
     SPEC_SKIPS,
 )
@@ -120,6 +121,7 @@ def discover_extension_specs(extension: str) -> list[CommandBehaviorSpec]:
                     skip_reason=skip_reason,
                     assertions=SPEC_CUSTOM_ASSERTIONS.get(spec_id, expect_interaction_response),
                     patch_targets=SPEC_PATCH_TARGETS.get(spec_id, ()),
+                    patch_exclude=SPEC_PATCH_EXCLUDE.get(spec_id, ()),
                 )
             )
     return specs

--- a/diagnostics/models.py
+++ b/diagnostics/models.py
@@ -67,3 +67,4 @@ class CommandBehaviorSpec:
     skip_reason: str | None = None
     assertions: AssertionFn | None = None
     patch_targets: tuple[str, ...] = ()
+    patch_exclude: tuple[str, ...] = ()

--- a/diagnostics/patches.py
+++ b/diagnostics/patches.py
@@ -16,6 +16,7 @@ def api_patches() -> Iterator[dict[str, AsyncMock]]:
         patch("api.execute_action", new_callable=AsyncMock, return_value=0),
         patch("api.safe_execute_query", new_callable=AsyncMock, return_value=[]),
         patch("api.execute_insert_and_get_id", new_callable=AsyncMock, return_value=1),
+        patch("api.feedbackIsBlocked", new_callable=AsyncMock, return_value=False),
     ]
     for p in patches:
         p.start()
@@ -27,15 +28,20 @@ def api_patches() -> Iterator[dict[str, AsyncMock]]:
 
 
 @contextmanager
-def extension_patches(extension: str, extra_targets: tuple[str, ...] = ()) -> Iterator[dict[str, AsyncMock]]:
+def extension_patches(
+    extension: str,
+    extra_targets: tuple[str, ...] = (),
+    patch_exclude: tuple[str, ...] = (),
+) -> Iterator[dict[str, AsyncMock]]:
     mocks: dict[str, AsyncMock] = {}
     module = importlib.import_module(extension)
+    excluded = set(patch_exclude)
 
     with ExitStack() as stack:
         stack.enter_context(api_patches())
 
         for name, obj in vars(module).items():
-            if name.startswith("_"):
+            if name.startswith("_") or name in excluded:
                 continue
             if not inspect.iscoroutinefunction(obj):
                 continue

--- a/diagnostics/registry.py
+++ b/diagnostics/registry.py
@@ -53,7 +53,9 @@ async def run_spec(spec: CommandBehaviorSpec, bot: Any) -> CheckOutcome:
         from contextlib import ExitStack
 
         with ExitStack() as stack:
-            mocks = stack.enter_context(extension_patches(spec.extension, spec.patch_targets))
+            mocks = stack.enter_context(
+                extension_patches(spec.extension, spec.patch_targets, spec.patch_exclude)
+            )
             interaction = await asyncio.wait_for(
                 invoke_interaction_command(handler, owner=group, extra_kwargs=extra_kwargs),
                 timeout=30.0,

--- a/diagnostics/specs/overrides.py
+++ b/diagnostics/specs/overrides.py
@@ -8,4 +8,6 @@ SPEC_OVERRIDES: dict[str, dict[str, Any] | Any] = {}
 
 SPEC_PATCH_TARGETS: dict[str, tuple[str, ...]] = {}
 
+SPEC_PATCH_EXCLUDE: dict[str, tuple[str, ...]] = {}
+
 SPEC_CUSTOM_ASSERTIONS: dict[str, Any] = {}

--- a/diagnostics/specs/utility.py
+++ b/diagnostics/specs/utility.py
@@ -9,7 +9,7 @@ from diagnostics.specs._helpers import (
     register_kwargs,
     register_method_commands,
 )
-from diagnostics.specs.overrides import SPEC_CUSTOM_ASSERTIONS
+from diagnostics.specs.overrides import SPEC_CUSTOM_ASSERTIONS, SPEC_PATCH_EXCLUDE
 
 
 def register() -> None:
@@ -103,11 +103,11 @@ def register() -> None:
             "avatar": "avatarCommand",
             "banner": "bannerCommand",
             "avatardecoration": "avatarDecorationCommand",
-            "feedback": "feedbackCommand",
             "afk": "afkCommand",
             "report": "reportCommand",
         },
     )
+    SPEC_PATCH_EXCLUDE["utility.UtilityCommands.feedback"] = ("feedbackCommand",)
     SPEC_CUSTOM_ASSERTIONS["utility.UtilityCommands.feedback"] = expect_interaction_or_modal
 
     register_method_commands(

--- a/tests/integration/extensions/test_level_comprehensive.py
+++ b/tests/integration/extensions/test_level_comprehensive.py
@@ -20,7 +20,7 @@ COMMAND_PATCHES = (
     "show_level_roles_command",
     "give_xp_command",
     "take_xp_command",
-    "leaderboard",
+    "leaderboard_command",
     "add_channel_to_blacklist_command",
     "add_role_to_blacklist_command",
     "add_user_to_blacklist_command",


### PR DESCRIPTION
## Summary
- Fix the failing `utility.UtilityCommands.feedback` Phase E spec by excluding `feedbackCommand` from extension auto-mocking so the handler can call `send_modal`, and mock `feedbackIsBlocked` in the diagnostics harness.
- Improve `test_bot` diagnostics reporting (PASS/FAIL/SKIP/WARN per phase), resolve other spec failures (level leaderboard, warn config, utility permission patches), and add `utility_help` to the command tree manifest.

## Test plan
- [ ] Run bot diagnostics (`test_bot`) and confirm Phase E shows 182 passed, 0 failed (feedback no longer fails).
- [ ] `pytest tests/unit/diagnostics/test_behavior_specs.py::test_all_behavior_specs_pass`
- [ ] `python scripts/check_diagnostics_manifest.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed command patching for leaderboard functionality in diagnostic integration tests.
  * Improved feedback command diagnostic handling.

* **Refactor**
  * Enhanced diagnostic testing framework with selective command mocking exclusion, providing better test isolation and reliability for diagnostic specs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->