### PR TITLE
Document admin commands and add explicit admin command errors

### DIFF
--- a/docs/admin-commands.md
+++ b/docs/admin-commands.md
@@ -1,0 +1,122 @@
+# Admin Commands
+
+These are owner/admin maintenance commands from `AdministrationCog` in `extensions/administration.py`.
+
+## Access
+
+- All commands in this page require the caller ID to be in `adminIds`.
+- If a non-admin runs one, the bot now responds with a permission error.
+
+## Command Reference
+
+- `sync`
+  - Syncs application commands to Discord.
+  - Usage: `t.sync`
+
+- `feedback <content>`
+  - Stores internal feedback text.
+  - Usage: `t.feedback <text>`
+
+- `blockFeedback <user>`
+  - Blocks a user from feedback features.
+  - Usage: `t.blockFeedback @user`
+
+- `unblockFeedback <user>`
+  - Unblocks a user from feedback features.
+  - Usage: `t.unblockFeedback @user`
+
+- `test_bot`
+  - Runs diagnostics suite.
+  - Usage: `t.test_bot`
+
+- `benchmark_bot`
+  - Runs benchmark suite.
+  - Usage: `t.benchmark_bot`
+
+- `test_translation`
+  - Sends a translation test output.
+  - Usage: `t.test_translation`
+
+- `update`
+  - Runs maintenance steps and triggers restart endpoint.
+  - Usage: `t.update`
+
+- `welcome [user]`
+  - Triggers welcome flow for a user (defaults to caller).
+  - Usage: `t.welcome` or `t.welcome @user`
+
+- `farewell [user]`
+  - Triggers farewell flow for a user (defaults to caller).
+  - Usage: `t.farewell` or `t.farewell @user`
+
+- `onethingaboutmeichfahrautoseitvierjahreneinestageswolltichindenclubfahnichstandaneinerrotenampelundichwarganzalleinhintermirwareinbusunderfihrmirreinerhuptemichanhuphupichschaumiranwaspassiertistunderkommtraus`
+  - Sends the hardcoded meme text.
+  - Usage: `t.onethingaboutmeichfahrautoseitvierjahreneinestageswolltichindenclubfahnichstandaneinerrotenampelundichwarganzalleinhintermirwareinbusunderfihrmirreinerhuptemichanhuphupichschaumiranwaspassiertistunderkommtraus`
+
+- `bsstarpoweremojis [start]`
+  - Imports Brawl Stars star power emojis.
+  - Usage: `t.bsstarpoweremojis` or `t.bsstarpoweremojis 10`
+
+- `bsgadgetsemojis [start]`
+  - Imports Brawl Stars gadget emojis.
+  - Usage: `t.bsgadgetsemojis` or `t.bsgadgetsemojis 10`
+
+- `bsaccdata <id>`
+  - Fetches and prints Brawl Stars account data.
+  - Usage: `t.bsaccdata <playerTagWithoutHash>`
+
+- `editembedmessage`
+  - Sends and edits a test embed message.
+  - Usage: `t.editembedmessage`
+
+- `setguildlocale <locale>`
+  - Sets guild preferred locale.
+  - Usage: `t.setguildlocale de`
+
+- `testgithubauthtoken`
+  - Runs a GitHub auth token localization path test.
+  - Usage: `t.testgithubauthtoken`
+
+- `testupdateuserroles`
+  - Runs role update logic test.
+  - Usage: `t.testupdateuserroles`
+
+- `testgetcorrectnextnumber <mode> <numbers>`
+  - Prints generated sequence for counting mode logic.
+  - Usage: `t.testgetcorrectnextnumber 1 25`
+
+- `sendUpdateTextToAllAdmins`
+  - Sends update broadcast DM flow after multi-step confirmation.
+  - Usage: `t.sendUpdateTextToAllAdmins`
+
+- `sendDemoIsNoMoreToAllAdmins`
+  - Sends demo-bot deprecation broadcast DM flow after confirmation.
+  - Usage: `t.sendDemoIsNoMoreToAllAdmins`
+
+- `me`
+  - Shows bot identity in current guild.
+  - Usage: `t.me`
+
+- `permissionTest`
+  - Prints composite permission test result for current channel.
+  - Usage: `t.permissionTest`
+
+- `permissionTest2`
+  - Prints manage_messages permission test result for current channel.
+  - Usage: `t.permissionTest2`
+
+- `listPermissions [channel]`
+  - Lists bot permissions for a channel (defaults to current).
+  - Usage: `t.listPermissions` or `t.listPermissions #channel`
+
+- `database_sync [url]`
+  - Downloads/imports SQL dump (from attachment or URL), asks for schema selection, backs up current DB, recreates target schema, imports filtered SQL.
+  - Usage:
+    - `t.database_sync` with SQL file attached
+    - `t.database_sync https://example.com/backup.sql`
+
+## Error Responses
+
+- Non-admin usage now returns an explicit permission error.
+- Missing required arguments now return a specific missing-argument error.
+- Invalid argument parsing now returns a command-usage error.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Welcome to the Tanjun documentation! Tanjun is a powerful, feature-rich Discord 
 - [Getting Started](user-manual.md#getting-started)
 - [Architecture Overview](architecture.md)
 - [Database Schema](database-schema.md)
+- [Admin Commands](admin-commands.md)
 - [Contributing Guide](https://github.com/TanjunBot/new_tanjun/blob/development/CONTRIBUTING.md)
 
 ## Project Overview
@@ -37,6 +38,7 @@ Tanjun is an all-in-one Discord bot designed for server management and community
 
 - [**Architecture**](architecture.md) — Internal structure, modules, and design patterns
 - [**Database Schema**](database-schema.md) — Complete table definitions and relationships
+- [**Admin Commands**](admin-commands.md) — Internal owner/admin maintenance command reference
 - [**User Manual**](user-manual.md) — Guide for server owners and administrators
 - [**Contributing**](https://github.com/TanjunBot/new_tanjun/blob/development/CONTRIBUTING.md) — Development setup, coding standards, PR process
 

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -55,6 +55,63 @@ def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
 class AdministrationCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        self._apply_command_docs()
+
+    def _apply_command_docs(self) -> None:
+        docs: dict[str, tuple[str, str, str]] = {
+            'sync': ('Syncs application commands to Discord.', 'Sync commands', 't.sync'),
+            'feedback': ('Stores internal feedback text.', 'Store feedback', 't.feedback <text>'),
+            'blockFeedback': ('Blocks a user from feedback features.', 'Block feedback user', 't.blockFeedback @user'),
+            'unblockFeedback': ('Unblocks a user from feedback features.', 'Unblock feedback user', 't.unblockFeedback @user'),
+            'test_bot': ('Runs the diagnostics suite.', 'Run diagnostics', 't.test_bot'),
+            'benchmark_bot': ('Runs the benchmark suite.', 'Run benchmarks', 't.benchmark_bot'),
+            'test_translation': ('Sends translation test output.', 'Test translations', 't.test_translation'),
+            'update': ('Runs maintenance steps and triggers restart endpoint.', 'Run maintenance update', 't.update'),
+            'welcome': ('Triggers welcome flow for a user.', 'Test welcome flow', 't.welcome [@user]'),
+            'farewell': ('Triggers farewell flow for a user.', 'Test farewell flow', 't.farewell [@user]'),
+            'onethingaboutmeichfahrautoseitvierjahreneinestageswolltichindenclubfahnichstandaneinerrotenampelundichwarganzalleinhintermirwareinbusunderfihrmirreinerhuptemichanhuphupichschaumiranwaspassiertistunderkommtraus': ('Sends the hardcoded long text message.', 'Send long meme text', 't.onethingaboutmeichfahrautoseitvierjahreneinestageswolltichindenclubfahnichstandaneinerrotenampelundichwarganzalleinhintermirwareinbusunderfihrmirreinerhuptemichanhuphupichschaumiranwaspassiertistunderkommtraus'),
+            'bsstarpoweremojis': ('Imports Brawl Stars star power emojis.', 'Import star power emojis', 't.bsstarpoweremojis [start]'),
+            'bsgadgetsemojis': ('Imports Brawl Stars gadget emojis.', 'Import gadget emojis', 't.bsgadgetsemojis [start]'),
+            'bsaccdata': ('Fetches and prints Brawl Stars account data.', 'Show Brawl Stars data', 't.bsaccdata <player_tag_without_hash>'),
+            'editembedmessage': ('Sends and edits a test embed message.', 'Test embed edit', 't.editembedmessage'),
+            'setguildlocale': ('Sets guild preferred locale.', 'Set guild locale', 't.setguildlocale <locale>'),
+            'testgithubauthtoken': ('Runs the GitHub auth token test path.', 'Test GitHub auth path', 't.testgithubauthtoken'),
+            'testupdateuserroles': ('Runs user role update logic test.', 'Test role updates', 't.testupdateuserroles'),
+            'testgetcorrectnextnumber': ('Prints sequence output for counting mode logic.', 'Test counting sequence', 't.testgetcorrectnextnumber <mode> <numbers>'),
+            'sendUpdateTextToAllAdmins': ('Broadcasts update text after confirmation flow.', 'Broadcast update message', 't.sendUpdateTextToAllAdmins'),
+            'sendDemoIsNoMoreToAllAdmins': ('Broadcasts demo deprecation text after confirmation flow.', 'Broadcast demo deprecation', 't.sendDemoIsNoMoreToAllAdmins'),
+            'me': ('Shows bot identity in current guild.', 'Show bot identity', 't.me'),
+            'permissionTest': ('Checks composite channel permissions.', 'Check permissions', 't.permissionTest'),
+            'permissionTest2': ('Checks manage_messages permission.', 'Check manage_messages', 't.permissionTest2'),
+            'listPermissions': ('Lists bot permissions for a channel.', 'List bot permissions', 't.listPermissions [#channel]'),
+            'database_sync': ('Imports SQL from attachment or URL, selects schema, backs up current DB, recreates target schema and imports.', 'Sync database from SQL backup', 't.database_sync [url] (or attach .sql)'),
+        }
+        for name, (help_text, brief_text, usage_text) in docs.items():
+            cmd = self.get_command(name)
+            if cmd is None:
+                continue
+            cmd.help = help_text
+            cmd.brief = brief_text
+            cmd.usage = usage_text
+
+    async def cog_check(self, ctx: commands.Context) -> bool:
+        if ctx.author.id in config.adminIds:
+            return True
+        await ctx.send(embed=warning_embed('You are not allowed to use this command.', title='Permission Denied'))
+        return False
+
+    async def cog_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
+        if isinstance(error, commands.CheckFailure):
+            return
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.send(embed=error_embed(f'Missing required argument: `{error.param.name}`.', title='Invalid Command Usage'))
+            return
+        if isinstance(error, commands.BadArgument):
+            await ctx.send(embed=error_embed('One or more command arguments are invalid.', title='Invalid Command Usage'))
+            return
+        if isinstance(error, commands.BadUnionArgument):
+            await ctx.send(embed=error_embed('Could not parse one or more arguments for this command.', title='Invalid Command Usage'))
+            return
 
     def _locale(self, ctx: commands.Context) -> str:
         """Get locale string from context."""


### PR DESCRIPTION
## Summary
- add a dedicated `docs/admin-commands.md` reference listing all `AdministrationCog` commands with usage examples
- link the new admin command reference from `docs/index.md`
- improve admin command UX by adding cog-level permission checks, argument error responses, and discord.py `help`/`brief`/`usage` metadata for command discoverability

## Test plan
- [x] `python -m py_compile extensions/administration.py`
- [x] verified lints for updated files are clean
- [ ] manually run selected admin commands in Discord to validate help text rendering and permission/argument error embeds

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive admin commands documentation, including complete command reference with usage, arguments, and access requirements.

* **Improvements**
  * Enhanced admin command permission validation and standardized error responses for better user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->