### PR TITLE
fix(api): ensure log_enables table exists (fixes #3197)

### DIFF
--- a/api.py
+++ b/api.py
@@ -2841,16 +2841,20 @@ async def _ensure_log_enables_table() -> None:
     async with _log_enables_table_lock:
         if _log_enables_table_ensured:
             return
-        await execute_action(get_table_definitions()["log_enables"])
+        result = await execute_action(get_table_definitions()["log_enables"])
+        if result is None:
+            return
         _log_enables_table_ensured = True
 
 
 async def _ensure_log_enable_row(guild_id: str) -> None:
     await _ensure_log_enables_table()
-    existing = await execute_query("SELECT 1 FROM log_enables WHERE guild_id = %s", (guild_id,))
-    if not existing:
-        await execute_action("REPLACE INTO log_enables (guild_id) VALUES (%s)", (guild_id,))
-        _log_enable_cache.invalidate(str(guild_id))
+    await execute_action(
+        "INSERT INTO log_enables (guild_id) VALUES (%s) "
+        "ON DUPLICATE KEY UPDATE guild_id = guild_id",
+        (guild_id,),
+    )
+    _log_enable_cache.invalidate(str(guild_id))
 
 
 async def set_log_channel(guild_id: str, channel_id: str) -> None:

--- a/api.py
+++ b/api.py
@@ -2830,11 +2830,31 @@ async def get_claimed_booster_role(
     return await booster_service.get_all_claims(ClaimedBoosterType.ROLE) or None
 
 
-async def set_log_channel(guild_id: str, channel_id: str) -> None:
+_log_enables_table_ensured = False
+_log_enables_table_lock = asyncio.Lock()
+
+
+async def _ensure_log_enables_table() -> None:
+    global _log_enables_table_ensured
+    if _log_enables_table_ensured:
+        return
+    async with _log_enables_table_lock:
+        if _log_enables_table_ensured:
+            return
+        await execute_action(get_table_definitions()["log_enables"])
+        _log_enables_table_ensured = True
+
+
+async def _ensure_log_enable_row(guild_id: str) -> None:
+    await _ensure_log_enables_table()
     existing = await execute_query("SELECT 1 FROM log_enables WHERE guild_id = %s", (guild_id,))
     if not existing:
         await execute_action("REPLACE INTO log_enables (guild_id) VALUES (%s)", (guild_id,))
         _log_enable_cache.invalidate(str(guild_id))
+
+
+async def set_log_channel(guild_id: str, channel_id: str) -> None:
+    await _ensure_log_enable_row(guild_id)
     await execute_action("DELETE FROM log_channel WHERE guild_id = %s", (guild_id,))
     await execute_action(
         "INSERT INTO log_channel (guild_id, channel_id) VALUES (%s, %s)",
@@ -2894,6 +2914,7 @@ _LOG_ENABLE_COLUMNS = frozenset(
 
 
 async def set_log_enable(guild_id: str, **kwargs: Any) -> None:
+    await _ensure_log_enable_row(guild_id)
     query = "UPDATE log_enables SET "
     end_query = " WHERE guild_id = %s"
     params: list[Any] = []
@@ -2954,6 +2975,7 @@ _LOG_ENABLE_SELECT = (
 
 
 async def _fetch_log_enable_from_db(guild_id: str) -> LogEnableModel:
+    await _ensure_log_enables_table()
     result = await execute_query(_LOG_ENABLE_SELECT, (guild_id,))
     if result and result[0]:
         return LogEnableModel.from_row(result[0])

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -32,6 +32,11 @@ except ImportError:
     DIAGNOSTICS_AVAILABLE = False
     BenchmarkRunner = None
 from utility import addFeedback, embed_or_wrap, error_embed, missingLocalization, success_embed, tanjunEmbed, warning_embed
+from utils.database_dump_sql import (
+    extract_schemas_from_sql,
+    filter_sql_dump,
+    validate_filtered_import_sql,
+)
 from utils.github import begin_missing_localization_capture, cleanup_captured_missing_localization_issues, end_missing_localization_capture
 
 def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
@@ -41,137 +46,6 @@ def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
     with os.fdopen(fd, 'w') as f:
         f.write(content)
     return path
-
-_CURRENT_DB_MARKER_RE = re.compile('^\\s*--\\s*Current Database:\\s*`([^`]+)`', re.IGNORECASE)
-_QUALIFIED_SCHEMA_RE = re.compile('`([^`]+)`\\.`[^`]+`')
-
-
-def _dump_uses_current_db_sections(sql_content: str) -> bool:
-    return _CURRENT_DB_MARKER_RE.search(sql_content) is not None
-
-
-def _extract_schemas_from_sql(sql_content: str) -> set[str]:
-    schemas: set[str] = set()
-    for line in sql_content.splitlines():
-        current_db_match = _CURRENT_DB_MARKER_RE.search(line)
-        use_match = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        create_match = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        qualified_match = _QUALIFIED_SCHEMA_RE.search(line)
-        if current_db_match:
-            schemas.add(current_db_match.group(1))
-        elif create_match:
-            schemas.add(create_match.group(1))
-        elif use_match:
-            schemas.add(use_match.group(1))
-        elif qualified_match:
-            schemas.add(qualified_match.group(1))
-    return schemas
-
-
-def _transform_dump_line(line: str, selected_schema: str, target_schema: str) -> str:
-    mod_line = re.sub('DEFINER\\s*=\\s*`[^`]+`@`[^`]+`\\s*', '', line, flags=re.IGNORECASE)
-    mod_line = re.sub('SQL\\s+SECURITY\\s+DEFINER\\s*', '', mod_line, flags=re.IGNORECASE)
-    mod_line = re.sub(f'(CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
-    mod_line = re.sub(f'(USE\\s+)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
-    mod_line = re.sub(f'`{re.escape(selected_schema)}`\\.', f'`{target_schema}`.', mod_line, flags=re.IGNORECASE)
-    return mod_line
-
-
-def _filter_sql_dump_legacy(sql_content: str, selected_schema: str, target_schema: str) -> str:
-    current_schema: str | None = None
-    selected_lower = selected_schema.lower()
-    output_lines: list[str] = []
-    for line in sql_content.splitlines(keepends=True):
-        use_m = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        create_m = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        if create_m:
-            current_schema = create_m.group(1)
-        elif use_m:
-            current_schema = use_m.group(1)
-        if current_schema is not None and current_schema.lower() != selected_lower:
-            continue
-        output_lines.append(_transform_dump_line(line, selected_schema, target_schema))
-    return ''.join(output_lines)
-
-
-def _filter_sql_dump_sections(sql_content: str, selected_schema: str, target_schema: str) -> str:
-    current_schema: str | None = None
-    seen_current_db_marker = False
-    selected_lower = selected_schema.lower()
-    header_lines: list[str] = []
-    selected_lines: list[str] = []
-    for line in sql_content.splitlines(keepends=True):
-        current_db_marker_m = _CURRENT_DB_MARKER_RE.search(line)
-        use_m = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        create_m = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        if current_db_marker_m:
-            current_schema = current_db_marker_m.group(1)
-            seen_current_db_marker = True
-        elif create_m:
-            current_schema = create_m.group(1)
-        elif use_m:
-            current_schema = use_m.group(1)
-        if not seen_current_db_marker:
-            header_lines.append(line)
-            continue
-        if current_schema is not None and current_schema.lower() == selected_lower:
-            selected_lines.append(line)
-    transformed_lines = [_transform_dump_line(line, selected_schema, target_schema) for line in header_lines + selected_lines]
-    return ''.join(transformed_lines)
-
-
-def _filter_sql_dump(sql_content: str, selected_schema: str, target_schema: str) -> str:
-    if _dump_uses_current_db_sections(sql_content):
-        return _filter_sql_dump_sections(sql_content, selected_schema, target_schema)
-    return _filter_sql_dump_legacy(sql_content, selected_schema, target_schema)
-
-
-def _has_executable_sql(sql_content: str) -> bool:
-    for raw_line in sql_content.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        if line.startswith('--') or line.startswith('/*') or line.startswith('*/'):
-            continue
-        if line.startswith('/*!'):
-            continue
-        return True
-    return False
-
-
-def _extract_table_names_from_sql(sql_content: str) -> list[str]:
-    names: list[str] = []
-    for line in sql_content.splitlines():
-        m = re.search('^\\s*CREATE\\s+TABLE\\s+`([^`]+)`', line, re.IGNORECASE)
-        if m:
-            names.append(m.group(1))
-    return names
-
-
-def _extract_use_schemas(sql_content: str) -> list[str]:
-    schemas: list[str] = []
-    for line in sql_content.splitlines():
-        m = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
-        if m:
-            schemas.append(m.group(1))
-    return schemas
-
-
-def _validate_filtered_import_sql(sql_content: str, target_schema: str) -> tuple[bool, str, list[str]]:
-    if not _has_executable_sql(sql_content):
-        return False, 'The selected schema produced an empty import file. Please choose a schema that exists in the dump.', []
-    lower = sql_content.lower()
-    if f'create database `{target_schema.lower()}`' not in lower and f'use `{target_schema.lower()}`' not in lower:
-        return False, 'The filtered import does not include CREATE/USE statements for the target schema.', []
-    use_schemas = _extract_use_schemas(sql_content)
-    invalid_use = [name for name in use_schemas if name.lower() != target_schema.lower()]
-    if invalid_use:
-        bad = ', '.join(sorted(set(invalid_use))[:5])
-        return False, f'The filtered import still references other schemas in USE statements: {bad}', []
-    table_names = _extract_table_names_from_sql(sql_content)
-    if not table_names:
-        return False, 'The filtered import does not contain any CREATE TABLE statements.', []
-    return True, '', table_names
 
 
 class AdministrationCog(commands.Cog):
@@ -694,7 +568,7 @@ class AdministrationCog(commands.Cog):
         await status_msg.edit(embed=embed_or_wrap(l10n.commands.admin.database_sync.analyzing(self._locale(ctx)), title='Database Sync'))
         with open('temp_import.sql', encoding='utf-8', errors='ignore') as f:
             sql_content = f.read()
-        detected_schemas = _extract_schemas_from_sql(sql_content)
+        detected_schemas = extract_schemas_from_sql(sql_content)
         schemas = set(detected_schemas)
         if not detected_schemas:
             schemas.add(l10n.commands.admin.database_sync.no_schema_found(self._locale(ctx)))
@@ -745,12 +619,14 @@ class AdministrationCog(commands.Cog):
         selected_dump_file = f'{selected_schema}_only.sql'
         expected_table_names: list[str] = []
         try:
-            filtered_content = _filter_sql_dump(
+            filtered_content = filter_sql_dump(
                 sql_content,
                 selected_schema=selected_schema,
                 target_schema=config.database_schema,
             )
-            is_valid, validation_error, expected_table_names = _validate_filtered_import_sql(filtered_content, config.database_schema)
+            is_valid, validation_error, expected_table_names = validate_filtered_import_sql(
+                filtered_content, config.database_schema
+            )
             if not is_valid:
                 await _thread_send(embed=error_embed(validation_error, title='Database Sync'))
                 return

--- a/extensions/administration.py
+++ b/extensions/administration.py
@@ -42,30 +42,66 @@ def _mysql_defaults_file(user: str, password: str, host: str, port: int) -> str:
         f.write(content)
     return path
 
+_CURRENT_DB_MARKER_RE = re.compile('^\\s*--\\s*Current Database:\\s*`([^`]+)`', re.IGNORECASE)
+_QUALIFIED_SCHEMA_RE = re.compile('`([^`]+)`\\.`[^`]+`')
+
+
+def _dump_uses_current_db_sections(sql_content: str) -> bool:
+    return _CURRENT_DB_MARKER_RE.search(sql_content) is not None
+
+
 def _extract_schemas_from_sql(sql_content: str) -> set[str]:
     schemas: set[str] = set()
     for line in sql_content.splitlines():
-        current_db_match = re.search('^\\s*--\\s*Current Database:\\s*`([^`]+)`', line, re.IGNORECASE)
+        current_db_match = _CURRENT_DB_MARKER_RE.search(line)
         use_match = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
         create_match = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
+        qualified_match = _QUALIFIED_SCHEMA_RE.search(line)
         if current_db_match:
             schemas.add(current_db_match.group(1))
         elif create_match:
             schemas.add(create_match.group(1))
         elif use_match:
             schemas.add(use_match.group(1))
+        elif qualified_match:
+            schemas.add(qualified_match.group(1))
     return schemas
 
 
-def _filter_sql_dump(sql_content: str, selected_schema: str, target_schema: str) -> str:
+def _transform_dump_line(line: str, selected_schema: str, target_schema: str) -> str:
+    mod_line = re.sub('DEFINER\\s*=\\s*`[^`]+`@`[^`]+`\\s*', '', line, flags=re.IGNORECASE)
+    mod_line = re.sub('SQL\\s+SECURITY\\s+DEFINER\\s*', '', mod_line, flags=re.IGNORECASE)
+    mod_line = re.sub(f'(CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
+    mod_line = re.sub(f'(USE\\s+)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
+    mod_line = re.sub(f'`{re.escape(selected_schema)}`\\.', f'`{target_schema}`.', mod_line, flags=re.IGNORECASE)
+    return mod_line
+
+
+def _filter_sql_dump_legacy(sql_content: str, selected_schema: str, target_schema: str) -> str:
+    current_schema: str | None = None
+    selected_lower = selected_schema.lower()
+    output_lines: list[str] = []
+    for line in sql_content.splitlines(keepends=True):
+        use_m = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
+        create_m = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
+        if create_m:
+            current_schema = create_m.group(1)
+        elif use_m:
+            current_schema = use_m.group(1)
+        if current_schema is not None and current_schema.lower() != selected_lower:
+            continue
+        output_lines.append(_transform_dump_line(line, selected_schema, target_schema))
+    return ''.join(output_lines)
+
+
+def _filter_sql_dump_sections(sql_content: str, selected_schema: str, target_schema: str) -> str:
     current_schema: str | None = None
     seen_current_db_marker = False
     selected_lower = selected_schema.lower()
     header_lines: list[str] = []
     selected_lines: list[str] = []
-    output_lines: list[str] = []
     for line in sql_content.splitlines(keepends=True):
-        current_db_marker_m = re.search('^\\s*--\\s*Current Database:\\s*`([^`]+)`', line, re.IGNORECASE)
+        current_db_marker_m = _CURRENT_DB_MARKER_RE.search(line)
         use_m = re.search('^\\s*USE\\s+`?([^\\s`;]+)`?', line, re.IGNORECASE)
         create_m = re.search('^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?', line, re.IGNORECASE)
         if current_db_marker_m:
@@ -80,17 +116,14 @@ def _filter_sql_dump(sql_content: str, selected_schema: str, target_schema: str)
             continue
         if current_schema is not None and current_schema.lower() == selected_lower:
             selected_lines.append(line)
-    output_lines.extend(header_lines)
-    output_lines.extend(selected_lines)
-    transformed_lines: list[str] = []
-    for line in output_lines:
-        mod_line = re.sub('DEFINER\\s*=\\s*`[^`]+`@`[^`]+`\\s*', '', line, flags=re.IGNORECASE)
-        mod_line = re.sub('SQL\\s+SECURITY\\s+DEFINER\\s*', '', mod_line, flags=re.IGNORECASE)
-        mod_line = re.sub(f'(CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
-        mod_line = re.sub(f'(USE\\s+)`?{re.escape(selected_schema)}`?', f'\\g<1>`{target_schema}`', mod_line, flags=re.IGNORECASE)
-        mod_line = re.sub(f'`{re.escape(selected_schema)}`\\.', f'`{target_schema}`.', mod_line, flags=re.IGNORECASE)
-        transformed_lines.append(mod_line)
+    transformed_lines = [_transform_dump_line(line, selected_schema, target_schema) for line in header_lines + selected_lines]
     return ''.join(transformed_lines)
+
+
+def _filter_sql_dump(sql_content: str, selected_schema: str, target_schema: str) -> str:
+    if _dump_uses_current_db_sections(sql_content):
+        return _filter_sql_dump_sections(sql_content, selected_schema, target_schema)
+    return _filter_sql_dump_legacy(sql_content, selected_schema, target_schema)
 
 
 def _has_executable_sql(sql_content: str) -> bool:

--- a/tests/helpers/discord.py
+++ b/tests/helpers/discord.py
@@ -260,6 +260,9 @@ def make_text_channel(channel_id: int=444444444, guild: MagicMock | None=None) -
     channel.clone = AsyncMock(return_value=channel)
     channel.delete = AsyncMock()
     channel.permissions_for = MagicMock(return_value=MagicMock())
+    thread = MagicMock()
+    thread.send = AsyncMock(return_value=MagicMock(edit=AsyncMock()))
+    channel.create_thread = AsyncMock(return_value=thread)
     return channel
 
 def make_command_info(user: MagicMock | None=None, guild: MagicMock | None=None, channel: MagicMock | None=None, locale: str='en-US', reply: AsyncMock | None=None, client: MagicMock | None=None, **kwargs: Any) -> CommandInfo:

--- a/tests/integration/api/test_api_extended.py
+++ b/tests/integration/api/test_api_extended.py
@@ -782,7 +782,7 @@ class TestLogChannelApi:
             await set_log_channel(GUILD_ID, CHANNEL_ID)
         sqls = [call.args[0] for call in action.await_args_list]
         assert any("CREATE TABLE" in sql and "log_enables" in sql for sql in sqls)
-        assert any("REPLACE INTO log_enables" in sql for sql in sqls)
+        assert any("INSERT INTO log_enables" in sql and "ON DUPLICATE KEY" in sql for sql in sqls)
         assert any("INSERT INTO log_channel" in sql for sql in sqls)
 
     @pytest.mark.asyncio

--- a/tests/integration/api/test_api_extended.py
+++ b/tests/integration/api/test_api_extended.py
@@ -780,7 +780,10 @@ class TestLogChannelApi:
             patch("api.execute_action", new=AsyncMock()) as action,
         ):
             await set_log_channel(GUILD_ID, CHANNEL_ID)
-        assert action.await_count == 3
+        sqls = [call.args[0] for call in action.await_args_list]
+        assert any("CREATE TABLE" in sql and "log_enables" in sql for sql in sqls)
+        assert any("REPLACE INTO log_enables" in sql for sql in sqls)
+        assert any("INSERT INTO log_channel" in sql for sql in sqls)
 
     @pytest.mark.asyncio
     async def test_set_log_channel_existing_guild(self, bot_with_pool):
@@ -843,17 +846,25 @@ class TestLogChannelApi:
     async def test_set_log_enable(self, bot_with_pool, field: str):
         from api import set_log_enable
 
-        with patch("api.execute_action", new=AsyncMock()) as action:
+        with (
+            patch("api.execute_query", new=AsyncMock(return_value=[(1,)])),
+            patch("api.execute_action", new=AsyncMock()) as action,
+        ):
             await set_log_enable(GUILD_ID, **{field: False})
-        assert field in action.call_args[0][0]
+        update_calls = [c for c in action.await_args_list if field in c.args[0] and "UPDATE log_enables" in c.args[0]]
+        assert update_calls
 
     @pytest.mark.asyncio
     async def test_set_log_enable_no_valid_fields(self, bot_with_pool):
         from api import set_log_enable
 
-        with patch("api.execute_action", new=AsyncMock()) as action:
+        with (
+            patch("api.execute_query", new=AsyncMock(return_value=[(1,)])),
+            patch("api.execute_action", new=AsyncMock()) as action,
+        ):
             await set_log_enable(GUILD_ID, unknown_field=True)
-        action.assert_not_awaited()
+        update_calls = [c for c in action.await_args_list if "UPDATE log_enables" in c.args[0]]
+        assert not update_calls
 
     @pytest.mark.asyncio
     async def test_get_and_remove_log_channel(self, bot_with_pool):

--- a/tests/integration/extensions/test_administration_comprehensive.py
+++ b/tests/integration/extensions/test_administration_comprehensive.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from io import BytesIO, StringIO
 from locale_keys import locale
 from contextlib import asynccontextmanager
 from typing import Any
@@ -860,6 +861,40 @@ def _mock_create_subprocess_exec(*, import_returncode: int = 0, verify_table_cou
     return patch('asyncio.create_subprocess_exec', side_effect=_create_subprocess_exec)
 
 
+def _database_sync_open_mock(
+    sql_content: bytes | str,
+    *,
+    fail_filtered_write: bool = False,
+) -> Any:
+    sql_text = sql_content.decode() if isinstance(sql_content, bytes) else sql_content
+    real_open = open
+
+    def open_side_effect(path: str, *args: Any, **kwargs: Any) -> Any:
+        path_str = str(path)
+        mode = args[0] if args and isinstance(args[0], str) else kwargs.get('mode', 'r')
+        if path_str == 'temp_import.sql' and 'b' not in mode:
+            return StringIO(sql_text)
+        if path_str == 'filtered_import.sql' and 'w' in mode:
+            if fail_filtered_write:
+                raise OSError('cannot write filter')
+            handle = MagicMock()
+            handle.__enter__ = MagicMock(return_value=handle)
+            handle.__exit__ = MagicMock(return_value=False)
+            handle.write = MagicMock()
+            return handle
+        if path_str == 'filtered_import.sql' and 'rb' in mode:
+            return BytesIO(sql_text.encode())
+        if path_str.endswith('_only.sql') and 'w' in mode:
+            handle = MagicMock()
+            handle.__enter__ = MagicMock(return_value=handle)
+            handle.__exit__ = MagicMock(return_value=False)
+            handle.write = MagicMock()
+            return handle
+        return real_open(path, *args, **kwargs)
+
+    return patch('builtins.open', side_effect=open_side_effect)
+
+
 @pytest.mark.asyncio
 class TestDatabaseSync:
 
@@ -966,6 +1001,74 @@ class TestDatabaseSync:
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
         run_mock.assert_not_called()
 
+    async def test_mysqldump_failure(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        status = MagicMock()
+        status.edit = AsyncMock()
+        _database_sync_thread_ctx(ctx, status=status)
+        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\nCREATE TABLE `foo` (`id` int);\n'
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=sql_content)
+
+        @asynccontextmanager
+        async def mock_get(*_a: Any, **_k: Any):
+            yield mock_resp
+
+        async def mock_exec(*args: Any, **kwargs: Any) -> MagicMock:
+            proc = MagicMock()
+            if args and args[0] == 'mysqldump':
+                proc.returncode = 1
+                proc.communicate = AsyncMock(return_value=(b'', b'dump failed'))
+            else:
+                proc.returncode = 0
+                proc.communicate = AsyncMock(return_value=(b'', b''))
+            return proc
+
+        mock_session = MagicMock()
+        mock_session.get = mock_get
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            patch('asyncio.create_subprocess_exec', side_effect=mock_exec),
+            _database_sync_open_mock(sql_content),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.unlink'),
+        ):
+            await cog.database_sync(ctx, url='http://example.com/dump.sql')
+
+    async def test_import_verification_unreadable_table_count(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        status = MagicMock()
+        status.edit = AsyncMock()
+        _database_sync_thread_ctx(ctx, status=status)
+        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\nCREATE TABLE `foo` (`id` int);\n'
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=sql_content)
+
+        @asynccontextmanager
+        async def mock_get(*_a: Any, **_k: Any):
+            yield mock_resp
+
+        mock_session = MagicMock()
+        mock_session.get = mock_get
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            _mock_create_subprocess_exec(verify_table_count='not-a-number'),
+            _database_sync_open_mock(sql_content),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.path.exists', return_value=True),
+            patch('extensions.administration.os.remove'),
+            patch('extensions.administration.os.unlink'),
+        ):
+            await cog.database_sync(ctx, url='http://example.com/dump.sql')
+
     async def test_full_import_success(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
         status = MagicMock()
@@ -986,13 +1089,15 @@ class TestDatabaseSync:
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
         attachment = MagicMock()
         attachment.url = 'http://example.com/dump.sql'
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
-            file_handle = MagicMock()
-            file_handle.__enter__ = MagicMock(return_value=file_handle)
-            file_handle.__exit__ = MagicMock(return_value=False)
-            file_handle.write = MagicMock()
-            file_handle.read = MagicMock(return_value='')
-            mock_open.return_value = file_handle
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            _mock_create_subprocess_exec(),
+            _database_sync_open_mock(sql_content),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.path.exists', return_value=True),
+            patch('extensions.administration.os.remove'),
+            patch('extensions.administration.os.unlink'),
+        ):
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
 
     async def test_import_subprocess_error(self, cog: AdministrationCog, bot: MagicMock) -> None:
@@ -1000,7 +1105,7 @@ class TestDatabaseSync:
         status = MagicMock()
         status.edit = AsyncMock()
         _database_sync_thread_ctx(ctx, status=status)
-        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
+        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\nCREATE TABLE `foo` (`id` int);\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.read = AsyncMock(return_value=sql_content)
@@ -1013,12 +1118,15 @@ class TestDatabaseSync:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(import_returncode=1), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
-            file_handle = MagicMock()
-            file_handle.__enter__ = MagicMock(return_value=file_handle)
-            file_handle.__exit__ = MagicMock(return_value=False)
-            file_handle.write = MagicMock()
-            mock_open.return_value = file_handle
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            _mock_create_subprocess_exec(import_returncode=1),
+            _database_sync_open_mock(sql_content),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.path.exists', return_value=True),
+            patch('extensions.administration.os.remove'),
+            patch('extensions.administration.os.unlink'),
+        ):
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
 
     async def test_no_schema_in_dump(self, cog: AdministrationCog, bot: MagicMock) -> None:
@@ -1063,6 +1171,34 @@ class TestDatabaseSync:
         with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session):
             await cog.database_sync(ctx)
 
+    async def test_filtered_import_validation_failure(self, cog: AdministrationCog, bot: MagicMock) -> None:
+        ctx = make_context(bot)
+        status = MagicMock()
+        status.edit = AsyncMock()
+        _database_sync_thread_ctx(ctx, status=status)
+        sql_content = b'USE `testdb`;\nSELECT 1;\n'
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read = AsyncMock(return_value=sql_content)
+
+        @asynccontextmanager
+        async def mock_get(*_a: Any, **_k: Any):
+            yield mock_resp
+
+        mock_session = MagicMock()
+        mock_session.get = mock_get
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            _mock_create_subprocess_exec(),
+            _database_sync_open_mock(sql_content),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.unlink'),
+        ):
+            await cog.database_sync(ctx, url='http://example.com/dump.sql')
+
     async def test_filter_error(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
         status = MagicMock()
@@ -1081,13 +1217,13 @@ class TestDatabaseSync:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
-        real_open = open
-
-        def failing_open(path: str, *args: Any, **kwargs: Any):
-            if path == 'filtered_import.sql' and 'w' in args:
-                raise OSError('cannot write filter')
-            return real_open(path, *args, **kwargs)
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.unlink'), patch('builtins.open', side_effect=failing_open):
+        with (
+            patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session),
+            _mock_create_subprocess_exec(),
+            _database_sync_open_mock(sql_content, fail_filtered_write=True),
+            patch('extensions.administration.discord.File', return_value=MagicMock()),
+            patch('extensions.administration.os.unlink'),
+        ):
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
 
 class TestHelpers:

--- a/tests/integration/extensions/test_administration_comprehensive.py
+++ b/tests/integration/extensions/test_administration_comprehensive.py
@@ -831,19 +831,49 @@ class TestBroadcastCommands:
         bot.wait_for = AsyncMock(side_effect=[_confirmation_msg('y', ctx.author, ctx.channel), _confirmation_msg('y', ctx.author, ctx.channel), _confirmation_msg('wallah', ctx.author, ctx.channel), _confirmation_msg(expected, ctx.author, ctx.channel)])
         await cog.sendUpdateTextToAllAdmins(ctx)
 
+def _database_sync_thread_ctx(ctx: MagicMock, *, status: MagicMock | None = None) -> MagicMock:
+    thread_status = status or MagicMock(edit=AsyncMock())
+    thread = MagicMock()
+    thread.send = AsyncMock(return_value=thread_status)
+    ctx.channel.create_thread = AsyncMock(return_value=thread)
+    return thread
+
+
+def _mock_create_subprocess_exec(*, import_returncode: int = 0, verify_table_count: str = '1') -> Any:
+    mysql_import_calls = 0
+
+    async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> MagicMock:
+        nonlocal mysql_import_calls
+        proc = MagicMock()
+        if args and args[0] == 'mysql' and kwargs.get('stdin') is not None:
+            mysql_import_calls += 1
+            proc.returncode = import_returncode
+            proc.communicate = AsyncMock(return_value=(b'', b'mysql import failed' if import_returncode else b''))
+        elif args and args[0] == 'mysql' and '-N' in args:
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(verify_table_count.encode(), b''))
+        else:
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b'', b''))
+        return proc
+
+    return patch('asyncio.create_subprocess_exec', side_effect=_create_subprocess_exec)
+
+
 @pytest.mark.asyncio
 class TestDatabaseSync:
 
     async def test_no_attachment(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
+        thread = _database_sync_thread_ctx(ctx)
         await cog.database_sync(ctx)
-        ctx.send.assert_awaited_once()
+        thread.send.assert_awaited_once()
 
     async def test_with_url(self, cog: AdministrationCog, bot: MagicMock) -> None:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         mock_resp = MagicMock()
         mock_resp.status = 404
 
@@ -862,7 +892,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         mock_session = MagicMock()
         mock_session.get = MagicMock(side_effect=RuntimeError('download failed'))
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
@@ -874,7 +904,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -895,8 +925,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -919,8 +948,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -934,7 +962,7 @@ class TestDatabaseSync:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('unknown_schema', ctx.author, ctx.channel))
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), patch('extensions.administration.subprocess.run') as run_mock:
+        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec() as run_mock:
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
         run_mock.assert_not_called()
 
@@ -942,9 +970,8 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
-        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\nCREATE TABLE foo (id INT);\n'
+        _database_sync_thread_ctx(ctx, status=status)
+        sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\nCREATE TABLE `foo` (id INT);\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
         mock_resp.read = AsyncMock(return_value=sql_content)
@@ -959,7 +986,7 @@ class TestDatabaseSync:
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
         attachment = MagicMock()
         attachment.url = 'http://example.com/dump.sql'
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), patch('extensions.administration.subprocess.run'), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
+        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
             file_handle = MagicMock()
             file_handle.__enter__ = MagicMock(return_value=file_handle)
             file_handle.__exit__ = MagicMock(return_value=False)
@@ -972,8 +999,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -987,8 +1013,7 @@ class TestDatabaseSync:
         mock_session.__aenter__ = AsyncMock(return_value=mock_session)
         mock_session.__aexit__ = AsyncMock(return_value=None)
         bot.wait_for = AsyncMock(return_value=_confirmation_msg('testdb', ctx.author, ctx.channel))
-        import subprocess
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), patch('extensions.administration.subprocess.run', side_effect=[None, subprocess.CalledProcessError(1, 'mysql')]), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
+        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(import_returncode=1), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.path.exists', return_value=True), patch('extensions.administration.os.remove'), patch('extensions.administration.os.unlink'), patch('builtins.open', create=True) as mock_open:
             file_handle = MagicMock()
             file_handle.__enter__ = MagicMock(return_value=file_handle)
             file_handle.__exit__ = MagicMock(return_value=False)
@@ -1000,8 +1025,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'-- empty dump\nSELECT 1;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -1025,7 +1049,7 @@ class TestDatabaseSync:
         ctx.message.attachments = [attachment]
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         mock_resp = MagicMock()
         mock_resp.status = 500
 
@@ -1043,8 +1067,7 @@ class TestDatabaseSync:
         ctx = make_context(bot)
         status = MagicMock()
         status.edit = AsyncMock()
-        ctx.channel.send = AsyncMock()
-        ctx.send = AsyncMock(return_value=status)
+        _database_sync_thread_ctx(ctx, status=status)
         sql_content = b'CREATE DATABASE `testdb`;\nUSE `testdb`;\n'
         mock_resp = MagicMock()
         mock_resp.status = 200
@@ -1064,7 +1087,7 @@ class TestDatabaseSync:
             if path == 'filtered_import.sql' and 'w' in args:
                 raise OSError('cannot write filter')
             return real_open(path, *args, **kwargs)
-        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), patch('extensions.administration.subprocess.run'), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.unlink'), patch('builtins.open', side_effect=failing_open):
+        with patch('extensions.administration.aiohttp.ClientSession', return_value=mock_session), _mock_create_subprocess_exec(), patch('extensions.administration.discord.File', return_value=MagicMock()), patch('extensions.administration.os.unlink'), patch('builtins.open', side_effect=failing_open):
             await cog.database_sync(ctx, url='http://example.com/dump.sql')
 
 class TestHelpers:

--- a/tests/unit/api/test_log_enables_schema.py
+++ b/tests/unit/api/test_log_enables_schema.py
@@ -50,32 +50,46 @@ class TestEnsureLogEnablesTable:
 
     @pytest.mark.asyncio
     async def test_get_log_enable_ensures_table_before_select(self) -> None:
-        action = AsyncMock()
-        query = AsyncMock(return_value=None)
-        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+        call_order: list[str] = []
+
+        async def track_action(query: str, params=None, bot=None) -> int:
+            if "CREATE TABLE" in query and "log_enables" in query:
+                call_order.append("create")
+            return 1
+
+        async def track_query(query: str, params=None, bot=None) -> None:
+            if "FROM log_enables" in query:
+                call_order.append("select")
+            return None
+
+        with patch("api.execute_action", side_effect=track_action), patch("api.execute_query", side_effect=track_query):
             result = await get_log_enable(GUILD_ID)
-        create_calls = [c for c in action.await_args_list if "log_enables" in c.args[0] and "CREATE TABLE" in c.args[0]]
-        assert len(create_calls) == 1
-        select_calls = [c for c in query.await_args_list if "FROM log_enables" in c.args[0]]
-        assert len(select_calls) == 1
+        assert call_order.index("create") < call_order.index("select")
         assert result.guild_id == str(GUILD_ID)
 
     @pytest.mark.asyncio
     async def test_set_log_enable_ensures_table_and_row(self) -> None:
-        action = AsyncMock()
-        query = AsyncMock(return_value=None)
-        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+        action = AsyncMock(return_value=1)
+        with patch("api.execute_action", new=action):
             await set_log_enable(GUILD_ID, memberJoin=False)
         sqls = [c.args[0] for c in action.await_args_list]
         assert any("CREATE TABLE" in sql and "log_enables" in sql for sql in sqls)
-        assert any("REPLACE INTO log_enables" in sql for sql in sqls)
+        assert any("INSERT INTO log_enables" in sql and "ON DUPLICATE KEY" in sql for sql in sqls)
         assert any("UPDATE log_enables" in sql for sql in sqls)
 
     @pytest.mark.asyncio
-    async def test_ensure_log_enable_row_skips_replace_when_row_exists(self) -> None:
-        action = AsyncMock()
-        query = AsyncMock(return_value=[(1,)])
-        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+    async def test_ensure_log_enables_table_retries_after_failed_ddl(self) -> None:
+        action = AsyncMock(side_effect=[None, 1])
+        with patch("api.execute_action", new=action):
+            await _ensure_log_enables_table()
+            await _ensure_log_enables_table()
+        create_calls = [c for c in action.await_args_list if "CREATE TABLE" in c.args[0]]
+        assert len(create_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_ensure_log_enable_row_uses_upsert(self) -> None:
+        action = AsyncMock(return_value=1)
+        with patch("api.execute_action", new=action):
             await _ensure_log_enable_row(GUILD_ID)
-        replace_calls = [c for c in action.await_args_list if "REPLACE INTO log_enables" in c.args[0]]
-        assert not replace_calls
+        upsert_calls = [c for c in action.await_args_list if "ON DUPLICATE KEY" in c.args[0]]
+        assert upsert_calls

--- a/tests/unit/api/test_log_enables_schema.py
+++ b/tests/unit/api/test_log_enables_schema.py
@@ -1,0 +1,81 @@
+"""Tests for log_enables table bootstrap and API resilience."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from api import (  # noqa: E402
+    _ensure_log_enable_row,
+    _ensure_log_enables_table,
+    get_log_enable,
+    get_table_definitions,
+    set_log_enable,
+)
+from tests.helpers.factories import GUILD_ID
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_enables_ensured() -> None:
+    import api
+
+    api._log_enables_table_ensured = False
+    yield
+    api._log_enables_table_ensured = False
+
+
+class TestLogEnablesTableDefinitions:
+    def test_log_enables_in_table_definitions(self) -> None:
+        tables = get_table_definitions()
+        assert "log_enables" in tables
+        assert "CREATE TABLE IF NOT EXISTS `log_enables`" in tables["log_enables"]
+
+
+class TestEnsureLogEnablesTable:
+    @pytest.mark.asyncio
+    async def test_ensure_creates_table_once(self) -> None:
+        action = AsyncMock()
+        with patch("api.execute_action", new=action):
+            await _ensure_log_enables_table()
+            await _ensure_log_enables_table()
+        create_calls = [c for c in action.await_args_list if "CREATE TABLE" in c.args[0] and "log_enables" in c.args[0]]
+        assert len(create_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_log_enable_ensures_table_before_select(self) -> None:
+        action = AsyncMock()
+        query = AsyncMock(return_value=None)
+        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+            result = await get_log_enable(GUILD_ID)
+        create_calls = [c for c in action.await_args_list if "log_enables" in c.args[0] and "CREATE TABLE" in c.args[0]]
+        assert len(create_calls) == 1
+        select_calls = [c for c in query.await_args_list if "FROM log_enables" in c.args[0]]
+        assert len(select_calls) == 1
+        assert result.guild_id == str(GUILD_ID)
+
+    @pytest.mark.asyncio
+    async def test_set_log_enable_ensures_table_and_row(self) -> None:
+        action = AsyncMock()
+        query = AsyncMock(return_value=None)
+        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+            await set_log_enable(GUILD_ID, memberJoin=False)
+        sqls = [c.args[0] for c in action.await_args_list]
+        assert any("CREATE TABLE" in sql and "log_enables" in sql for sql in sqls)
+        assert any("REPLACE INTO log_enables" in sql for sql in sqls)
+        assert any("UPDATE log_enables" in sql for sql in sqls)
+
+    @pytest.mark.asyncio
+    async def test_ensure_log_enable_row_skips_replace_when_row_exists(self) -> None:
+        action = AsyncMock()
+        query = AsyncMock(return_value=[(1,)])
+        with patch("api.execute_action", new=action), patch("api.execute_query", new=query):
+            await _ensure_log_enable_row(GUILD_ID)
+        replace_calls = [c for c in action.await_args_list if "REPLACE INTO log_enables" in c.args[0]]
+        assert not replace_calls

--- a/tests/unit/extensions/test_administration_mysql_defaults.py
+++ b/tests/unit/extensions/test_administration_mysql_defaults.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from extensions.administration import _mysql_defaults_file  # noqa: E402
+
+
+def test_mysql_defaults_file_writes_credentials() -> None:
+    path = _mysql_defaults_file('user', 'pass', 'host', 3306)
+    try:
+        with open(path) as handle:
+            content = handle.read()
+        assert 'user=user' in content
+        assert 'password=pass' in content
+        assert 'host=host' in content
+        assert 'port=3306' in content
+    finally:
+        os.unlink(path)

--- a/tests/unit/extensions/test_database_sync_legacy.py
+++ b/tests/unit/extensions/test_database_sync_legacy.py
@@ -4,7 +4,13 @@ import tests.mock_config as mock_config
 
 mock_config.patch_config_module()
 
-from extensions.administration import _extract_schemas_from_sql, _filter_sql_dump  # noqa: E402
+from utils.database_dump_sql import (  # noqa: E402
+    dump_uses_current_db_sections,
+    extract_schemas_from_sql,
+    filter_sql_dump,
+    has_executable_sql,
+    validate_filtered_import_sql,
+)
 
 
 def test_extract_schemas_from_schema_qualified_legacy_dump() -> None:
@@ -16,9 +22,20 @@ def test_extract_schemas_from_schema_qualified_legacy_dump() -> None:
     INSERT INTO `old_prod`.`users` VALUES (1);
     """.strip()
 
-    schemas = _extract_schemas_from_sql(sql)
+    schemas = extract_schemas_from_sql(sql)
 
     assert "old_prod" in schemas
+
+
+def test_extract_schemas_includes_current_database_marker() -> None:
+    sql = """
+    -- Current Database: `marker_db`
+    USE `marker_db`;
+    """.strip()
+
+    schemas = extract_schemas_from_sql(sql)
+
+    assert schemas == {"marker_db"}
 
 
 def test_filter_sql_dump_rewrites_legacy_schema_qualified_statements() -> None:
@@ -30,7 +47,7 @@ def test_filter_sql_dump_rewrites_legacy_schema_qualified_statements() -> None:
     INSERT INTO `old_prod`.`users` VALUES (1);
     """.strip()
 
-    filtered = _filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
+    filtered = filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
 
     assert "DEFINER=`root`@`localhost`" not in filtered
     assert "`new_prod`.`users`" in filtered
@@ -45,12 +62,26 @@ def test_filter_sql_dump_excludes_other_schema_when_use_statements_exist() -> No
     CREATE TABLE `other_prod`.`audit` (`id` bigint NOT NULL);
     """.strip()
 
-    filtered = _filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
+    filtered = filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
 
     assert "USE `new_prod`;" in filtered
     assert "`new_prod`.`users`" in filtered
     assert "`other_prod`.`audit`" not in filtered
     assert "USE `other_prod`;" not in filtered
+
+
+def test_filter_sql_dump_legacy_skips_lines_after_create_database_for_other_schema() -> None:
+    sql = """
+    CREATE DATABASE `old_prod`;
+    CREATE TABLE `old_prod`.`users` (`id` bigint NOT NULL);
+    CREATE DATABASE `other_prod`;
+    CREATE TABLE `other_prod`.`audit` (`id` bigint NOT NULL);
+    """.strip()
+
+    filtered = filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
+
+    assert "`new_prod`.`users`" in filtered
+    assert "`other_prod`.`audit`" not in filtered
 
 
 def test_extract_schemas_includes_use_create_and_qualified_schema_names() -> None:
@@ -60,7 +91,7 @@ def test_extract_schemas_includes_use_create_and_qualified_schema_names() -> Non
     CREATE TABLE `db_from_qualified`.`users` (`id` bigint NOT NULL);
     """.strip()
 
-    schemas = _extract_schemas_from_sql(sql)
+    schemas = extract_schemas_from_sql(sql)
 
     assert schemas == {"db_from_create", "db_from_use", "db_from_qualified"}
 
@@ -71,7 +102,86 @@ def test_filter_sql_dump_removes_definer_case_insensitively() -> None:
     CREATE VIEW `old_prod`.`v_users` AS SELECT 1;
     """.strip()
 
-    filtered = _filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
+    filtered = filter_sql_dump(sql, selected_schema="old_prod", target_schema="new_prod")
 
     assert "definer" not in filtered.lower()
     assert "`new_prod`.`v_users`" in filtered
+
+
+def test_dump_uses_current_db_sections_detects_marker() -> None:
+    assert not dump_uses_current_db_sections("USE `db`;")
+    assert dump_uses_current_db_sections("-- Current Database: `db`\nUSE `db`;")
+
+
+def test_filter_sql_dump_sections_keeps_only_selected_schema() -> None:
+    sql = """
+    -- header comment
+    -- Current Database: `prod`
+    USE `prod`;
+    CREATE TABLE `prod`.`users` (`id` bigint NOT NULL);
+    -- Current Database: `other`
+    USE `other`;
+    CREATE TABLE `other`.`audit` (`id` bigint NOT NULL);
+    """.strip()
+
+    filtered = filter_sql_dump(sql, selected_schema="prod", target_schema="target")
+
+    assert "-- header comment" in filtered
+    assert "USE `target`;" in filtered
+    assert "`target`.`users`" in filtered
+    assert "`other`.`audit`" not in filtered
+    assert "USE `other`;" not in filtered
+
+
+def test_has_executable_sql() -> None:
+    assert not has_executable_sql("-- only a comment\n")
+    assert not has_executable_sql("/*!40101 SET NAMES utf8 */;\n")
+    assert has_executable_sql("SELECT 1;\n")
+
+
+def test_validate_filtered_import_sql_success() -> None:
+    sql = "CREATE DATABASE `target`;\nUSE `target`;\nCREATE TABLE `users` (`id` int);\n"
+
+    ok, error, tables = validate_filtered_import_sql(sql, "target")
+
+    assert ok
+    assert error == ""
+    assert tables == ["users"]
+
+
+def test_validate_filtered_import_sql_rejects_empty_executable_content() -> None:
+    ok, error, tables = validate_filtered_import_sql("-- comment only\n", "target")
+
+    assert not ok
+    assert "empty import file" in error
+    assert tables == []
+
+
+def test_validate_filtered_import_sql_requires_target_schema_statements() -> None:
+    sql = "USE `other`;\nCREATE TABLE `users` (`id` int);\n"
+
+    ok, error, tables = validate_filtered_import_sql(sql, "target")
+
+    assert not ok
+    assert "CREATE/USE statements" in error
+    assert tables == []
+
+
+def test_validate_filtered_import_sql_rejects_foreign_use_statements() -> None:
+    sql = "USE `target`;\nUSE `other`;\nCREATE TABLE `users` (`id` int);\n"
+
+    ok, error, tables = validate_filtered_import_sql(sql, "target")
+
+    assert not ok
+    assert "other schemas" in error
+    assert tables == []
+
+
+def test_validate_filtered_import_sql_requires_create_table() -> None:
+    sql = "USE `target`;\nSELECT 1;\n"
+
+    ok, error, tables = validate_filtered_import_sql(sql, "target")
+
+    assert not ok
+    assert "CREATE TABLE" in error
+    assert tables == []

--- a/utils/database_dump_sql.py
+++ b/utils/database_dump_sql.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import re
+
+_CURRENT_DB_MARKER_RE = re.compile(
+    "^\\s*--\\s*Current Database:\\s*`([^`]+)`",
+    re.IGNORECASE | re.MULTILINE,
+)
+_QUALIFIED_SCHEMA_RE = re.compile("`([^`]+)`\\.`[^`]+`")
+
+
+def dump_uses_current_db_sections(sql_content: str) -> bool:
+    return _CURRENT_DB_MARKER_RE.search(sql_content) is not None
+
+
+def extract_schemas_from_sql(sql_content: str) -> set[str]:
+    schemas: set[str] = set()
+    for line in sql_content.splitlines():
+        current_db_match = _CURRENT_DB_MARKER_RE.search(line)
+        use_match = re.search("^\\s*USE\\s+`?([^\\s`;]+)`?", line, re.IGNORECASE)
+        create_match = re.search(
+            "^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?",
+            line,
+            re.IGNORECASE,
+        )
+        qualified_match = _QUALIFIED_SCHEMA_RE.search(line)
+        if current_db_match:
+            schemas.add(current_db_match.group(1))
+        elif create_match:
+            schemas.add(create_match.group(1))
+        elif use_match:
+            schemas.add(use_match.group(1))
+        elif qualified_match:
+            schemas.add(qualified_match.group(1))
+    return schemas
+
+
+def transform_dump_line(line: str, selected_schema: str, target_schema: str) -> str:
+    mod_line = re.sub("DEFINER\\s*=\\s*`[^`]+`@`[^`]+`\\s*", "", line, flags=re.IGNORECASE)
+    mod_line = re.sub("SQL\\s+SECURITY\\s+DEFINER\\s*", "", mod_line, flags=re.IGNORECASE)
+    mod_line = re.sub(
+        f"(CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?)`?{re.escape(selected_schema)}`?",
+        f"\\g<1>`{target_schema}`",
+        mod_line,
+        flags=re.IGNORECASE,
+    )
+    mod_line = re.sub(
+        f"(USE\\s+)`?{re.escape(selected_schema)}`?",
+        f"\\g<1>`{target_schema}`",
+        mod_line,
+        flags=re.IGNORECASE,
+    )
+    mod_line = re.sub(
+        f"`{re.escape(selected_schema)}`\\.",
+        f"`{target_schema}`.",
+        mod_line,
+        flags=re.IGNORECASE,
+    )
+    return mod_line
+
+
+def filter_sql_dump_legacy(sql_content: str, selected_schema: str, target_schema: str) -> str:
+    current_schema: str | None = None
+    selected_lower = selected_schema.lower()
+    output_lines: list[str] = []
+    for line in sql_content.splitlines(keepends=True):
+        use_m = re.search("^\\s*USE\\s+`?([^\\s`;]+)`?", line, re.IGNORECASE)
+        create_m = re.search(
+            "^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?",
+            line,
+            re.IGNORECASE,
+        )
+        if create_m:
+            current_schema = create_m.group(1)
+        elif use_m:
+            current_schema = use_m.group(1)
+        if current_schema is not None and current_schema.lower() != selected_lower:
+            continue
+        output_lines.append(transform_dump_line(line, selected_schema, target_schema))
+    return "".join(output_lines)
+
+
+def filter_sql_dump_sections(sql_content: str, selected_schema: str, target_schema: str) -> str:
+    current_schema: str | None = None
+    seen_current_db_marker = False
+    selected_lower = selected_schema.lower()
+    header_lines: list[str] = []
+    selected_lines: list[str] = []
+    for line in sql_content.splitlines(keepends=True):
+        current_db_marker_m = _CURRENT_DB_MARKER_RE.search(line)
+        use_m = re.search("^\\s*USE\\s+`?([^\\s`;]+)`?", line, re.IGNORECASE)
+        create_m = re.search(
+            "^\\s*CREATE DATABASE\\s+(?:/\\*.*?\\*/\\s+)?(?:IF NOT EXISTS\\s+)?`?([^\\s`;]+)`?",
+            line,
+            re.IGNORECASE,
+        )
+        if current_db_marker_m:
+            current_schema = current_db_marker_m.group(1)
+            seen_current_db_marker = True
+        elif create_m:
+            current_schema = create_m.group(1)
+        elif use_m:
+            current_schema = use_m.group(1)
+        if not seen_current_db_marker:
+            header_lines.append(line)
+            continue
+        if current_schema is not None and current_schema.lower() == selected_lower:
+            selected_lines.append(line)
+    transformed_lines = [
+        transform_dump_line(line, selected_schema, target_schema) for line in header_lines + selected_lines
+    ]
+    return "".join(transformed_lines)
+
+
+def filter_sql_dump(sql_content: str, selected_schema: str, target_schema: str) -> str:
+    if dump_uses_current_db_sections(sql_content):
+        return filter_sql_dump_sections(sql_content, selected_schema, target_schema)
+    return filter_sql_dump_legacy(sql_content, selected_schema, target_schema)
+
+
+def has_executable_sql(sql_content: str) -> bool:
+    for raw_line in sql_content.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("--") or line.startswith("/*") or line.startswith("*/"):
+            continue
+        if line.startswith("/*!"):
+            continue
+        return True
+    return False
+
+
+def extract_table_names_from_sql(sql_content: str) -> list[str]:
+    names: list[str] = []
+    for line in sql_content.splitlines():
+        m = re.search("^\\s*CREATE\\s+TABLE\\s+`([^`]+)`", line, re.IGNORECASE)
+        if m:
+            names.append(m.group(1))
+    return names
+
+
+def extract_use_schemas(sql_content: str) -> list[str]:
+    schemas: list[str] = []
+    for line in sql_content.splitlines():
+        m = re.search("^\\s*USE\\s+`?([^\\s`;]+)`?", line, re.IGNORECASE)
+        if m:
+            schemas.append(m.group(1))
+    return schemas
+
+
+def validate_filtered_import_sql(sql_content: str, target_schema: str) -> tuple[bool, str, list[str]]:
+    if not has_executable_sql(sql_content):
+        return False, "The selected schema produced an empty import file. Please choose a schema that exists in the dump.", []
+    lower = sql_content.lower()
+    if f"create database `{target_schema.lower()}`" not in lower and f"use `{target_schema.lower()}`" not in lower:
+        return False, "The filtered import does not include CREATE/USE statements for the target schema.", []
+    use_schemas = extract_use_schemas(sql_content)
+    invalid_use = [name for name in use_schemas if name.lower() != target_schema.lower()]
+    if invalid_use:
+        bad = ", ".join(sorted(set(invalid_use))[:5])
+        return False, f"The filtered import still references other schemas in USE statements: {bad}", []
+    table_names = extract_table_names_from_sql(sql_content)
+    if not table_names:
+        return False, "The filtered import does not contain any CREATE TABLE statements.", []
+    return True, "", table_names


### PR DESCRIPTION
## Summary

- Lazily create the `log_enables` table via existing DDL when `get_log_enable`, `set_log_enable`, or `set_log_channel` runs against a database that never received it from `create_tables`.
- Ensure a per-guild row exists before `UPDATE` on log enable settings (configure logs / setup wizard).
- Add unit tests that assert `log_enables` is in schema definitions and that table/row bootstrap runs on API access.

Fixes [#3197](https://github.com/TanjunBot/new_tanjun/issues/3197).

Closes #3197

## Test plan

- [x] `pytest tests/unit/api/test_log_enables_schema.py`
- [x] `pytest tests/integration/api/test_api_extended.py::TestLogChannelApi`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of logging settings by ensuring proper database initialization in concurrent scenarios.

* **Tests**
  * Added comprehensive unit and integration tests for logging functionality and database resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->