### PR TITLE
fix: mediaChannel schema ensure

### DIFF
--- a/api.py
+++ b/api.py
@@ -1514,47 +1514,9 @@ async def create_tables(bot=None) -> None:
         for table_name in sorted(batch):
             await execute_action(tables[table_name], bot=bot)
 
-    # Run schema migrations for existing tables that need column additions
-    migrations = [
-        # Add attachments column to scheduledMessages for attachment support
-        """ALTER TABLE `scheduledMessages`
-         ADD COLUMN `attachments` TEXT DEFAULT NULL
-         AFTER `repeatAmount`""",
-        # Add discord_message_id column to scheduledMessages for exact-match deletion
-        """ALTER TABLE `scheduledMessages`
-         ADD COLUMN `discord_message_id` VARCHAR(20) DEFAULT NULL
-         AFTER `attachments`,
-         ADD INDEX `idx_discord_message` (`discord_message_id`)""",
-        """ALTER TABLE `reports`
-         ADD COLUMN `status` VARCHAR(20) DEFAULT 'PENDING'
-         AFTER `created_at`,
-         ADD COLUMN `status_updated_at` TIMESTAMP DEFAULT NULL
-         AFTER `status`,
-         ADD COLUMN `status_updated_by` VARCHAR(20) DEFAULT NULL
-         AFTER `status_updated_at`,
-         ADD INDEX `idx_status` (`status`)""",
-        """ALTER TABLE `level`
-         ADD INDEX `idx_level_guild_xp` (`guild_id`, `xp` DESC)""",
-        """ALTER TABLE `warnings`
-         ADD INDEX `idx_warnings_user_guild` (`user_id`, `guild_id`)""",
-        """ALTER TABLE `giveaway`
-         ADD INDEX `idx_giveaway_ended_endtime` (`ended`, `endtime`)""",
-    ]
-    for migration in migrations:
-        try:
-            await execute_action(migration, bot=bot)
-        except Exception as exc:
-            exc_str = str(exc).lower()
-            if (
-                "column already exists" in exc_str
-                or "duplicate column" in exc_str
-                or "duplicate column name" in exc_str
-                or "duplicate key name" in exc_str
-            ):
-                logging.debug("Migration skipped (already applied): %s", migration[:60])
-            else:
-                logging.exception("Unexpected migration error: %s", migration[:60])
-                raise
+    from utils.schema_ensure import run_startup_migrations
+
+    await run_startup_migrations(bot=bot)
 
 
 # ── Warning functions (delegated to WarningRepository) ───────────────────────────

--- a/api.py
+++ b/api.py
@@ -3292,6 +3292,9 @@ async def remove_join_to_create_channel(guild_id: str) -> None:
 
 
 async def get_media_channel(channel_id: str) -> bool:
+    from utils.schema_ensure import ensure_table_schema
+
+    await ensure_table_schema("mediaChannel")
     query = "SELECT 1 FROM mediaChannel WHERE channel_id = %s"
     params = (channel_id,)
     result = await execute_query(query, params)
@@ -3299,12 +3302,18 @@ async def get_media_channel(channel_id: str) -> bool:
 
 
 async def add_media_channel(guild_id: str, channel_id: str) -> None:
+    from utils.schema_ensure import ensure_table_schema
+
+    await ensure_table_schema("mediaChannel")
     query = "INSERT INTO mediaChannel (guild_id, channel_id) VALUES (%s, %s)"
     params = (guild_id, channel_id)
     await execute_action(query, params)
 
 
 async def remove_media_channel(guild_id: str, channel_id: str) -> None:
+    from utils.schema_ensure import ensure_table_schema
+
+    await ensure_table_schema("mediaChannel")
     query = "DELETE FROM mediaChannel WHERE guild_id = %s AND channel_id = %s"
     params = (guild_id, channel_id)
     await execute_action(query, params)

--- a/tests/unit/api/test_create_tables_migrations.py
+++ b/tests/unit/api/test_create_tables_migrations.py
@@ -15,6 +15,71 @@ from utils import schema_ensure  # noqa: E402
 pytestmark = pytest.mark.unit
 
 
+class TestSchemaEnsureHelpers:
+    def test_extract_table_name_from_alter(self) -> None:
+        assert schema_ensure.extract_table_name_from_alter("ALTER TABLE `foo` ADD COLUMN `x` INT") == "foo"
+        assert schema_ensure.extract_table_name_from_alter("SELECT 1") is None
+
+    def test_is_benign_migration_error(self) -> None:
+        assert schema_ensure.is_benign_migration_error(Exception("Duplicate column name 'x'"))
+        assert not schema_ensure.is_benign_migration_error(Exception("syntax error"))
+
+
+class TestEnsureTableSchema:
+    @pytest.mark.asyncio
+    async def test_ensure_table_schema_from_table_def(self) -> None:
+        from api import get_table_defs
+
+        table_def = get_table_defs()["mediaChannel"]
+        with (
+            patch.object(schema_ensure, "ensure_columns_from_table_def", new=AsyncMock()) as ensure_cols,
+            patch("api.get_table_defs", return_value={"mediaChannel": table_def}),
+        ):
+            await schema_ensure.ensure_table_schema("mediaChannel")
+        ensure_cols.assert_awaited_once_with(table_def, None)
+
+    @pytest.mark.asyncio
+    async def test_ensure_table_schema_from_ddl_when_not_in_defs(self) -> None:
+        ddl = "CREATE TABLE IF NOT EXISTS `legacy` (`id` INT)"
+        with (
+            patch("api.get_table_defs", return_value={}),
+            patch("api.get_table_definitions", return_value={"legacy": ddl}),
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=False)),
+            patch.object(schema_ensure, "ensure_table_from_ddl", new=AsyncMock()) as ensure_ddl,
+        ):
+            await schema_ensure.ensure_table_schema("legacy")
+        ensure_ddl.assert_awaited_once_with(ddl, None)
+
+
+class TestEnsureColumnsFromTableDef:
+    @pytest.mark.asyncio
+    async def test_adds_missing_columns(self) -> None:
+        from api import get_table_defs
+
+        table_def = get_table_defs()["mediaChannel"]
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=True)),
+            patch.object(schema_ensure, "column_exists", new=AsyncMock(return_value=False)),
+            patch("api.execute_action", new=AsyncMock(return_value=True)) as action,
+        ):
+            await schema_ensure.ensure_columns_from_table_def(table_def)
+        assert action.await_count == len(table_def.columns)
+
+    @pytest.mark.asyncio
+    async def test_creates_table_when_absent(self) -> None:
+        from api import get_table_defs
+
+        table_def = get_table_defs()["mediaChannel"]
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=False)),
+            patch.object(schema_ensure, "ensure_table_from_ddl", new=AsyncMock()) as ensure_ddl,
+            patch("api.execute_action", new=AsyncMock()) as action,
+        ):
+            await schema_ensure.ensure_columns_from_table_def(table_def)
+        ensure_ddl.assert_awaited_once()
+        action.assert_not_awaited()
+
+
 class TestRunAlterMigration:
     @pytest.mark.asyncio
     async def test_skips_when_table_missing_and_not_in_definitions(self) -> None:
@@ -61,6 +126,30 @@ class TestRunAlterMigration:
                 table_name="scheduledMessages",
             )
         assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_raises(self) -> None:
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=True)),
+            patch("api.execute_action", new=AsyncMock(side_effect=Exception("syntax error"))),
+            pytest.raises(Exception, match="syntax error"),
+        ):
+            await schema_ensure.run_alter_migration(
+                "ALTER TABLE `level` ADD INDEX `idx` (`guild_id`)",
+                table_name="level",
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_execute_action_returns_none(self) -> None:
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=True)),
+            patch("api.execute_action", new=AsyncMock(return_value=None)),
+        ):
+            ok = await schema_ensure.run_alter_migration(
+                "ALTER TABLE `level` ADD INDEX `idx` (`guild_id`)",
+                table_name="level",
+            )
+        assert ok is False
 
 
 class TestMigrateReportsStatusColumns:
@@ -111,6 +200,18 @@ class TestMigrateReportsStatusColumns:
         ):
             await schema_ensure.migrate_reports_status_columns()
         action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reports_still_missing_after_create_logs_and_returns(self) -> None:
+        ddl = "CREATE TABLE IF NOT EXISTS `reports` (`id` INT)"
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=False)),
+            patch("api.get_table_definitions", return_value={"reports": ddl}),
+            patch.object(schema_ensure, "ensure_table_from_ddl", new=AsyncMock()),
+            patch.object(schema_ensure, "run_alter_migration", new=AsyncMock()) as migrate,
+        ):
+            await schema_ensure.migrate_reports_status_columns()
+        migrate.assert_not_awaited()
 
 
 class TestRunStartupMigrations:

--- a/tests/unit/api/test_create_tables_migrations.py
+++ b/tests/unit/api/test_create_tables_migrations.py
@@ -1,0 +1,143 @@
+"""Tests for safe startup schema migrations (schema_ensure)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from utils import schema_ensure  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+class TestRunAlterMigration:
+    @pytest.mark.asyncio
+    async def test_skips_when_table_missing_and_not_in_definitions(self) -> None:
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=False)),
+            patch("api.get_table_definitions", return_value={}),
+            patch("api.execute_action", new=AsyncMock()) as action,
+        ):
+            ok = await schema_ensure.run_alter_migration(
+                "ALTER TABLE `missing_table` ADD COLUMN `x` INT",
+                table_name="missing_table",
+            )
+        assert ok is False
+        action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_creates_table_from_definitions_when_missing(self) -> None:
+        ddl = "CREATE TABLE IF NOT EXISTS `scheduledMessages` (`id` INT)"
+        exists = AsyncMock(side_effect=[False, True])
+        with (
+            patch.object(schema_ensure, "table_exists", new=exists),
+            patch("api.get_table_definitions", return_value={"scheduledMessages": ddl}),
+            patch("api.execute_action", new=AsyncMock(return_value=True)) as action,
+        ):
+            ok = await schema_ensure.run_alter_migration(
+                "ALTER TABLE `scheduledMessages` ADD COLUMN `attachments` TEXT",
+                table_name="scheduledMessages",
+            )
+        assert ok is True
+        create_calls = [c for c in action.await_args_list if "CREATE TABLE" in c.args[0]]
+        assert len(create_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_duplicate_column_is_benign(self) -> None:
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=True)),
+            patch(
+                "api.execute_action",
+                new=AsyncMock(side_effect=Exception("Duplicate column name 'attachments'")),
+            ),
+        ):
+            ok = await schema_ensure.run_alter_migration(
+                "ALTER TABLE `scheduledMessages` ADD COLUMN `attachments` TEXT",
+                table_name="scheduledMessages",
+            )
+        assert ok is True
+
+
+class TestMigrateReportsStatusColumns:
+    @pytest.mark.asyncio
+    async def test_adds_created_at_before_status_columns(self) -> None:
+        column_checks: dict[str, bool] = {
+            "created_at": False,
+            "status": False,
+            "status_updated_at": False,
+            "status_updated_by": False,
+        }
+
+        async def col_exists(_table: str, column: str, bot=None) -> bool:
+            return column_checks.get(column, True)
+
+        executed: list[str] = []
+
+        async def track_action(sql: str, *args, **kwargs) -> bool:
+            executed.append(sql)
+            if "ADD COLUMN `created_at`" in sql:
+                column_checks["created_at"] = True
+            if "ADD COLUMN `status`" in sql and "status_updated" not in sql:
+                column_checks["status"] = True
+            if "status_updated_at" in sql:
+                column_checks["status_updated_at"] = True
+            if "status_updated_by" in sql:
+                column_checks["status_updated_by"] = True
+            return True
+
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=True)),
+            patch.object(schema_ensure, "column_exists", side_effect=col_exists),
+            patch("api.execute_action", side_effect=track_action),
+        ):
+            await schema_ensure.migrate_reports_status_columns()
+
+        assert any("created_at" in sql for sql in executed)
+        created_at_idx = next(i for i, sql in enumerate(executed) if "created_at" in sql)
+        status_idx = next(i for i, sql in enumerate(executed) if "ADD COLUMN `status`" in sql)
+        assert created_at_idx < status_idx
+
+    @pytest.mark.asyncio
+    async def test_skips_when_reports_table_absent(self) -> None:
+        with (
+            patch.object(schema_ensure, "table_exists", new=AsyncMock(return_value=False)),
+            patch("api.get_table_definitions", return_value={}),
+            patch("api.execute_action", new=AsyncMock()) as action,
+        ):
+            await schema_ensure.migrate_reports_status_columns()
+        action.assert_not_awaited()
+
+
+class TestRunStartupMigrations:
+    @pytest.mark.asyncio
+    async def test_does_not_raise_on_missing_table(self) -> None:
+        with patch.object(schema_ensure, "run_alter_migration", new=AsyncMock(return_value=False)):
+            await schema_ensure.run_startup_migrations()
+
+    @pytest.mark.asyncio
+    async def test_create_tables_invokes_startup_migrations(self) -> None:
+        import api
+
+        pool = AsyncMock()
+        conn = AsyncMock()
+        cursor = AsyncMock()
+        cursor.fetchall = AsyncMock(return_value=[("level",), ("warnings",)])
+        cursor_cm = AsyncMock()
+        cursor_cm.__aenter__ = AsyncMock(return_value=cursor)
+        cursor_cm.__aexit__ = AsyncMock(return_value=None)
+        conn.cursor = MagicMock(return_value=cursor_cm)
+        pool.acquire = AsyncMock(return_value=conn)
+
+        with (
+            patch("api._get_pool", return_value=pool),
+            patch("api.execute_action", new=AsyncMock(return_value=True)),
+            patch("utils.schema_ensure.run_startup_migrations", new=AsyncMock()) as migrations,
+        ):
+            await api.create_tables()
+
+        migrations.assert_awaited_once()

--- a/tests/unit/api/test_media_channel_schema.py
+++ b/tests/unit/api/test_media_channel_schema.py
@@ -1,0 +1,38 @@
+"""Tests for mediaChannel schema repair on API access."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from api import add_media_channel, get_media_channel  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_get_media_channel_ensures_schema_before_query() -> None:
+    ensure = AsyncMock()
+    with (
+        patch("utils.schema_ensure.ensure_table_schema", new=ensure),
+        patch("api.execute_query", new=AsyncMock(return_value=[])),
+    ):
+        result = await get_media_channel("123")
+    ensure.assert_awaited_once_with("mediaChannel")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_add_media_channel_ensures_schema_before_insert() -> None:
+    ensure = AsyncMock()
+    with (
+        patch("utils.schema_ensure.ensure_table_schema", new=ensure),
+        patch("api.execute_action", new=AsyncMock(return_value=True)),
+    ):
+        await add_media_channel("1", "2")
+    ensure.assert_awaited_once_with("mediaChannel")

--- a/utils/schema_ensure.py
+++ b/utils/schema_ensure.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from table_def_models.table_def import ColumnDef, TableDef
+
+_ALTER_TABLE_RE = re.compile(r"ALTER\s+TABLE\s+`([^`]+)`", re.IGNORECASE)
+_BENIGN_MIGRATION_FRAGMENTS = (
+    "column already exists",
+    "duplicate column",
+    "duplicate column name",
+    "duplicate key name",
+    "doesn't exist",
+    "does not exist",
+)
+
+
+def extract_table_name_from_alter(sql: str) -> str | None:
+    match = _ALTER_TABLE_RE.search(sql)
+    return match.group(1) if match else None
+
+
+def is_benign_migration_error(exc: BaseException) -> bool:
+    exc_str = str(exc).lower()
+    return any(fragment in exc_str for fragment in _BENIGN_MIGRATION_FRAGMENTS)
+
+
+async def table_exists(table_name: str, bot: Any = None) -> bool:
+    from api import execute_query
+
+    rows = await execute_query(
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_schema = DATABASE() AND table_name = %s LIMIT 1",
+        (table_name,),
+        bot,
+    )
+    return bool(rows)
+
+
+async def column_exists(table_name: str, column_name: str, bot: Any = None) -> bool:
+    from api import execute_query
+
+    rows = await execute_query(
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_schema = DATABASE() AND table_name = %s AND column_name = %s LIMIT 1",
+        (table_name, column_name),
+        bot,
+    )
+    return bool(rows)
+
+
+async def ensure_table_from_ddl(ddl: str, bot: Any = None) -> None:
+    from api import execute_action
+
+    result = await execute_action(ddl, bot=bot)
+    if result is None:
+        logging.warning("ensure_table_from_ddl: execute_action returned None")
+
+
+def _column_add_sql(table_name: str, column: ColumnDef) -> str:
+    parts = [f"ALTER TABLE `{table_name}` ADD COLUMN `{column.name}` {column.sql_type}"]
+    if column.default is not None:
+        parts.append(f"DEFAULT {column.default}")
+    elif not column.nullable and not column.primary_key:
+        parts.append("NOT NULL")
+    return " ".join(parts)
+
+
+async def ensure_columns_from_table_def(table_def: TableDef, bot: Any = None) -> None:
+    from api import execute_action
+
+    if not await table_exists(table_def.name, bot):
+        await ensure_table_from_ddl(table_def.to_sql(), bot)
+        return
+
+    for column in table_def.columns:
+        if await column_exists(table_def.name, column.name, bot):
+            continue
+        try:
+            await execute_action(_column_add_sql(table_def.name, column), bot=bot)
+        except Exception as exc:
+            if not is_benign_migration_error(exc):
+                raise
+
+
+async def ensure_table_schema(table_name: str, bot: Any = None) -> None:
+    from api import get_table_defs, get_table_definitions
+
+    defs = get_table_defs()
+    if table_name in defs:
+        await ensure_columns_from_table_def(defs[table_name], bot)
+        return
+
+    ddl_map = get_table_definitions()
+    if table_name in ddl_map:
+        if not await table_exists(table_name, bot):
+            await ensure_table_from_ddl(ddl_map[table_name], bot)
+
+
+async def run_alter_migration(sql: str, *, table_name: str | None = None, bot: Any = None) -> bool:
+    from api import execute_action
+
+    resolved_table = table_name or extract_table_name_from_alter(sql)
+    if resolved_table and not await table_exists(resolved_table, bot):
+        from api import get_table_definitions
+
+        ddl_map = get_table_definitions()
+        if resolved_table in ddl_map:
+            await ensure_table_from_ddl(ddl_map[resolved_table], bot)
+        if not await table_exists(resolved_table, bot):
+            logging.warning("Skipping migration for missing table %s", resolved_table)
+            return False
+
+    try:
+        result = await execute_action(sql, bot=bot)
+        if result is None:
+            logging.warning("Migration returned None (pool unavailable): %s", sql[:80])
+            return False
+        return True
+    except Exception as exc:
+        if is_benign_migration_error(exc):
+            logging.debug("Migration skipped (already applied or benign): %s", sql[:80])
+            return True
+        logging.exception("Unexpected migration error: %s", sql[:80])
+        return False
+
+
+async def migrate_reports_status_columns(bot: Any = None) -> None:
+    if not await table_exists("reports", bot):
+        from api import get_table_definitions
+
+        ddl_map = get_table_definitions()
+        if "reports" not in ddl_map:
+            logging.warning("reports table missing and no DDL available")
+            return
+        await ensure_table_from_ddl(ddl_map["reports"], bot)
+        if not await table_exists("reports", bot):
+            logging.warning("reports table still missing after CREATE")
+            return
+
+    if not await column_exists("reports", "created_at", bot):
+        await run_alter_migration(
+            "ALTER TABLE `reports` ADD COLUMN `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
+            table_name="reports",
+            bot=bot,
+        )
+
+    status_migrations = [
+        (
+            "status",
+            "ALTER TABLE `reports` ADD COLUMN `status` VARCHAR(20) DEFAULT 'PENDING' AFTER `created_at`",
+        ),
+        (
+            "status_updated_at",
+            "ALTER TABLE `reports` ADD COLUMN `status_updated_at` TIMESTAMP DEFAULT NULL AFTER `status`",
+        ),
+        (
+            "status_updated_by",
+            "ALTER TABLE `reports` ADD COLUMN `status_updated_by` VARCHAR(20) DEFAULT NULL "
+            "AFTER `status_updated_at`",
+        ),
+        (
+            "idx_status",
+            "ALTER TABLE `reports` ADD INDEX `idx_status` (`status`)",
+        ),
+    ]
+    for column_name, sql in status_migrations:
+        if column_name.startswith("idx_"):
+            await run_alter_migration(sql, table_name="reports", bot=bot)
+        elif not await column_exists("reports", column_name, bot):
+            await run_alter_migration(sql, table_name="reports", bot=bot)
+
+
+async def run_startup_migrations(bot: Any = None) -> None:
+    await run_alter_migration(
+        """ALTER TABLE `scheduledMessages`
+         ADD COLUMN `attachments` TEXT DEFAULT NULL
+         AFTER `repeatAmount`""",
+        table_name="scheduledMessages",
+        bot=bot,
+    )
+    await run_alter_migration(
+        """ALTER TABLE `scheduledMessages`
+         ADD COLUMN `discord_message_id` VARCHAR(20) DEFAULT NULL
+         AFTER `attachments`,
+         ADD INDEX `idx_discord_message` (`discord_message_id`)""",
+        table_name="scheduledMessages",
+        bot=bot,
+    )
+    await migrate_reports_status_columns(bot)
+    await run_alter_migration(
+        """ALTER TABLE `level`
+         ADD INDEX `idx_level_guild_xp` (`guild_id`, `xp` DESC)""",
+        table_name="level",
+        bot=bot,
+    )
+    await run_alter_migration(
+        """ALTER TABLE `warnings`
+         ADD INDEX `idx_warnings_user_guild` (`user_id`, `guild_id`)""",
+        table_name="warnings",
+        bot=bot,
+    )
+    await run_alter_migration(
+        """ALTER TABLE `giveaway`
+         ADD INDEX `idx_giveaway_ended_endtime` (`ended`, `endtime`)""",
+        table_name="giveaway",
+        bot=bot,
+    )

--- a/utils/schema_ensure.py
+++ b/utils/schema_ensure.py
@@ -124,7 +124,7 @@ async def run_alter_migration(sql: str, *, table_name: str | None = None, bot: A
             logging.debug("Migration skipped (already applied or benign): %s", sql[:80])
             return True
         logging.exception("Unexpected migration error: %s", sql[:80])
-        return False
+        raise
 
 
 async def migrate_reports_status_columns(bot: Any = None) -> None:


### PR DESCRIPTION
## Summary
- Call `ensure_table_schema("mediaChannel")` in get/add/remove media channel API paths

## Test plan
- [x] `pytest tests/unit/api/test_media_channel_schema.py`

Closes #3179

Stacks on #3199.

Made with [Cursor](https://cursor.com)