### PR TITLE
fix: correct test_bot phase order and help command coverage

### DIFF
--- a/diagnostics/discovery.py
+++ b/diagnostics/discovery.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from typing import Any, Optional
 
 from discord import app_commands
+from discord.ext import commands
 
 from diagnostics.assertions import expect_interaction_response
 from diagnostics.kwargs_defaults import build_kwargs_for_handler
@@ -51,6 +52,26 @@ def _instantiate_group(group_cls: type) -> Optional[Any]:
         return group_cls(MagicMock())
     except TypeError:
         return None
+
+
+def _find_cog_classes(module: Any) -> list[type]:
+    classes: list[type] = []
+    seen: set[type] = set()
+    for _name, obj in inspect.getmembers(module, inspect.isclass):
+        try:
+            if not issubclass(obj, commands.Cog):
+                continue
+        except TypeError:
+            continue
+        if obj is commands.Cog:
+            continue
+        if obj.__module__ != module.__name__:
+            continue
+        if obj in seen:
+            continue
+        seen.add(obj)
+        classes.append(obj)
+    return classes
 
 
 def _find_group_classes(module: Any) -> list[type]:
@@ -152,12 +173,52 @@ def _tree_path_for_command(command: Any, method_name: str) -> str:
     return " ".join(parts)
 
 
+def _discover_cog_specs(
+    extension: str,
+    ext_short: str,
+    paths_by_leaf: dict[str, list[str]],
+) -> list[CommandBehaviorSpec]:
+    module = importlib.import_module(extension)
+    specs: list[CommandBehaviorSpec] = []
+    for cog_cls in _find_cog_classes(module):
+        seen_ids: set[str] = set()
+        for command in getattr(cog_cls, "__cog_app_commands__", ()) or ():
+            callback = command.callback
+            method_name = getattr(callback, "__name__", "unknown")
+            if method_name in ("interaction_check", "on_error"):
+                continue
+            spec_id = f"{ext_short}.{cog_cls.__name__}.{method_name}"
+            if spec_id in seen_ids:
+                continue
+            seen_ids.add(spec_id)
+            leaf = _locale_name(command.name)
+            manifest_path = _resolve_manifest_tree_path(leaf, leaf, paths_by_leaf)
+            skip_reason = SPEC_SKIPS.get(spec_id)
+            specs.append(
+                CommandBehaviorSpec(
+                    id=spec_id,
+                    extension=extension,
+                    group_cls=cog_cls,
+                    method_name=method_name,
+                    tree_path=manifest_path,
+                    extra_kwargs=_resolve_extra_kwargs(spec_id, callback),
+                    skip_reason=skip_reason,
+                    assertions=SPEC_CUSTOM_ASSERTIONS.get(spec_id, expect_interaction_response),
+                    patch_targets=SPEC_PATCH_TARGETS.get(spec_id, ()),
+                    patch_exclude=SPEC_PATCH_EXCLUDE.get(spec_id, ()),
+                )
+            )
+    return specs
+
+
 def discover_extension_specs(extension: str) -> list[CommandBehaviorSpec]:
     module = importlib.import_module(extension)
     specs: list[CommandBehaviorSpec] = []
     ext_short = extension.rsplit(".", 1)[-1]
 
     paths_by_leaf = _manifest_paths_by_leaf()
+
+    specs.extend(_discover_cog_specs(extension, ext_short, paths_by_leaf))
 
     for group_cls in _find_group_classes(module):
         group = _instantiate_group(group_cls)

--- a/diagnostics/runner.py
+++ b/diagnostics/runner.py
@@ -11,7 +11,6 @@ from diagnostics.coverage import check_duplicate_spec_ids, check_manifest_spec_c
 from diagnostics.infra_checks import check_database, check_gateway_latency, check_ping
 from diagnostics.locale_checks import check_locale_files, check_localizer_samples
 from diagnostics.models import CheckOutcome, DiagnosticsSummary, PhaseResult
-from diagnostics.prefix_checks import run_prefix_command_checks
 from diagnostics.registry import all_specs, run_spec
 from diagnostics.tree import compare_tree_to_manifest
 
@@ -46,11 +45,10 @@ _PHASE_PLAN: tuple[tuple[str, str], ...] = (
     ("B", "Platform health"),
     ("C", "Background loops"),
     ("D", "Command tree manifest"),
-    ("G", "Spec coverage"),
-    ("F", "Extensions loaded"),
     ("E", "Slash handler behaviors"),
+    ("F", "Extensions loaded"),
+    ("G", "Spec coverage"),
     ("H", "Localization"),
-    ("I", "Admin prefix commands"),
 )
 
 
@@ -160,11 +158,10 @@ class DiagnosticsRunner:
             self._run_phase_b_health,
             self._run_phase_c_loops,
             self._run_phase_d_tree,
-            self._run_phase_g_coverage,
-            self._run_phase_f_extensions,
             self._run_phase_e_handlers,
+            self._run_phase_f_extensions,
+            self._run_phase_g_coverage,
             self._run_phase_h_locales,
-            self._run_phase_i_prefix,
         )
         for phase_index, ((phase_id, phase_title), phase_fn) in enumerate(
             zip(_PHASE_PLAN, phase_runners, strict=True), start=1
@@ -343,16 +340,6 @@ class DiagnosticsRunner:
         self.summary.phases.append(phase)
         await self._report_phase(phase, compact_passed=True)
         await self._update_progress(phase_index, "H: Localization", f"Complete — {phase.failed} failed")
-
-    async def _run_phase_i_prefix(self, phase_index: int) -> None:
-        phase = PhaseResult("I", "Admin prefix commands")
-        await self._thread_send("## Phase I: Administration prefix commands")
-
-        phase.outcomes.extend(await run_prefix_command_checks(self.bot))
-
-        self.summary.phases.append(phase)
-        await self._report_phase(phase, compact_passed=True)
-        await self._update_progress(phase_index, "I: Admin prefix commands", f"Complete — {phase.failed} failed")
 
     async def _finalize(self) -> None:
         s = self.summary

--- a/diagnostics/specs/utility.py
+++ b/diagnostics/specs/utility.py
@@ -6,6 +6,7 @@ from diagnostics.specs._helpers import (
     default_channel_kwargs,
     default_member_kwargs,
     default_role_kwargs,
+    register_defer_and_mock,
     register_kwargs,
     register_method_commands,
 )
@@ -13,6 +14,9 @@ from diagnostics.specs.overrides import SPEC_CUSTOM_ASSERTIONS, SPEC_PATCH_EXCLU
 
 
 def register() -> None:
+    register_kwargs("utility.UtilityCog.help_slash", lambda: {})
+    register_defer_and_mock("utility.UtilityCog.help_slash", "helpCommand")
+
     register_kwargs("utility.MessageTrackingCommands.messagetrackingoptout", lambda: {})
     register_kwargs("utility.MessageTrackingCommands.messagetrackingoptin", lambda: {})
     register_method_commands(


### PR DESCRIPTION
## Summary
- Run diagnostics phases in order A→H with E (slash handlers), F (extensions), then G (coverage) after the tree check
- Remove Phase I (administration prefix command checks) from test_bot
- Discover cog-level slash commands and add a behavior spec for `utility_help_name` so Phase G coverage passes

## Test plan
- [x] `python3 -c` manifest coverage reports all 195 paths covered
- [ ] Run `test_bot` in Discord and confirm phases A→H execute in order without Phase I
- [ ] Confirm Phase G passes (`utility_help_name` no longer missing)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and analyzing cog-based slash commands within the diagnostic system, including spec registration and behavior analysis.

* **Changes**
  * Removed the prefix command diagnostic phase from the diagnostics runner, streamlining the diagnostic sequence.
  * Extended registration support for help slash command specifications with defer and mock behavior associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->