### PR TITLE
fix: coverage gate - omit auto-generated locale files and add nav.py tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,8 @@ source = ["."]
 omit = [
     "tests/*",
     "build/*",
+    "locale_keys/_literal_keys.py",
+    "locale_keys/_registry.py",
 ]
 branch = true
 

--- a/tests/unit/locale_keys/test_nav.py
+++ b/tests/unit/locale_keys/test_nav.py
@@ -1,0 +1,60 @@
+"""Tests for locale_keys.nav module."""
+from __future__ import annotations
+
+import pytest
+
+from locale_keys.nav import at, field_name
+
+
+class TestFieldName:
+    def test_simple_identifier(self) -> None:
+        """Standard dot-separated path segments."""
+        assert field_name("hello") == "hello"
+        assert field_name("helloWorld") == "helloWorld"
+        assert field_name("_hello") == "_hello"
+
+    def test_quoted_identifier(self) -> None:
+        """Quoted segments that are valid identifiers."""
+        assert field_name('"hello"') == "hello"
+
+    def test_non_identifier_characters(self) -> None:
+        """Segments with special characters get underscores."""
+        result = field_name("hello-world")
+        assert result == "hello_world"
+        assert _is_valid_identifier(result)
+
+    def test_empty_segment_defaults_to_key(self) -> None:
+        """An empty segment gets 'key'."""
+        result = field_name("")
+        assert result == "key"
+
+    def test_digit_prefix_gets_underscore(self) -> None:
+        """A segment starting with a digit gets an underscore prefix."""
+        result = field_name("123abc")
+        assert result == "_123abc"
+
+    def test_keyword_becomes_keyword_underscore(self) -> None:
+        """Python keywords get an underscore suffix."""
+        result = field_name("for")
+        assert result == "for_"
+        result = field_name("class")
+        assert result == "class_"
+        result = field_name("in")
+        assert result == "in_"
+
+
+class TestAt:
+    def test_simple_path(self) -> None:
+        """at resolves a dotted path to a locale node."""
+        result = at("admin.name")
+        # The root.admin.name should exist as a LocalizedString
+        assert result is not None
+
+    def test_nested_path(self) -> None:
+        """at resolves deeper paths."""
+        result = at("admin.addrole.name")
+        assert result is not None
+
+
+def _is_valid_identifier(s: str) -> bool:
+    return s.isidentifier()


### PR DESCRIPTION
## Summary

The Coverage Gate CI check was failing on `development` because three files were below the 85% per-file coverage threshold:

1. `locale_keys/_literal_keys.py` (0%) — auto-generated
2. `locale_keys/_registry.py` (0%) — auto-generated
3. `locale_keys/nav.py` (81.2%) — utility module

## Changes

- **pyproject.toml**: Added `locale_keys/_literal_keys.py` and `locale_keys/_registry.py` to coverage omit list (they are auto-generated data files, not testable code)
- **tests/unit/locale_keys/test_nav.py**: Added comprehensive tests for `nav.py` covering all branches in `field_name()` (identifiers, quoted, non-identifier chars, empty, digit-prefix, keywords) and `at()` path resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for locale key navigation helpers, including field name validation and dotted path resolution.

* **Chores**
  * Updated code coverage configuration to exclude specific internal modules from measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->