### PR TITLE
fix: correct hasattr checks for locale in logs extension (#3123)

### DIFF
--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -610,7 +610,7 @@ class LogsCog(commands.Cog):
         log_enable = after.guild and (await get_log_enable(after.guild.id)).guild_update
         if not log_enable:
             return
-        locale = after.locale if hasattr(after, 'preferred_locale') else 'en_US'
+        locale = after.locale if hasattr(after, 'locale') else 'en_US'
         description_parts = []
         keiner_locale = l10n.logs.guildUpdate.none(locale)
         if before.afk_channel != after.afk_channel:
@@ -996,7 +996,7 @@ class LogsCog(commands.Cog):
         for blacklisted_role in blacklisted_roles:
             if any((str(role.id) == blacklisted_role for role in after.author.roles)):
                 return
-        locale = after.guild.preferred_locale if hasattr(after, 'preferred_locale') else 'en_US'
+        locale = after.guild.preferred_locale
         description_parts = []
         description_parts.append(l10n.logs.messageEdit.name(locale, user=after.author.mention, url=after.jump_url))
         if before.content != after.content:


### PR DESCRIPTION
Fixes #3123

Two bugs:
- **Line 613** (on_guild_update): `hasattr(after, 'preferred_locale')` should check for `'locale'` since `after` is a `discord.Guild`, not a Discord user/member.
- **Line 999** (on_message_edit): `hasattr(after, 'preferred_locale')` should check `after.guild` since `after` is a `discord.Message`. The guild was already verified non-null above, so simplified to direct access.

These incorrectly formed `hasattr` checks would result in the fallback `'en_US'` string being used, which would then fail when passed as a locale identifier if the locale module expected an enum value. However, the main crash from #3123 (v1.2.66: `'str' object has no attribute 'logs'`) was already fixed by the earlier `locale` → `l10n` rename. These remaining bugs would cause incorrect locale resolution for guild update and message edit events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale handling for server update and message edit event logs to properly reflect server language preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->