### PR TITLE
feat: add /ai tokens command to view AI token balance

### DIFF
--- a/commands/ai/show_tokens.py
+++ b/commands/ai/show_tokens.py
@@ -1,0 +1,30 @@
+import utility
+from localizer import tanjunLocalizer
+from services.ai_service import AiService, TokenOverview
+
+
+async def show_tokens(command_info: utility.CommandInfo) -> None:
+    overview = await AiService.get_token_overview(command_info.user.id)
+
+    if overview is None:
+        await AiService.initialize_user(command_info.user.id)
+        overview = await AiService.get_token_overview(command_info.user.id)
+
+    if overview is None:
+        overview = TokenOverview(free_token=500, plus_token=0, paid_token=0, used_token=0)
+
+    total = overview.free_token + overview.plus_token + overview.paid_token
+
+    embed = utility.tanjunEmbed(
+        title=tanjunLocalizer.localize(str(command_info.locale), "commands.ai.tokens.success.title"),
+        description=tanjunLocalizer.localize(
+            command_info.locale,
+            "commands.ai.tokens.success.description",
+            total=total,
+            free=overview.free_token,
+            plus=overview.plus_token,
+            paid=overview.paid_token,
+            used=overview.used_token,
+        ),
+    )
+    await command_info.reply(embed=embed)

--- a/diagnostics/manifest.json
+++ b/diagnostics/manifest.json
@@ -68,6 +68,7 @@
     "ai_name ai_askcustom_name",
     "ai_name ai_askgpt_name",
     "ai_name ai_asktanjuwun_name",
+    "ai_name ai_tokens_name",
     "ai_name ai_customsituations_name ai_createcustom_name",
     "ai_name ai_customsituations_name ai_deletecustom_name",
     "channel_name channel_ds_name channel_ds_add_name",

--- a/extensions/ai.py
+++ b/extensions/ai.py
@@ -8,6 +8,7 @@ import utility
 from commands.ai.add_custom_situation import add_custom_situation
 from commands.ai.ask_gpt import ask_gpt
 from commands.ai.delete_custom_situation import delete_custom_situation
+from commands.ai.show_tokens import show_tokens
 from services.ai_service import AiService
 
 
@@ -245,6 +246,29 @@ class AiCommands(discord.app_commands.Group):
             frequency_penalty=frequencypenalty,
             presence_penalty=presencepenalty,
         )
+
+    @app_commands.command(
+        name=app_commands.locale_str("ai_tokens_name"),
+        description=app_commands.locale_str("ai_tokens_description"),
+    )
+    async def tokens_command(self, interaction: discord.Interaction) -> None:
+        from typing import cast
+
+        await interaction.response.defer()
+
+        command_info = utility.CommandInfo(
+            user=interaction.user,
+            channel=cast(discord.abc.GuildChannel, interaction.channel),
+            guild=interaction.guild,
+            command=interaction.command,
+            locale=interaction.locale,  # type: ignore[arg-type]
+            message=interaction.message,
+            permissions=interaction.permissions,
+            reply=interaction.followup.send,
+            client=interaction.client,
+        )
+
+        await show_tokens(command_info)
 
 
 class AiCog(commands.Cog):

--- a/locales/en.json
+++ b/locales/en.json
@@ -2416,6 +2416,22 @@
     "max_length": 100
   },
   {
+    "identifier": "ai.tokens.description",
+    "source_string": "View your AI token balance",
+    "translation": "View your AI token balance",
+    "context": "AI / ChatGPT command parameter or UI label (ai.tokens). English: \"View your AI token balance\". Used in `extensions/ai.py`.",
+    "labels": "ai, description",
+    "max_length": 100
+  },
+  {
+    "identifier": "ai.tokens.name",
+    "source_string": "tokens",
+    "translation": "tokens",
+    "context": "AI / ChatGPT command parameter or UI label (ai.tokens). English: \"tokens\". Used in `extensions/ai.py`.",
+    "labels": "ai",
+    "max_length": 32
+  },
+  {
     "identifier": "ai.createcustom.description",
     "source_string": "Creates a custom AI",
     "translation": "Creates a custom AI",
@@ -8940,6 +8956,22 @@
     "source_string": "Reply from ${name}",
     "translation": "Reply from ${name}",
     "context": "Title of the reply embed for `/ai ask` when the command completed successfully. Used in `commands/ai/ask_gpt.py`.",
+    "labels": "commands, embed_title, success",
+    "max_length": 256
+  },
+  {
+    "identifier": "commands.ai.tokens.success.description",
+    "source_string": "You have **${total}** tokens available (${free} free, ${plus} plus, ${paid} purchased). You have used **${used}** tokens in total. Each AI request needs at least 20 tokens.",
+    "translation": "You have **${total}** tokens available (${free} free, ${plus} plus, ${paid} purchased). You have used **${used}** tokens in total. Each AI request needs at least 20 tokens.",
+    "context": "Description body of the reply embed for `/ai tokens`. Used in `commands/ai/show_tokens.py`.",
+    "labels": "commands, embed_description, success",
+    "max_length": 4096
+  },
+  {
+    "identifier": "commands.ai.tokens.success.title",
+    "source_string": "AI token balance",
+    "translation": "AI token balance",
+    "context": "Title of the reply embed for `/ai tokens`. Used in `commands/ai/show_tokens.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
   },

--- a/tests/integration/commands/ai/test_ai_branches.py
+++ b/tests/integration/commands/ai/test_ai_branches.py
@@ -4,6 +4,8 @@ import pytest
 
 from commands.ai.add_custom_situation import add_custom_situation
 from commands.ai.ask_gpt import ask_gpt
+from commands.ai.show_tokens import show_tokens
+from services.ai_service import TokenOverview
 
 pytestmark = pytest.mark.asyncio
 
@@ -104,4 +106,25 @@ async def test_ask_gpt_consume_fails(mock_service, mock_client, admin_command_in
     response.choices = [MagicMock(message=MagicMock(content="Hello!"))]
     mock_client.chat.completions.create = AsyncMock(return_value=response)
     await ask_gpt(admin_command_info, "GPT", "be helpful", "hello")
+    admin_command_info.reply.assert_awaited_once()
+
+
+@patch("commands.ai.show_tokens.AiService")
+async def test_show_tokens_with_balance(mock_service, admin_command_info):
+    mock_service.get_token_overview = AsyncMock(
+        return_value=TokenOverview(free_token=100, plus_token=50, paid_token=25, used_token=10)
+    )
+    await show_tokens(admin_command_info)
+    mock_service.initialize_user.assert_not_awaited()
+    admin_command_info.reply.assert_awaited_once()
+
+
+@patch("commands.ai.show_tokens.AiService")
+async def test_show_tokens_initializes_new_user(mock_service, admin_command_info):
+    mock_service.get_token_overview = AsyncMock(
+        side_effect=[None, TokenOverview(free_token=500, plus_token=0, paid_token=0, used_token=0)]
+    )
+    mock_service.initialize_user = AsyncMock()
+    await show_tokens(admin_command_info)
+    mock_service.initialize_user.assert_awaited_once()
     admin_command_info.reply.assert_awaited_once()

--- a/tests/integration/extensions/test_ai.py
+++ b/tests/integration/extensions/test_ai.py
@@ -61,11 +61,11 @@ async def test_root_command_name_is_ai_name():
     assert get_tree_command_names(bot) == ["ai_name"]
 
 
-async def test_root_group_has_4_entries():
+async def test_root_group_has_5_entries():
     bot = await load_extension_bot(EXTENSION)
     root = find_tree_group(bot, "ai_name")
     assert root is not None
-    assert len(get_subcommand_names(root)) == 4
+    assert len(get_subcommand_names(root)) == 5
 
 
 async def test_subcommand_ai_askgpt_name_registered():
@@ -80,6 +80,13 @@ async def test_subcommand_ai_asktanjuwun_name_registered():
     root = find_tree_group(bot, "ai_name")
     assert root is not None
     assert "ai_asktanjuwun_name" in get_subcommand_names(root)
+
+
+async def test_subcommand_ai_tokens_name_registered():
+    bot = await load_extension_bot(EXTENSION)
+    root = find_tree_group(bot, "ai_name")
+    assert root is not None
+    assert "ai_tokens_name" in get_subcommand_names(root)
 
 
 async def test_subcommand_ai_customsituations_name_registered():


### PR DESCRIPTION
## Summary
- Adds `/ai tokens` slash command so users can view free, plus, and paid token balances without making an AI request
- Initializes new users with the default token row when checking balance (same as ask commands)
- Updates diagnostics manifest and integration tests

## Test plan
- [ ] Run `pytest tests/integration/extensions/test_ai.py tests/integration/commands/ai/test_ai_branches.py`
- [ ] Sync slash commands and verify `/ai tokens` appears in Discord
- [ ] Confirm embed shows correct breakdown for users with and without existing `aiToken` rows