### PR TITLE
Improve admin diagnostics and benchmark readability

### DIFF
--- a/diagnostics/benchmark_models.py
+++ b/diagnostics/benchmark_models.py
@@ -3,6 +3,43 @@ from __future__ import annotations
 import statistics
 from dataclasses import dataclass, field
 
+GRADE_BANDS: tuple[tuple[str, float], ...] = (
+    ("A+", 115.0),
+    ("A", 100.0),
+    ("B", 90.0),
+    ("C", 75.0),
+    ("D", 60.0),
+    ("F", 0.0),
+)
+
+BENCH_TARGETS_MS: dict[str, float] = {
+    "discord.gateway_latency": 120.0,
+    "discord.message_roundtrip": 280.0,
+    "database.pool_acquire": 6.0,
+    "database.select_1": 22.0,
+    "database.parallel_select_1": 150.0,
+    "database.level_config_count": 40.0,
+    "database.guild_level_config": 30.0,
+    "localization.sample_keys": 10.0,
+    "localization.locale_file_load": 30.0,
+    "io.manifest_json_parse": 1.0,
+    "commands.tree_enumerate": 7.0,
+    "commands.manifest_compare": 12.0,
+    "commands.prefix_enumerate": 8.0,
+    "handlers.all_specs": 350.0,
+    "runtime.event_loop_yield": 1.5,
+    "runtime.async_gather": 10.0,
+}
+
+PREFIX_TARGETS_MS: tuple[tuple[str, float], ...] = (
+    ("health.", 120.0),
+    ("database.", 30.0),
+    ("runtime.", 10.0),
+    ("commands.", 12.0),
+    ("localization.", 20.0),
+    ("discord.", 250.0),
+)
+
 
 @dataclass
 class BenchmarkResult:
@@ -53,6 +90,64 @@ class BenchmarkResult:
             return 0.0
         return round(statistics.mean(self.samples_ms), 2)
 
+    @property
+    def display_name(self) -> str:
+        return self.bench_id.replace(".", " ").replace("_", " ").title()
+
+    @property
+    def target_ms(self) -> float:
+        if self.bench_id in BENCH_TARGETS_MS:
+            return BENCH_TARGETS_MS[self.bench_id]
+        for prefix, target in PREFIX_TARGETS_MS:
+            if self.bench_id.startswith(prefix):
+                return target
+        return 50.0
+
+    @property
+    def grade_score(self) -> float:
+        if not self.ok:
+            return 0.0
+        median = self.median_ms
+        if median <= 0:
+            return 120.0
+        score = (self.target_ms / median) * 100
+        return round(max(0.0, min(130.0, score)), 1)
+
+    @property
+    def grade(self) -> str:
+        for grade, threshold in GRADE_BANDS:
+            if self.grade_score >= threshold:
+                return grade
+        return "F"
+
+    @property
+    def plain_quality(self) -> str:
+        if self.error:
+            return "not available"
+        if self.grade in {"A+", "A"}:
+            return "excellent"
+        if self.grade == "B":
+            return "good"
+        if self.grade == "C":
+            return "acceptable"
+        if self.grade == "D":
+            return "weak"
+        return "poor"
+
+    @property
+    def plain_explanation(self) -> str:
+        if self.error:
+            return "This check failed and should be reviewed."
+        if self.grade in {"A+", "A"}:
+            return "Users should feel this as fast and responsive."
+        if self.grade == "B":
+            return "Performance is solid and should feel smooth."
+        if self.grade == "C":
+            return "This is usable but has room to improve."
+        if self.grade == "D":
+            return "Users may notice delays in this area."
+        return "This is slow and likely needs optimization."
+
     def summary(self) -> str:
         if self.error:
             return f"{self.bench_id}: ERROR — {self.error}"
@@ -63,6 +158,7 @@ class BenchmarkResult:
             f"p95={self.p95_ms}ms mean={self.mean_ms}ms "
             f"min={self.min_ms} max={self.max_ms} (n={self.count})"
         )
+        base = f"{base} grade={self.grade} ({self.plain_quality})"
         if self.detail:
             return f"{base} — {self.detail}"
         return base
@@ -91,3 +187,23 @@ class BenchmarkSummary:
     @property
     def error_count(self) -> int:
         return sum(1 for p in self.phases for r in p.results if r.error)
+
+    @property
+    def ok_results(self) -> list[BenchmarkResult]:
+        return [r for p in self.phases for r in p.results if r.ok]
+
+    @property
+    def overall_score(self) -> float:
+        ok = self.ok_results
+        if not ok:
+            return 0.0
+        raw = sum((r.grade_score for r in ok)) / len(ok)
+        penalized = max(0.0, raw - (self.error_count * 12.0))
+        return round(penalized, 1)
+
+    @property
+    def overall_grade(self) -> str:
+        for grade, threshold in GRADE_BANDS:
+            if self.overall_score >= threshold:
+                return grade
+        return "F"

--- a/diagnostics/benchmark_runner.py
+++ b/diagnostics/benchmark_runner.py
@@ -46,8 +46,20 @@ class BenchmarkRunner:
     async def _report_phase(self, phase: BenchmarkPhase) -> None:
         header = f'**Phase {phase.phase_id}: {phase.title}**'
         await self._thread_send(header)
-        lines = [r.summary() for r in phase.results]
+        lines = [self._friendly_result_line(r) for r in phase.results]
         await self._thread_send_lines(lines)
+
+    def _friendly_result_line(self, result: BenchmarkResult) -> str:
+        if result.error:
+            return f"- {result.display_name}: Grade F (not available). {result.plain_explanation} Error: {result.error}"
+        line = (
+            f"- {result.display_name}: Grade {result.grade} ({result.plain_quality}). "
+            f"Typical speed: {result.median_ms}ms, worst normal case: {result.p95_ms}ms. "
+            f"{result.plain_explanation}"
+        )
+        if result.detail:
+            return f"{line} Details: {result.detail}"
+        return line
 
     async def run_all(self) -> BenchmarkSummary:
         wall_start = time.perf_counter()
@@ -124,10 +136,33 @@ class BenchmarkRunner:
     async def _finalize(self) -> None:
         s = self.summary
         phase_lines = [f'- Phase {p.phase_id} ({p.title}): {len(p.results)} benchmarks' for p in s.phases]
-        lines = ['## Summary', *phase_lines, f'**Benchmarks:** {s.bench_count}', f'**Errors:** {s.error_count}', f'**Total wall time:** {s.total_wall_ms}ms']
+        best = None
+        if s.ok_results:
+            best = max(s.ok_results, key=lambda r: r.grade_score)
+        worst = None
+        if s.ok_results:
+            worst = min(s.ok_results, key=lambda r: r.grade_score)
+        lines = [
+            '## Benchmark Overview',
+            f'**Overall grade:** {s.overall_grade} ({s.overall_score}/100)',
+            f'**Benchmarks:** {s.bench_count}',
+            f'**Errors:** {s.error_count}',
+            f'**Total wall time:** {s.total_wall_ms}ms',
+            *phase_lines,
+        ]
+        if best is not None:
+            lines.append(f'**Best area:** {best.display_name} (Grade {best.grade})')
+        if worst is not None:
+            lines.append(f'**Needs most attention:** {worst.display_name} (Grade {worst.grade})')
         await self._thread_send('\n'.join(lines))
         from utility import success_embed, warning_embed
-        summary_body = '\n'.join([f'Benchmarks run: {s.bench_count}', f'Errors: {s.error_count}', f'Wall time: {s.total_wall_ms}ms', 'See thread for per-phase timings.'])
+        summary_body = '\n'.join([
+            f'Overall grade: {s.overall_grade} ({s.overall_score}/100)',
+            f'Benchmarks run: {s.bench_count}',
+            f'Errors: {s.error_count}',
+            f'Wall time: {s.total_wall_ms}ms',
+            'See thread for plain-language benchmark details.',
+        ])
         if s.error_count:
             embed = warning_embed(summary_body, title='Bot Benchmarks')
         else:

--- a/tests/integration/extensions/test_administration_comprehensive.py
+++ b/tests/integration/extensions/test_administration_comprehensive.py
@@ -138,34 +138,256 @@ class TestTestBot:
         ctx = make_context(bot)
         sent = MagicMock()
         sent.edit = AsyncMock()
+        sent.create_thread = AsyncMock()
         ctx.send = AsyncMock(return_value=sent)
         with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
             await cog.test_bot(ctx)
+        ctx.send.assert_awaited_once()
         sent.edit.assert_awaited()
+        sent.create_thread.assert_not_awaited()
 
     async def test_diagnostics_error(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
+        ctx.message.id = 987654321
         sent = MagicMock()
-        sent.create_thread = AsyncMock(return_value=MagicMock(send=AsyncMock()))
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
         sent.edit = AsyncMock()
         ctx.send = AsyncMock(return_value=sent)
         with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', autospec=True) as mock_runner_cls:
             mock_runner = mock_runner_cls.return_value
             mock_runner.run_all = AsyncMock(side_effect=RuntimeError('diagnostics fail'))
             await cog.test_bot(ctx)
+        sent.create_thread.assert_awaited_once_with(name='bot-diagnostics-987654321')
+        mock_runner_cls.assert_called_once_with(cog.bot, ctx, thread, sent, locale='en')
         sent.edit.assert_awaited()
+        thread.send.assert_awaited_once_with('Diagnostics aborted: diagnostics fail')
 
     async def test_diagnostics_success(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
+        ctx.message.id = 222
+        ctx.guild.preferred_locale = 'de'
         sent = MagicMock()
-        sent.create_thread = AsyncMock(return_value=MagicMock(send=AsyncMock()))
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
         sent.edit = AsyncMock()
         ctx.send = AsyncMock(return_value=sent)
         mock_runner = MagicMock()
         mock_runner.run_all = AsyncMock()
-        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=mock_runner):
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=mock_runner) as runner_cls:
             await cog.test_bot(ctx)
+        sent.create_thread.assert_awaited_once_with(name='bot-diagnostics-222')
+        runner_cls.assert_called_once_with(cog.bot, ctx, thread, sent, locale='de')
         mock_runner.run_all.assert_awaited_once()
+        thread.send.assert_not_awaited()
+        sent.edit.assert_not_awaited()
+
+    async def test_diagnostics_thread_creation_failure(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        ctx.message.id = 111
+        sent = MagicMock()
+        sent.create_thread = AsyncMock(side_effect=RuntimeError('thread fail'))
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', autospec=True) as runner_cls:
+            await cog.test_bot(ctx)
+        sent.create_thread.assert_awaited_once_with(name='bot-diagnostics-111')
+        sent.edit.assert_awaited_once()
+        runner_cls.assert_not_called()
+
+    async def test_diagnostics_unavailable_uses_en_fallback_locale(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot, guild_locale='fr')
+        sent = MagicMock()
+        sent.edit = AsyncMock()
+        sent.create_thread = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
+            await cog.test_bot(ctx)
+        first_embed = ctx.send.await_args.kwargs['embed']
+        edited_embed = sent.edit.await_args.kwargs['embed']
+        assert first_embed.title == 'Bot Diagnostics'
+        assert edited_embed.title == 'Bot Diagnostics'
+        sent.create_thread.assert_not_awaited()
+
+    async def test_diagnostics_without_guild_uses_default_locale(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        ctx.guild = None
+        ctx.message.id = 4321
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock()
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner) as runner_cls:
+            await cog.test_bot(ctx)
+        runner_cls.assert_called_once_with(cog.bot, ctx, thread, sent, locale='en')
+        runner.run_all.assert_awaited_once()
+
+    async def test_diagnostics_error_without_thread_does_not_send_abort(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        sent = MagicMock()
+        sent.create_thread = AsyncMock(side_effect=RuntimeError('create thread failed'))
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True):
+            await cog.test_bot(ctx)
+        sent.edit.assert_awaited_once()
+
+    async def test_diagnostics_error_embed_contains_test_name(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock(side_effect=RuntimeError('boom'))
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            await cog.test_bot(ctx)
+        edited_embed = sent.edit.await_args.kwargs['embed']
+        assert edited_embed.title == 'Bot Diagnostics'
+        assert 'Diagnostics' in edited_embed.description
+        assert 'boom' in edited_embed.description
+
+    async def test_diagnostics_thread_name_is_trimmed_to_100_chars(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        ctx.message.id = int('9' * 120)
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock()
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            await cog.test_bot(ctx)
+        created_name = sent.create_thread.await_args.kwargs['name']
+        assert len(created_name) == 100
+        assert created_name.startswith('bot-diagnostics-')
+
+    async def test_diagnostics_start_embed_title_is_constant(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        sent = MagicMock()
+        sent.edit = AsyncMock()
+        sent.create_thread = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
+            await cog.test_bot(ctx)
+        start_embed = ctx.send.await_args.kwargs['embed']
+        assert start_embed.title == 'Bot Diagnostics'
+
+    async def test_diagnostics_start_embed_description_matches_locale(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot, guild_locale='de')
+        sent = MagicMock()
+        sent.edit = AsyncMock()
+        sent.create_thread = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
+            await cog.test_bot(ctx)
+        start_embed = ctx.send.await_args.kwargs['embed']
+        assert start_embed.description == locale.commands.admin.administration.test_bot.starting('de')
+
+    async def test_diagnostics_unavailable_embed_description_matches_locale(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot, guild_locale='de')
+        sent = MagicMock()
+        sent.edit = AsyncMock()
+        sent.create_thread = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
+            await cog.test_bot(ctx)
+        unavailable_embed = sent.edit.await_args.kwargs['embed']
+        assert unavailable_embed.description == locale.commands.admin.administration.test_bot.tests_unavailable('de')
+
+    async def test_diagnostics_error_embed_description_matches_locale(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot, guild_locale='de')
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock(side_effect=RuntimeError('kaputt'))
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            await cog.test_bot(ctx)
+        edited_embed = sent.edit.await_args.kwargs['embed']
+        assert edited_embed.description == locale.commands.admin.administration.test_bot.error('de', test_name='Diagnostics', error=RuntimeError('kaputt'))
+
+    async def test_diagnostics_send_failure_bubbles_up(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        ctx.send = AsyncMock(side_effect=RuntimeError('send failed'))
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', False):
+            with pytest.raises(RuntimeError, match='send failed'):
+                await cog.test_bot(ctx)
+
+    async def test_diagnostics_runner_constructor_failure_edits_and_notifies_thread(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', side_effect=RuntimeError('ctor fail')):
+            await cog.test_bot(ctx)
+        sent.edit.assert_awaited_once()
+        thread.send.assert_awaited_once_with('Diagnostics aborted: ctor fail')
+
+    async def test_diagnostics_abort_notification_failure_bubbles_up(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock(side_effect=RuntimeError('thread notify failed')))
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock(side_effect=RuntimeError('runner fail'))
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            with pytest.raises(RuntimeError, match='thread notify failed'):
+                await cog.test_bot(ctx)
+        sent.edit.assert_awaited_once()
+
+    async def test_diagnostics_success_call_order_send_then_thread_then_runner(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        call_order: list[str] = []
+        ctx = make_context(bot)
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+
+        async def _create_thread(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append('create_thread')
+            return thread
+
+        sent.create_thread = AsyncMock(side_effect=_create_thread)
+        sent.edit = AsyncMock()
+
+        async def _send(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append('send')
+            return sent
+
+        ctx.send = AsyncMock(side_effect=_send)
+        runner = MagicMock()
+
+        async def _run_all() -> None:
+            call_order.append('run_all')
+
+        runner.run_all = AsyncMock(side_effect=_run_all)
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            await cog.test_bot(ctx)
+        assert call_order == ['send', 'create_thread', 'run_all']
+
+    async def test_diagnostics_thread_name_exact_for_short_message_id(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        ctx.message.id = 17
+        sent = MagicMock()
+        thread = MagicMock(send=AsyncMock())
+        sent.create_thread = AsyncMock(return_value=thread)
+        sent.edit = AsyncMock()
+        ctx.send = AsyncMock(return_value=sent)
+        runner = MagicMock()
+        runner.run_all = AsyncMock()
+        with patch.object(admin_mod, 'DIAGNOSTICS_AVAILABLE', True), patch('extensions.administration.DiagnosticsRunner', return_value=runner):
+            await cog.test_bot(ctx)
+        assert sent.create_thread.await_args.kwargs['name'] == 'bot-diagnostics-17'
 
 @pytest.mark.asyncio
 class TestBenchmarkBot:

--- a/tests/unit/diagnostics/test_benchmark_models.py
+++ b/tests/unit/diagnostics/test_benchmark_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from diagnostics.benchmark_models import BenchmarkResult
+from diagnostics.benchmark_models import BenchmarkPhase, BenchmarkResult, BenchmarkSummary
 
 
 def test_benchmark_result_summary_with_samples() -> None:
@@ -23,3 +23,19 @@ def test_benchmark_result_ok_false_on_error() -> None:
 def test_benchmark_result_p95_single_sample() -> None:
     result = BenchmarkResult("x", samples_ms=[42.0])
     assert result.p95_ms == 42.0
+
+
+def test_benchmark_result_has_grade() -> None:
+    result = BenchmarkResult("database.select_1", samples_ms=[9.0, 10.0, 11.0])
+    assert result.grade in {"A+", "A", "B", "C", "D", "F"}
+    assert result.plain_quality
+    assert result.plain_explanation
+
+
+def test_benchmark_summary_overall_grade_penalizes_errors() -> None:
+    fast = BenchmarkResult("runtime.event_loop_yield", samples_ms=[0.2, 0.2, 0.3])
+    failed = BenchmarkResult("database.select_1", error="db down")
+    summary = BenchmarkSummary(phases=[BenchmarkPhase("A", "Test", results=[fast, failed])])
+    assert summary.error_count == 1
+    assert summary.overall_grade in {"A+", "A", "B", "C", "D", "F"}
+    assert summary.overall_score >= 0.0


### PR DESCRIPTION
## Summary
- deepens `test_bot` command coverage in the administration integration suite
- adds plain-language benchmark reporting with per-benchmark letter grades and quality descriptions
- adds an overall benchmark score/grade plus best/worst area callouts in the final benchmark summary

## Test plan
- [x] `pytest tests/unit/diagnostics/test_benchmark_models.py`
- [x] `pytest tests/integration/extensions/test_administration_comprehensive.py -k benchmark`

Made with [Cursor](https://cursor.com)