### PR TITLE
feat: Uptime Kuma push heartbeats from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ sentry_dsn="https://examplePublicKey@o0.ingest.sentry.io/0"
 SENTRY_TRACES_SAMPLE_RATE=0.0
 SENTRY_ENVIRONMENT="production"
 
+# Push token from the Tanjun monitor in Uptime Kuma (monitor badge id 8 on status.tanjun.bot)
+# UPTIME_KUMA_PUSH_TOKEN=""
+# UPTIME_KUMA_STATUS_URL="https://status.tanjun.bot"
+
 # ── Emoji configuration (optional overrides) ─────────────────────────────────
 # Calculator button emojis  (format: name:id)
 # CALC_ADD="math_add:1254372629456883793"

--- a/config.py
+++ b/config.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings, cli_parse_args=False):
     # ── Metrics ───────────────────────────────────────────────────────────────
     metrics_port: int = Field(default=8001, alias="METRICS_PORT")
 
+    # ── Uptime Kuma (status page push heartbeat) ──────────────────────────────
+    uptime_kuma_push_token: SecretStr = Field(default=SecretStr(""), alias="UPTIME_KUMA_PUSH_TOKEN")
+    uptime_kuma_status_url: str = Field(default="https://status.tanjun.bot", alias="UPTIME_KUMA_STATUS_URL")
+
     # ── Activity ──────────────────────────────────────────────────────────────
     activity: str = "Tanjun {version}"
 
@@ -151,7 +155,8 @@ sentry_dsn: str = settings.sentry_dsn
 sentry_traces_sample_rate: float = settings.sentry_traces_sample_rate
 sentry_environment: str = settings.sentry_environment
 metrics_port: int = settings.metrics_port
-
+UPTIME_KUMA_PUSH_TOKEN: str = settings.uptime_kuma_push_token.get_secret_value()
+UPTIME_KUMA_STATUS_URL: str = settings.uptime_kuma_status_url.rstrip("/")
 
 # ── Emoji identifiers for calculator ─────────────────────────────────────────
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,8 +156,10 @@ The health monitoring system validates:
 
 Health checks run:
 1. On startup (before the bot is marked ready)
-2. Periodically in the background (`alivemonitor.py`)
+2. Periodically via the health check manager
 3. On demand via the `/status` command
+
+`alivemonitor.py` sends an optional Uptime Kuma push heartbeat every 60 seconds when `UPTIME_KUMA_PUSH_TOKEN` is configured.
 
 ### Configuration (`config.py`)
 
@@ -200,7 +202,7 @@ Tanjun runs several periodic background tasks:
 
 | Loop | Interval | Purpose |
 |------|----------|---------|
-| Alivemonitor | Every 5 min | Verify all health checks pass |
+| Alivemonitor | Every 60 sec | Uptime Kuma push heartbeat (when token configured) |
 | Giveaway check | Every 30 sec | End giveaways and pick winners |
 | Level processing | Every 60 sec | Process XP decay and level updates |
 | Database backup | Configurable | Create periodic database backups |

--- a/docs/infra/environment.md
+++ b/docs/infra/environment.md
@@ -46,6 +46,10 @@ Tanjun is configured through environment variables defined in a `.env` file. Thi
 | `prometheus_port` | Port for Prometheus metrics endpoint (default: `9090`) |
 | `healthcheck_port` | Port for health check endpoint (default: `8080`) |
 | `sentry_dsn` | Sentry DSN for error tracking |
+| `UPTIME_KUMA_PUSH_TOKEN` | Uptime Kuma push monitor token (optional; omit to disable heartbeats) |
+| `UPTIME_KUMA_STATUS_URL` | Uptime Kuma base URL (default: `https://status.tanjun.bot`) |
+| `HEALTH_ALERT_CHANNEL_ID` | Discord channel ID for internal health-check failure alerts |
+| `HEALTH_ALERT_USER_ID` | Discord user ID to ping with health-check failure alerts |
 
 ### Bot Behavior
 
@@ -87,6 +91,8 @@ openai_tokens=10000
 log_level=INFO
 prometheus_port=9090
 healthcheck_port=8080
+UPTIME_KUMA_PUSH_TOKEN=your_push_token_from_uptime_kuma
+# UPTIME_KUMA_STATUS_URL=https://status.tanjun.bot
 ```
 
 > See [.env.example](https://github.com/TanjunBot/new_tanjun/blob/development/.env.example) in the repository for the latest template.

--- a/docs/infra/monitoring.md
+++ b/docs/infra/monitoring.md
@@ -65,12 +65,25 @@ http://localhost:8080/metrics
 
 A pre-configured Grafana dashboard is available in the `grafana/` directory. Import it into your Grafana instance to get started quickly.
 
-## Status Page
+## Status Page (Uptime Kuma)
 
-The bot's operational status is tracked at [status.tanjun.bot](https://status.tanjun.bot). You can subscribe to updates there.
+The bot's operational status is tracked at [status.tanjun.bot](https://status.tanjun.bot). Users can subscribe to incident notifications on that page (configured in Uptime Kuma, not in the bot).
+
+### Uptime Kuma setup
+
+1. In Uptime Kuma, create or edit a **Push** monitor for Tanjun (not HTTP polling).
+2. Set the heartbeat interval to **60–90 seconds** (the bot pushes every 60 seconds).
+3. Copy the push token from the monitor URL (`/api/push/<token>`).
+4. Set `UPTIME_KUMA_PUSH_TOKEN` in the bot `.env`. Optionally override `UPTIME_KUMA_STATUS_URL` if the status page host differs.
+5. In Uptime Kuma **Settings → Notifications**, configure Discord/email and send a test notification.
+
+The bot sends a lightweight `GET` to `/api/push/<token>?status=up&msg=OK&ping=<latency_ms>` when the token is set. If `UPTIME_KUMA_PUSH_TOKEN` is empty, no push requests are made (useful for local dev).
+
+The legacy `botstatus-api.tanjun.bot` relay is no longer used.
 
 ## Discord Alerts
 
-Configure alerting by monitoring the health endpoint from your preferred monitoring service (e.g., Uptime Robot, Better Uptime, Grafana OnCall).
+- **Status page subscribers:** Uptime Kuma notification providers on [status.tanjun.bot](https://status.tanjun.bot).
+- **Internal health failures:** set `HEALTH_ALERT_CHANNEL_ID` and `HEALTH_ALERT_USER_ID` so startup/periodic health check failures post to a Discord channel.
 
-> **Tip:** Set up a dedicated Discord channel for bot health alerts so the team gets notified if something goes wrong.
+You can also monitor the bot `/health` endpoint from an external service if needed.

--- a/loops/alivemonitor.py
+++ b/loops/alivemonitor.py
@@ -1,17 +1,37 @@
+import logging
+
 import aiohttp
 from aiohttp import ClientTimeout
 from discord import Client
+
+import config
+
+logger = logging.getLogger(__name__)
+
+
+def _build_push_url(latency_ms: int) -> str | None:
+    token = config.UPTIME_KUMA_PUSH_TOKEN.strip()
+    if not token:
+        return None
+    base = config.UPTIME_KUMA_STATUS_URL
+    return f"{base}/api/push/{token}?status=up&msg=OK&ping={latency_ms}"
 
 
 async def ping_server(client: Client) -> None:
     if client is None or client.user is None:
         return
-    url = "https://botstatus-api.tanjun.bot"
-    payload = {"id": str(client.user.id), "status": "alive", "latency": str(client.latency)}
+    push_url = _build_push_url(max(0, int(client.latency * 1000)))
+    if push_url is None:
+        return
 
-    async with (
-        aiohttp.ClientSession() as session,
-        session.post(url, json=payload, timeout=ClientTimeout(total=10)) as response,
-    ):
-        if response.status != 200:
-            print(f"Failed to send message, status code: {response.status}")
+    try:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(push_url, timeout=ClientTimeout(total=10)) as response,
+        ):
+            if response.status == 200:
+                logger.debug("Uptime Kuma push succeeded")
+            else:
+                logger.warning("Uptime Kuma push failed, status code: %s", response.status)
+    except (aiohttp.ClientError, TimeoutError) as exc:
+        logger.warning("Uptime Kuma push error: %s", exc)

--- a/tests/mock_config.py
+++ b/tests/mock_config.py
@@ -36,6 +36,8 @@ def patch_config_module() -> MagicMock:
     mock_config_module_instance.sentry_dsn = None
     mock_config_module_instance.sentry_environment = None
     mock_config_module_instance.sentry_traces_sample_rate = 0.0
+    mock_config_module_instance.UPTIME_KUMA_PUSH_TOKEN = ""
+    mock_config_module_instance.UPTIME_KUMA_STATUS_URL = "https://status.tanjun.bot"
 
     mock_env_dict = {
         "token": mock_config_module_instance.token,

--- a/tests/unit/loops/test_loops_direct.py
+++ b/tests/unit/loops/test_loops_direct.py
@@ -21,8 +21,20 @@ async def test_ping_server_no_user():
     await alivemonitor.ping_server(client)
 
 
+@patch("loops.alivemonitor.config.UPTIME_KUMA_PUSH_TOKEN", "")
+async def test_ping_server_skipped_when_token_unset():
+    client = MagicMock()
+    client.user = MagicMock(id=1)
+    client.latency = 0.1
+    with patch("loops.alivemonitor.aiohttp.ClientSession") as mock_session_cls:
+        await alivemonitor.ping_server(client)
+        mock_session_cls.assert_not_called()
+
+
+@patch("loops.alivemonitor.config.UPTIME_KUMA_STATUS_URL", "https://status.example.test")
+@patch("loops.alivemonitor.config.UPTIME_KUMA_PUSH_TOKEN", "test-push-token")
 @patch("loops.alivemonitor.aiohttp.ClientSession")
-async def test_ping_server_success(mock_session_cls):
+async def test_ping_server_push_success(mock_session_cls):
     client = MagicMock()
     client.user = MagicMock(id=1)
     client.latency = 0.1
@@ -31,13 +43,19 @@ async def test_ping_server_success(mock_session_cls):
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=None)
     session = AsyncMock()
-    session.post = MagicMock(return_value=resp)
+    session.get = MagicMock(return_value=resp)
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=None)
     mock_session_cls.return_value = session
     await alivemonitor.ping_server(client)
+    call_url = session.get.call_args[0][0]
+    assert "/api/push/test-push-token" in call_url
+    assert "status=up" in call_url
+    assert "ping=100" in call_url
 
 
+@patch("loops.alivemonitor.config.UPTIME_KUMA_STATUS_URL", "https://status.example.test")
+@patch("loops.alivemonitor.config.UPTIME_KUMA_PUSH_TOKEN", "test-push-token")
 @patch("loops.alivemonitor.aiohttp.ClientSession")
 async def test_ping_server_failure_status(mock_session_cls):
     client = MagicMock()
@@ -48,7 +66,7 @@ async def test_ping_server_failure_status(mock_session_cls):
     resp.__aenter__ = AsyncMock(return_value=resp)
     resp.__aexit__ = AsyncMock(return_value=None)
     session = AsyncMock()
-    session.post = MagicMock(return_value=resp)
+    session.get = MagicMock(return_value=resp)
     session.__aenter__ = AsyncMock(return_value=session)
     session.__aexit__ = AsyncMock(return_value=None)
     mock_session_cls.return_value = session


### PR DESCRIPTION
## Summary

- Replaces the lost `botstatus-api.tanjun.bot` relay with a direct Uptime Kuma push from `loops/alivemonitor.py`.
- Loads `UPTIME_KUMA_PUSH_TOKEN` and optional `UPTIME_KUMA_STATUS_URL` from env via `config.py` (optional; no push when token is empty).
- Sends `GET /api/push/{token}?status=up&msg=OK&ping={gateway_latency_ms}` every 60s (existing `pingServerLoop` interval).
- Documents setup for [status.tanjun.bot](https://status.tanjun.bot) including using the push token from the Tanjun monitor (badge id 8).

## Test plan

- [x] `pytest tests/unit/loops/test_loops_direct.py`
- [ ] Set `UPTIME_KUMA_PUSH_TOKEN` in production `.env` (token from Tanjun Push monitor in Uptime Kuma)
- [ ] Deploy and confirm monitor #8 shows recent heartbeat and ping values
- [ ] Optional: `curl "https://status.tanjun.bot/api/push/TOKEN?status=up&msg=OK&ping=50"`


Made with [Cursor](https://cursor.com)