### PR TITLE
fix(admin): clean up temporary localization issues after diagnostics

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -33,6 +33,7 @@ except ImportError:
     DIAGNOSTICS_AVAILABLE = False
     BenchmarkRunner = None
 from utility import addFeedback, embed_or_wrap, error_embed, missingLocalization, success_embed, tanjunEmbed, warning_embed
+from utils.github import begin_missing_localization_capture, cleanup_captured_missing_localization_issues, end_missing_localization_capture
 
 def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
     """Create a temporary MySQL defaults file with credentials. Returns the file path."""
@@ -214,6 +215,7 @@ class AdministrationCog(commands.Cog):
             await message.edit(embed=tanjunEmbed(title='Bot Diagnostics', description=l10n.commands.admin.administration.test_bot.tests_unavailable(locale)))
             return
         thread = None
+        begin_missing_localization_capture()
         try:
             thread_name = f'bot-diagnostics-{ctx.message.id}'
             thread = await message.create_thread(name=thread_name[:100])
@@ -223,6 +225,11 @@ class AdministrationCog(commands.Cog):
             await message.edit(embed=error_embed(l10n.commands.admin.administration.test_bot.error(locale, test_name='Diagnostics', error=e), title='Bot Diagnostics'))
             if thread is not None:
                 await thread.send(f'Diagnostics aborted: {e}')
+        finally:
+            end_missing_localization_capture()
+            closed_count = await cleanup_captured_missing_localization_issues()
+            if thread is not None and closed_count:
+                await thread.send(f"Closed {closed_count} temporary missing-localization issue(s) created during this diagnostics run.")
 
     @commands.command()
     async def benchmark_bot(self, ctx: commands.Context) -> None:

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -10,6 +10,9 @@ import pytest
 from utils.github import (
     _recent_reports,
     addFeedback,
+    begin_missing_localization_capture,
+    cleanup_captured_missing_localization_issues,
+    end_missing_localization_capture,
     missingLocalization,
     report_bot_exception,
     report_bot_exception_sync,
@@ -183,3 +186,39 @@ class TestSyncHelpers:
 
         mock_repo.create_issue.assert_called_once()
         assert "Alice" in mock_repo.create_issue.call_args[1]["body"]
+
+
+class TestMissingLocalizationCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_captured_missing_localization_issues_closes_created_issues(self):
+        issue = MagicMock()
+        issue.number = 123
+        issue_to_close = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.create_issue.return_value = issue
+        mock_repo.get_issue.return_value = issue_to_close
+        mock_g = MagicMock()
+        mock_g.get_repo.return_value = mock_repo
+        mock_g.search_issues.return_value.totalCount = 0
+
+        with (
+            patch("utils.github.GithubAuthToken", "token"),
+            patch("utils.github.Github", return_value=mock_g),
+            patch("utils.github._missing_localization_resolved", return_value=False),
+        ):
+            begin_missing_localization_capture()
+            from utils.github import _sync_create_missing_localization_issue
+
+            _sync_create_missing_localization_issue("fr-FR", "commands.test.title")
+            end_missing_localization_capture()
+            closed = await cleanup_captured_missing_localization_issues()
+
+        assert closed == 1
+        issue_to_close.edit.assert_called_once_with(state="closed")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_capture_does_nothing(self):
+        begin_missing_localization_capture()
+        end_missing_localization_capture()
+        closed = await cleanup_captured_missing_localization_issues()
+        assert closed == 0

--- a/utils/github.py
+++ b/utils/github.py
@@ -18,6 +18,8 @@ _REPO = 'TanjunBot/new_tanjun'
 _EXCEPTION_LABELS = ('bug', 'bot exception')
 _DEDUP_TTL_SEC = 3600.0
 _recent_reports: dict[str, float] = {}
+_capture_missing_localization_issues = False
+_captured_missing_localization_issue_numbers: set[int] = set()
 
 def _is_discord_instance(exc: BaseException, exc_type: Any) -> bool:
     if not isinstance(exc_type, type):
@@ -128,6 +130,25 @@ async def missingLocalization(locale: str, key: str) -> None:
     """Create a GitHub issue reporting a missing localization."""
     await run_blocking(_sync_create_missing_localization_issue, locale, key)
 
+
+def begin_missing_localization_capture() -> None:
+    global _capture_missing_localization_issues
+    _capture_missing_localization_issues = True
+    _captured_missing_localization_issue_numbers.clear()
+
+
+def end_missing_localization_capture() -> None:
+    global _capture_missing_localization_issues
+    _capture_missing_localization_issues = False
+
+
+async def cleanup_captured_missing_localization_issues() -> int:
+    issue_numbers = list(_captured_missing_localization_issue_numbers)
+    _captured_missing_localization_issue_numbers.clear()
+    if not issue_numbers:
+        return 0
+    return await run_blocking(_sync_close_missing_localization_issues, issue_numbers)
+
 def _missing_localization_issue_title(locale: str, key: str) -> str:
     return f'Missing localization: {key} ({locale})'
 
@@ -156,9 +177,29 @@ def _sync_create_missing_localization_issue(locale: str, key: str) -> None:
             return
         repo = g.get_repo(_REPO)
         label = repo.get_label('missing localization')
-        repo.create_issue(title=title, body=f'Missing translation for key `{key}` in locale `{locale}`.', labels=[label])
+        created = repo.create_issue(title=title, body=f'Missing translation for key `{key}` in locale `{locale}`.', labels=[label])
+        if _capture_missing_localization_issues:
+            number = getattr(created, "number", None)
+            if isinstance(number, int):
+                _captured_missing_localization_issue_numbers.add(number)
     except Exception as report_error:
         logger.error('Failed to create missing localization issue: %s', report_error)
+
+
+def _sync_close_missing_localization_issues(issue_numbers: list[int]) -> int:
+    if not GithubAuthToken:
+        return 0
+    closed = 0
+    g = Github(GithubAuthToken)
+    repo = g.get_repo(_REPO)
+    for issue_number in issue_numbers:
+        try:
+            issue = repo.get_issue(issue_number)
+            issue.edit(state="closed")
+            closed += 1
+        except Exception as close_error:
+            logger.error('Failed to close missing localization issue #%s: %s', issue_number, close_error)
+    return closed
 
 async def addFeedback(content: str, author: str) -> None:
     """Create a GitHub issue with user feedback."""


### PR DESCRIPTION
## Summary
- capture missing-localization issues created during `t.test_bot` diagnostics runs
- close captured issues automatically in `finally` so test runs do not leave manual cleanup
- add unit tests for capture and cleanup behavior in `utils.github`

## Test plan
- [x] `pytest tests/unit/utils/test_github.py -q`
- [ ] Run `t.test_bot` in Discord and confirm no leftover temporary missing-localization issues remain open


Made with [Cursor](https://cursor.com)