### PR TITLE
fix: add missing register_defer_only import in admin.py specs

### DIFF
--- a/diagnostics/specs/admin.py
+++ b/diagnostics/specs/admin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from diagnostics.specs._helpers import register_defer_and_mock
+from diagnostics.specs._helpers import register_defer_and_mock, register_defer_only
 
 
 def register() -> None:


### PR DESCRIPTION
Fixes the `NameError: name 'register_defer_only' is not defined` that occurs when `admin.register()` runs and hits line 20 which calls `register_defer_only` without importing it.

Also fixes the `test_find_group_classes_dedupes_same_class_twice` failure which occurs when the `admin.register()` NameError corrupts the diagnostics spec loading state.