### PR TITLE
fix(admin): return message from _thread_send so .edit() works

### DIFF
--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -586,8 +586,8 @@ class AdministrationCog(commands.Cog):
             type=discord.ChannelType.public_thread,
         )
 
-        async def _thread_send(content: str | None = None, embed: discord.Embed | None = None, file: discord.File | None = None) -> None:
-            await thread.send(content=content, embed=embed, file=file)
+        async def _thread_send(content: str | None = None, embed: discord.Embed | None = None, file: discord.File | None = None) -> discord.Message:
+            return await thread.send(content=content, embed=embed, file=file)
 
         attachment_url = None
         if ctx.message.attachments:


### PR DESCRIPTION
## Summary
Cherry-pick of #3191 to ver/1.2.

`_thread_send` was not returning the `Message` from `thread.send()`, so `status_msg` was `None` and calling `.edit()` on it caused `AttributeError: 'NoneType' object has no attribute 'edit'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)