### PR TITLE
fix: prevent administration extension load crash (ver/1.2)

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -115,7 +115,7 @@ class AdministrationCog(commands.Cog):
             'database_sync': ('Imports SQL from attachment or URL, selects schema, backs up current DB, recreates target schema and imports.', 'Sync database from SQL backup', 't.database_sync [url] (or attach .sql)'),
         }
         for name, (help_text, brief_text, usage_text) in docs.items():
-            cmd = self.get_command(name)
+            cmd = self.bot.get_command(name)
             if cmd is None:
                 continue
             cmd.help = help_text


### PR DESCRIPTION
## Summary
- use `self.bot.get_command(name)` when applying admin command docs
- avoid `AttributeError` during cog initialization on startup
- keep command docs behavior unchanged

## Test plan
- [x] `pytest tests/integration/extensions/test_administration_comprehensive.py -q`
- [ ] deploy `ver/1.2` and verify healthcheck status is healthy

Made with [Cursor](https://cursor.com)