### PR TITLE
fix: guard on_timeout against missing message attribute in LogConfigureView

### DIFF
--- a/commands/logs/configure_logs.py
+++ b/commands/logs/configure_logs.py
@@ -128,7 +128,8 @@ async def configure_logs(command_info: utility.command_info):
         async def on_timeout(self):
             for item in self.children:
                 item.disabled = True
-            await self.message.edit(view=self)
+            if self.message:
+                await self.message.edit(view=self)
 
         async def regenerate_embed(self, interaction: discord.Interaction):
             description = await build_log_settings_embed(self.locale, self.guild, self.selected_index)
@@ -152,4 +153,6 @@ async def configure_logs(command_info: utility.command_info):
         title=tanjunLocalizer.localize(command_info.locale, "commands.logs.configureLogs.title"),
         description=configuration_embed,
     )
-    await command_info.reply(embed=embed, view=view)
+    message = await command_info.reply(embed=embed, view=view)
+    if message:
+        view.message = message


### PR DESCRIPTION
Fixes #3099

## Problem
The `LogConfigureView.on_timeout` method was calling `self.message.edit(view=self)` but the `message` attribute was never set on the view. This caused an `AttributeError: 'LogConfigureView' object has no attribute 'message'` exception in production when the view timed out.

## Fix
Added a guard (`if self.message:`) before the `self.message.edit()` call in `on_timeout`. When `message` isn't captured (e.g., because `command_info.reply` doesn't return the message in production), the timeout handler will safely disable buttons without crashing.