### PR TITLE
fix: prevent administration extension load crash

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -115,7 +115,7 @@ class AdministrationCog(commands.Cog):
             'database_sync': ('Imports SQL from attachment or URL, selects schema, backs up current DB, recreates target schema and imports.', 'Sync database from SQL backup', 't.database_sync [url] (or attach .sql)'),
         }
         for name, (help_text, brief_text, usage_text) in docs.items():
-            cmd = self.get_command(name)
+            cmd = self.bot.get_command(name)
             if cmd is None:
                 continue
             cmd.help = help_text


### PR DESCRIPTION
## Summary
- use the bot command registry when applying admin command docs at cog init
- avoid calling a non-existent cog method (`get_command`) that crashed extension startup
- keep behavior otherwise unchanged (docs still attach to the same command names)

## Test plan
- [x] `pytest tests/integration/extensions/test_administration_comprehensive.py -q`
- [ ] deploy and verify container healthcheck passes

Made with [Cursor](https://cursor.com)