### PR TITLE
fix(admin): return message from _thread_send so .edit() works

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -586,8 +586,8 @@ class AdministrationCog(commands.Cog):
             type=discord.ChannelType.public_thread,
         )
 
-        async def _thread_send(content: str | None = None, embed: discord.Embed | None = None, file: discord.File | None = None) -> None:
-            await thread.send(content=content, embed=embed, file=file)
+        async def _thread_send(content: str | None = None, embed: discord.Embed | None = None, file: discord.File | None = None) -> discord.Message:
+            return await thread.send(content=content, embed=embed, file=file)
 
         attachment_url = None
         if ctx.message.attachments:


### PR DESCRIPTION
## Summary
- `_thread_send` was declared with return type `None` and didn't return the `Message` from `thread.send()`, so `status_msg = await _thread_send(...)` was `None`
- This caused `AttributeError: 'NoneType' object has no attribute 'edit'` at line 612 when trying to edit the download status message
- Fix: return the message object from `_thread_send` so `.edit()` calls on `status_msg` work correctly
- Audited all other `.send()` + `.edit()` patterns in the file — they all use `ctx.send()` which properly returns `Message`

## Test plan
- [ ] Run `database_sync` and verify the downloading/analyzing status message updates correctly in the thread
- [ ] Verify the error path (download failure) also edits the status message properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)