### PR TITLE
fix: diagnostics manifest coverage and prefix command checks

### DIFF
--- a/diagnostics/discovery.py
+++ b/diagnostics/discovery.py
@@ -10,6 +10,7 @@ from discord import app_commands
 from diagnostics.assertions import expect_interaction_response
 from diagnostics.kwargs_defaults import build_kwargs_for_handler
 from diagnostics.models import CommandBehaviorSpec
+from diagnostics.tree import load_manifest
 from diagnostics.specs.overrides import (
     SPEC_CUSTOM_ASSERTIONS,
     SPEC_OVERRIDES,
@@ -54,6 +55,7 @@ def _instantiate_group(group_cls: type) -> Optional[Any]:
 
 def _find_group_classes(module: Any) -> list[type]:
     classes: list[type] = []
+    seen: set[type] = set()
     group_base: type = app_commands.Group
     for _name, obj in inspect.getmembers(module, inspect.isclass):
         try:
@@ -65,8 +67,53 @@ def _find_group_classes(module: Any) -> list[type]:
             continue
         if obj.__module__ != module.__name__:
             continue
+        if obj in seen:
+            continue
+        seen.add(obj)
         classes.append(obj)
     return classes
+
+
+def _locale_name(value: Any) -> str:
+    if value is None:
+        return ""
+    key = getattr(value, "key", None)
+    if key is not None:
+        return str(key)
+    message = getattr(value, "message", None)
+    if isinstance(message, str):
+        return message
+    return str(value)
+
+
+def _command_leaf_name(command: Any, method_name: str) -> str:
+    name = getattr(command, "name", None)
+    if name is not None:
+        return _locale_name(name)
+    return method_name
+
+
+def _manifest_paths_by_leaf() -> dict[str, list[str]]:
+    paths = load_manifest().get("paths") or []
+    by_leaf: dict[str, list[str]] = {}
+    for path in paths:
+        leaf = path.rsplit(" ", 1)[-1]
+        by_leaf.setdefault(leaf, []).append(path)
+    return by_leaf
+
+
+def _resolve_manifest_tree_path(leaf: str, provisional: str, by_leaf: dict[str, list[str]]) -> str:
+    candidates = by_leaf.get(leaf, [])
+    if not candidates:
+        return provisional
+    if len(candidates) == 1:
+        return candidates[0]
+    prov_parts = [p for p in (_locale_name(part) for part in provisional.split()) if p and p != "diag"]
+    if prov_parts:
+        narrowed = [path for path in candidates if all(part in path.split() for part in prov_parts)]
+        if len(narrowed) == 1:
+            return narrowed[0]
+    return provisional
 
 
 def _resolve_extra_kwargs(spec_id: str, handler: Any) -> dict[str, Any] | Any:
@@ -85,7 +132,7 @@ def _iter_command_leaves(commands_list: list[Any], prefix: tuple[str, ...] = ())
         name = getattr(cmd, "name", None)
         if not name:
             continue
-        path = (*prefix, str(name))
+        path = (*prefix, _locale_name(name))
         children = list(getattr(cmd, "commands", []) or [])
         if children:
             yield from _iter_command_leaves(children, path)
@@ -97,11 +144,11 @@ def _tree_path_for_command(command: Any, method_name: str) -> str:
     parts: list[str] = []
     parent = getattr(command, "parent", None)
     while parent is not None and getattr(parent, "name", None):
-        parts.append(str(parent.name))
+        parts.append(_locale_name(parent.name))
         parent = getattr(parent, "parent", None)
     parts.reverse()
     name = getattr(command, "name", None) or method_name
-    parts.append(str(name))
+    parts.append(_locale_name(name))
     return " ".join(parts)
 
 
@@ -109,6 +156,8 @@ def discover_extension_specs(extension: str) -> list[CommandBehaviorSpec]:
     module = importlib.import_module(extension)
     specs: list[CommandBehaviorSpec] = []
     ext_short = extension.rsplit(".", 1)[-1]
+
+    paths_by_leaf = _manifest_paths_by_leaf()
 
     for group_cls in _find_group_classes(module):
         group = _instantiate_group(group_cls)
@@ -149,13 +198,15 @@ def discover_extension_specs(extension: str) -> list[CommandBehaviorSpec]:
             seen_ids.add(spec_id)
             skip_reason = SPEC_SKIPS.get(spec_id)
             handler = command.callback if hasattr(command, "callback") else command
+            leaf = _command_leaf_name(command, method_name)
+            manifest_path = _resolve_manifest_tree_path(leaf, tree_path, paths_by_leaf)
             specs.append(
                 CommandBehaviorSpec(
                     id=spec_id,
                     extension=extension,
                     group_cls=group_cls,
                     method_name=method_name,
-                    tree_path=tree_path,
+                    tree_path=manifest_path,
                     extra_kwargs=_resolve_extra_kwargs(spec_id, handler),
                     skip_reason=skip_reason,
                     assertions=SPEC_CUSTOM_ASSERTIONS.get(spec_id, expect_interaction_response),

--- a/diagnostics/mocks.py
+++ b/diagnostics/mocks.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
+
 
 def make_guild(guild_id: int = 123456789, *, with_me: bool = True) -> MagicMock:
     guild = MagicMock()
     guild.id = guild_id
     guild.name = "Diagnostics Guild"
     guild.preferred_locale = "en-US"
+    guild.edit = AsyncMock()
     guild.get_member = MagicMock(return_value=None)
     guild.get_role = MagicMock(return_value=None)
     guild.get_channel = MagicMock(return_value=None)
-    default_role = MagicMock()
-    default_role.id = 222222222
-    default_role.name = "@everyone"
-    guild.default_role = default_role
+    guild.default_role = discord.Object(id=guild_id)
     if with_me:
         me = MagicMock()
         me.id = 999999999

--- a/diagnostics/prefix_checks.py
+++ b/diagnostics/prefix_checks.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from contextlib import ExitStack
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from diagnostics.models import CheckOutcome
 from diagnostics.patches import extension_patches
@@ -38,8 +39,10 @@ async def _invoke_prefix_command(cog: Any, command: Any, bot: Any) -> None:
     ctx.guild = guild
     ctx.channel = channel
     ctx.bot = bot
-    ctx.send = AsyncMock()
-    ctx.message = type("Msg", (), {"attachments": [], "content": "diag"})()
+    status_message = MagicMock()
+    status_message.edit = AsyncMock()
+    ctx.send = AsyncMock(return_value=status_message)
+    ctx.message = type("Msg", (), {"attachments": [], "content": "diag", "guild": guild})()
 
     kwargs = _build_prefix_kwargs(command.callback)
     params = list(inspect.signature(command.callback).parameters)
@@ -76,7 +79,21 @@ async def run_prefix_command_checks(bot: Any) -> list[CheckOutcome]:
             continue
         try:
             with extension_patches("extensions.administration"):
-                await asyncio.wait_for(_invoke_prefix_command(cog, command, bot), timeout=30.0)
+                with ExitStack() as stack:
+                    if name == "bsaccdata":
+                        stack.enter_context(
+                            patch.object(
+                                cog,
+                                "getAccData",
+                                AsyncMock(return_value={"brawlers": [{}, {}]}),
+                            )
+                        )
+                    if name == "sync":
+                        bot.tree.sync = AsyncMock(return_value=[])
+                        stack.enter_context(
+                            patch("extensions.administration.asyncio.sleep", new_callable=AsyncMock)
+                        )
+                    await asyncio.wait_for(_invoke_prefix_command(cog, command, bot), timeout=30.0)
         except TimeoutError:
             outcomes.append(CheckOutcome(check_id, False, "Timed out after 30s"))
         except Exception as exc:

--- a/diagnostics/specs/admin.py
+++ b/diagnostics/specs/admin.py
@@ -17,3 +17,4 @@ def register() -> None:
     register_defer_and_mock("admin.AdminMessagingCommands.say", "sayCommand")
     register_defer_and_mock("admin.AdminMessagingCommands.embed", "createEmbedCommand")
     register_defer_and_mock("admin.AdminSetupCommands.create_ticket", "createTicketCommand")
+    register_defer_only("admin.AdminEmojiCommands.createemoji")

--- a/tests/unit/diagnostics/test_discovery_paths.py
+++ b/tests/unit/diagnostics/test_discovery_paths.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from diagnostics.discovery import (
+    _find_group_classes,
+    _manifest_paths_by_leaf,
+    _resolve_manifest_tree_path,
+)
+
+
+def test_resolve_manifest_tree_path_unique_leaf() -> None:
+    by_leaf = _manifest_paths_by_leaf()
+    path = _resolve_manifest_tree_path(
+        "admin_ban_name",
+        "diag admin_ban_name",
+        by_leaf,
+    )
+    assert path == "admin_moderation_name admin_ban_name"
+
+
+def test_resolve_manifest_tree_path_nested_utility() -> None:
+    by_leaf = _manifest_paths_by_leaf()
+    path = _resolve_manifest_tree_path(
+        "utility_claimboosterrole_name",
+        "diag utility_claimboosterrole_name",
+        by_leaf,
+    )
+    assert path == "utilitycmd_name utility_boosterrole_name utility_claimboosterrole_name"
+
+
+def test_find_group_classes_dedupes_same_class_twice() -> None:
+    from discord import app_commands
+
+    class AliasGroup(app_commands.Group):
+        __module__ = "fake_admin"
+
+    module = type(
+        "fake_admin",
+        (),
+        {
+            "__name__": "fake_admin",
+            "Moderation": AliasGroup,
+            "Administration": AliasGroup,
+        },
+    )()
+    classes = _find_group_classes(module)
+    assert len(classes) == 1


### PR DESCRIPTION
## Summary
- Map discovered behavior spec tree paths to manifest locale keys so Phase G coverage passes.
- Deduplicate alias command groups (e.g. AdministrationCommands) to avoid duplicate spec IDs.
- Fix Phase E createemoji by using discord.Object for default_role in diagnostics mocks.
- Fix Phase I prefix admin checks: bsaccdata mock data, sync/setguildlocale/testupdateuserroles mocks.

## Test plan
- [ ] Run strict test_bot diagnostics and confirm Phase G, E, and I pass
- [ ] Run pytest tests/unit/diagnostics/test_discovery_paths.py


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command path discovery to correctly resolve locale-aware names and prevent duplicate command collection.
  * Enhanced mock setup for testing Discord interactions with more realistic context.

* **Tests**
  * Added unit tests for command discovery path resolution and deduplication logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->