### PR TITLE
fix(admin/db): clean localization diagnostics and persist DB writes

### DIFF
--- a/api.py
+++ b/api.py
@@ -268,6 +268,11 @@ async def _execute_with_retry(
             async with conn.cursor() as cursor:
                 await asyncio.wait_for(cursor.execute(query, params), timeout=_QUERY_TIMEOUT)
                 _result = await callback(cursor, conn)
+                if not is_write:
+                    try:
+                        await conn.rollback()
+                    except Exception:
+                        pass
             _elapsed = time.monotonic() - _start
             try:
                 from extensions.prometheus_metrics import record_db_query
@@ -292,12 +297,22 @@ async def _execute_with_retry(
             if not is_write:
                 retryable = retryable or "connection" in err_str or "timeout" in err_str
             if attempt < _MAX_DB_RETRIES - 1 and retryable:
+                if is_write and conn is not None:
+                    try:
+                        await conn.rollback()
+                    except Exception:
+                        pass
                 print(f"Transient error on {operation} attempt {attempt + 1}/{_MAX_DB_RETRIES}: {safe_id}")
                 await asyncio.sleep(0.5 * (attempt + 1))
                 last_exception = e
                 if "connection" in err_str or "timeout" in err_str:
                     broken_connection = True
                 continue
+            if is_write and conn is not None:
+                try:
+                    await conn.rollback()
+                except Exception:
+                    pass
             _elapsed = time.monotonic() - _start
             try:
                 from extensions.prometheus_metrics import record_db_query
@@ -578,6 +593,10 @@ async def execute_query_iter(
                 async for row in cursor:
                     yielded_any = True
                     yield row
+            try:
+                await conn.rollback()
+            except Exception:
+                pass
             return
         except TimeoutError:
             broken_connection = True

--- a/api.py
+++ b/api.py
@@ -126,6 +126,7 @@ class DatabaseManager:
             return None
 
         async def _callback(cursor: Any, conn: Any) -> int:
+            await conn.commit()
             return cursor.rowcount
 
         return await _execute_with_retry("execute_action", _callback, query, params, is_write=True)
@@ -141,6 +142,7 @@ class DatabaseManager:
 
         async def _callback(cursor: Any, conn: Any) -> None:
             await cursor.executemany(query, params_list)
+            await conn.commit()
             return None
 
         await _execute_with_retry("execute_batch", _callback, query, is_write=True)

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -33,6 +33,7 @@ except ImportError:
     DIAGNOSTICS_AVAILABLE = False
     BenchmarkRunner = None
 from utility import addFeedback, embed_or_wrap, error_embed, missingLocalization, success_embed, tanjunEmbed, warning_embed
+from utils.github import begin_missing_localization_capture, cleanup_captured_missing_localization_issues, end_missing_localization_capture
 
 def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
     """Create a temporary MySQL defaults file with credentials. Returns the file path."""
@@ -214,6 +215,7 @@ class AdministrationCog(commands.Cog):
             await message.edit(embed=tanjunEmbed(title='Bot Diagnostics', description=l10n.commands.admin.administration.test_bot.tests_unavailable(locale)))
             return
         thread = None
+        begin_missing_localization_capture()
         try:
             thread_name = f'bot-diagnostics-{ctx.message.id}'
             thread = await message.create_thread(name=thread_name[:100])
@@ -223,6 +225,11 @@ class AdministrationCog(commands.Cog):
             await message.edit(embed=error_embed(l10n.commands.admin.administration.test_bot.error(locale, test_name='Diagnostics', error=e), title='Bot Diagnostics'))
             if thread is not None:
                 await thread.send(f'Diagnostics aborted: {e}')
+        finally:
+            end_missing_localization_capture()
+            closed_count = await cleanup_captured_missing_localization_issues()
+            if thread is not None and closed_count:
+                await thread.send(f"Closed {closed_count} temporary missing-localization issue(s) created during this diagnostics run.")
 
     @commands.command()
     async def benchmark_bot(self, ctx: commands.Context) -> None:

--- a/tests/integration/api/test_api_integration.py
+++ b/tests/integration/api/test_api_integration.py
@@ -559,6 +559,7 @@ async def test_tables_are_created_via_create_tables(integration_db_pool):
     async with pool.acquire() as conn, conn.cursor() as cursor:
         await cursor.execute("SHOW TABLES")
         tables = {row[0] for row in await cursor.fetchall()}
+        await conn.rollback()
 
     # Core expected tables
     expected = {
@@ -628,6 +629,7 @@ async def test_channel_blacklist_round_trip(integration_db_pool):
             (TEST_GUILD, TEST_CHANNEL),
         )
         row = await cursor.fetchone()
+        await conn.rollback()
     assert row is not None, "Channel should appear in blacklist"
     assert row[0] == TEST_CHANNEL
     assert row[1] == "Integration test channel blacklist"
@@ -646,6 +648,7 @@ async def test_role_blacklist_round_trip(integration_db_pool):
             (TEST_GUILD, TEST_ROLE),
         )
         row = await cursor.fetchone()
+        await conn.rollback()
     assert row is not None, "Role should appear in blacklist"
     assert row[0] == TEST_ROLE
     assert row[1] == "Integration test role blacklist"

--- a/tests/unit/api/test_execute_with_retry.py
+++ b/tests/unit/api/test_execute_with_retry.py
@@ -10,7 +10,7 @@ import tests.mock_config as mock_config
 
 mock_config.patch_config_module()
 
-from api import _MAX_DB_RETRIES, _execute_with_retry, set_bot  # noqa: E402
+from api import _MAX_DB_RETRIES, _execute_with_retry, db_manager, set_bot  # noqa: E402
 from tests.helpers.db import make_mock_pool  # noqa: E402
 
 pytestmark = pytest.mark.unit
@@ -117,3 +117,48 @@ class TestExecuteWithRetry:
         assert result == 42
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs.get("error") is False
+
+    @pytest.mark.asyncio
+    async def test_execute_action_commits_write_transaction(self):
+        cursor = MagicMock()
+        cursor.rowcount = 3
+        conn = MagicMock()
+        conn.commit = AsyncMock()
+        db_manager._pool = MagicMock()
+
+        async def run_callback(*args, **kwargs):
+            callback = args[1]
+            return await callback(cursor, conn)
+
+        with patch("api._execute_with_retry", new=AsyncMock(side_effect=run_callback)):
+            result = await db_manager.execute_action("UPDATE level SET xp = xp + 1")
+
+        assert result == 3
+        conn.commit.assert_awaited_once()
+        db_manager._pool = None
+
+    @pytest.mark.asyncio
+    async def test_execute_batch_commits_write_transaction(self):
+        cursor = MagicMock()
+        cursor.executemany = AsyncMock()
+        conn = MagicMock()
+        conn.commit = AsyncMock()
+        db_manager._pool = MagicMock()
+
+        async def run_callback(*args, **kwargs):
+            callback = args[1]
+            await callback(cursor, conn)
+            cursor.executemany.assert_awaited_once_with(
+                "INSERT INTO level (user_id, guild_id, xp) VALUES (%s, %s, %s)",
+                [("1", "2", 10)],
+            )
+            return None
+
+        with patch("api._execute_with_retry", new=AsyncMock(side_effect=run_callback)):
+            await db_manager.execute_batch(
+                "INSERT INTO level (user_id, guild_id, xp) VALUES (%s, %s, %s)",
+                [("1", "2", 10)],
+            )
+
+        conn.commit.assert_awaited_once()
+        db_manager._pool = None

--- a/tests/unit/api/test_execute_with_retry.py
+++ b/tests/unit/api/test_execute_with_retry.py
@@ -10,7 +10,7 @@ import tests.mock_config as mock_config
 
 mock_config.patch_config_module()
 
-from api import _MAX_DB_RETRIES, _execute_with_retry, db_manager, set_bot  # noqa: E402
+from api import _MAX_DB_RETRIES, _execute_with_retry, db_manager, execute_query_iter, set_bot  # noqa: E402
 from tests.helpers.db import make_mock_pool  # noqa: E402
 
 pytestmark = pytest.mark.unit
@@ -117,6 +117,54 @@ class TestExecuteWithRetry:
         assert result == 42
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs.get("error") is False
+
+    @pytest.mark.asyncio
+    async def test_retryable_write_error_rolls_back_before_retry(self):
+        pool, conn, cursor = make_mock_pool()
+        pool.release = MagicMock()
+        conn.rollback = AsyncMock()
+        deadlock = Exception("Deadlock found when trying to get lock")
+        cursor.execute = AsyncMock(side_effect=[deadlock, None])
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result, callback = await _run_retry(pool, cursor, is_write=True)
+
+        assert result == "ok"
+        conn.rollback.assert_awaited_once()
+        callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_read_query_rolls_back_after_success(self):
+        pool, conn, cursor = make_mock_pool()
+        pool.release = MagicMock()
+        conn.rollback = AsyncMock()
+        bot = MagicMock(_pool=pool)
+        set_bot(bot)
+        callback = AsyncMock(return_value=[("ok",)])
+
+        result = await _execute_with_retry("test_read", callback, "SELECT 1")
+
+        assert result == [("ok",)]
+        conn.rollback.assert_awaited_once()
+        callback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_query_iter_rolls_back_after_iteration(self):
+        pool, conn, cursor = make_mock_pool()
+        pool.release = MagicMock()
+        conn.rollback = AsyncMock()
+
+        async def async_iter_rows():
+            yield ("row",)
+
+        cursor.__aiter__ = lambda self: async_iter_rows()
+        bot = MagicMock(_pool=pool)
+        set_bot(bot)
+
+        rows = [row async for row in execute_query_iter("SELECT 1")]
+
+        assert rows == [("row",)]
+        conn.rollback.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_execute_action_commits_write_transaction(self):

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -10,6 +10,9 @@ import pytest
 from utils.github import (
     _recent_reports,
     addFeedback,
+    begin_missing_localization_capture,
+    cleanup_captured_missing_localization_issues,
+    end_missing_localization_capture,
     missingLocalization,
     report_bot_exception,
     report_bot_exception_sync,
@@ -183,3 +186,39 @@ class TestSyncHelpers:
 
         mock_repo.create_issue.assert_called_once()
         assert "Alice" in mock_repo.create_issue.call_args[1]["body"]
+
+
+class TestMissingLocalizationCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_captured_missing_localization_issues_closes_created_issues(self):
+        issue = MagicMock()
+        issue.number = 123
+        issue_to_close = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.create_issue.return_value = issue
+        mock_repo.get_issue.return_value = issue_to_close
+        mock_g = MagicMock()
+        mock_g.get_repo.return_value = mock_repo
+        mock_g.search_issues.return_value.totalCount = 0
+
+        with (
+            patch("utils.github.GithubAuthToken", "token"),
+            patch("utils.github.Github", return_value=mock_g),
+            patch("utils.github._missing_localization_resolved", return_value=False),
+        ):
+            begin_missing_localization_capture()
+            from utils.github import _sync_create_missing_localization_issue
+
+            _sync_create_missing_localization_issue("fr-FR", "commands.test.title")
+            end_missing_localization_capture()
+            closed = await cleanup_captured_missing_localization_issues()
+
+        assert closed == 1
+        issue_to_close.edit.assert_called_once_with(state="closed")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_without_capture_does_nothing(self):
+        begin_missing_localization_capture()
+        end_missing_localization_capture()
+        closed = await cleanup_captured_missing_localization_issues()
+        assert closed == 0

--- a/utils/github.py
+++ b/utils/github.py
@@ -18,6 +18,8 @@ _REPO = 'TanjunBot/new_tanjun'
 _EXCEPTION_LABELS = ('bug', 'bot exception')
 _DEDUP_TTL_SEC = 3600.0
 _recent_reports: dict[str, float] = {}
+_capture_missing_localization_issues = False
+_captured_missing_localization_issue_numbers: set[int] = set()
 
 def _is_discord_instance(exc: BaseException, exc_type: Any) -> bool:
     if not isinstance(exc_type, type):
@@ -128,6 +130,25 @@ async def missingLocalization(locale: str, key: str) -> None:
     """Create a GitHub issue reporting a missing localization."""
     await run_blocking(_sync_create_missing_localization_issue, locale, key)
 
+
+def begin_missing_localization_capture() -> None:
+    global _capture_missing_localization_issues
+    _capture_missing_localization_issues = True
+    _captured_missing_localization_issue_numbers.clear()
+
+
+def end_missing_localization_capture() -> None:
+    global _capture_missing_localization_issues
+    _capture_missing_localization_issues = False
+
+
+async def cleanup_captured_missing_localization_issues() -> int:
+    issue_numbers = list(_captured_missing_localization_issue_numbers)
+    _captured_missing_localization_issue_numbers.clear()
+    if not issue_numbers:
+        return 0
+    return await run_blocking(_sync_close_missing_localization_issues, issue_numbers)
+
 def _missing_localization_issue_title(locale: str, key: str) -> str:
     return f'Missing localization: {key} ({locale})'
 
@@ -156,9 +177,29 @@ def _sync_create_missing_localization_issue(locale: str, key: str) -> None:
             return
         repo = g.get_repo(_REPO)
         label = repo.get_label('missing localization')
-        repo.create_issue(title=title, body=f'Missing translation for key `{key}` in locale `{locale}`.', labels=[label])
+        created = repo.create_issue(title=title, body=f'Missing translation for key `{key}` in locale `{locale}`.', labels=[label])
+        if _capture_missing_localization_issues:
+            number = getattr(created, "number", None)
+            if isinstance(number, int):
+                _captured_missing_localization_issue_numbers.add(number)
     except Exception as report_error:
         logger.error('Failed to create missing localization issue: %s', report_error)
+
+
+def _sync_close_missing_localization_issues(issue_numbers: list[int]) -> int:
+    if not GithubAuthToken:
+        return 0
+    closed = 0
+    g = Github(GithubAuthToken)
+    repo = g.get_repo(_REPO)
+    for issue_number in issue_numbers:
+        try:
+            issue = repo.get_issue(issue_number)
+            issue.edit(state="closed")
+            closed += 1
+        except Exception as close_error:
+            logger.error('Failed to close missing localization issue #%s: %s', issue_number, close_error)
+    return closed
 
 async def addFeedback(content: str, author: str) -> None:
     """Create a GitHub issue with user feedback."""


### PR DESCRIPTION
## Summary
- close temporary missing-localization issues created during `test_bot` diagnostics runs to keep issue tracker clean
- ensure database write helpers commit transactions in `DatabaseManager` so read-after-write integration flows are consistent across pooled connections
- add unit regression tests covering transaction commits for `execute_action` and `execute_batch`

## Test plan
- [x] `pytest -q tests/unit/api/test_execute_with_retry.py`
- [ ] Re-run GitHub Actions `integration-db` job for this branch

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database transaction handling with explicit commit/rollback operations for write and read transactions.
  * Improved transaction retry mechanism with rollback handling for transient failures.
  * Refined missing-localization diagnostics capture and cleanup process.

* **Tests**
  * Extended test coverage for transaction management and diagnostic cleanup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->