### PR TITLE
fix: keep container healthy during Alembic migrations on deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ USER appuser
 ENV PYTHONPATH=/usr/local/app
 ENV TANJUN_APP_ROOT=/usr/local/app
 
-# Health check for container orchestration (Discord ready can take 2+ minutes on cold start)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=180s --retries=5 \
+# Health check: .bot_startup during migrations/boot, .bot_ready when Discord is up
+HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=10 \
   CMD ["python", "/usr/local/app/healthcheck.py"]
 
 EXPOSE 8001

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,7 +1,8 @@
 """Docker health check for Tanjun bot.
 
-Runs in a separate process from main.py. Checks the on_ready marker file and,
-as a fallback, the Prometheus /health endpoint once the metrics server is up.
+Runs in a separate process from main.py. Checks the on_ready marker file,
+startup marker while migrations or Discord connect are in progress, and as a
+fallback the Prometheus /health endpoint once the metrics server is up.
 """
 
 import os
@@ -11,11 +12,16 @@ import urllib.request
 from pathlib import Path
 
 READY_FILE = Path(os.environ.get("BOT_READY_FILE", "/usr/local/app/.bot_ready"))
+STARTUP_FILE = Path(os.environ.get("BOT_STARTUP_FILE", "/usr/local/app/.bot_startup"))
 METRICS_PORT = int(os.environ.get("METRICS_PORT", "8001"))
 
 
 def check_ready_file() -> bool:
     return READY_FILE.is_file()
+
+
+def check_startup_in_progress() -> bool:
+    return STARTUP_FILE.is_file()
 
 
 def check_metrics_health() -> bool:
@@ -28,7 +34,7 @@ def check_metrics_health() -> bool:
 
 
 def check_health() -> bool:
-    return check_ready_file() or check_metrics_health()
+    return check_ready_file() or check_startup_in_progress() or check_metrics_health()
 
 
 def main() -> None:

--- a/main.py
+++ b/main.py
@@ -147,8 +147,13 @@ def _bot_ready_path() -> Path:
     return Path(os.environ.get("BOT_READY_FILE", "/usr/local/app/.bot_ready"))
 
 
+def _startup_marker_path() -> Path:
+    return Path(os.environ.get("BOT_STARTUP_FILE", "/usr/local/app/.bot_startup"))
+
+
 @bot.event
 async def on_ready() -> None:
+    _startup_marker_path().unlink(missing_ok=True)
     ready_path = _bot_ready_path()
     ready_path.parent.mkdir(parents=True, exist_ok=True)
     ready_path.touch()

--- a/main.py
+++ b/main.py
@@ -151,9 +151,13 @@ def _startup_marker_path() -> Path:
     return Path(os.environ.get("BOT_STARTUP_FILE", "/usr/local/app/.bot_startup"))
 
 
+def _clear_startup_marker() -> None:
+    _startup_marker_path().unlink(missing_ok=True)
+
+
 @bot.event
 async def on_ready() -> None:
-    _startup_marker_path().unlink(missing_ok=True)
+    _clear_startup_marker()
     ready_path = _bot_ready_path()
     ready_path.parent.mkdir(parents=True, exist_ok=True)
     ready_path.touch()

--- a/scripts/docker_entrypoint.py
+++ b/scripts/docker_entrypoint.py
@@ -7,12 +7,23 @@ import logging
 import os
 import sys
 import time
+from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
 _DB_WAIT_ATTEMPTS = int(os.environ.get("TANJUN_DB_WAIT_ATTEMPTS", "60"))
 _DB_WAIT_DELAY_SEC = float(os.environ.get("TANJUN_DB_WAIT_DELAY_SEC", "2"))
+
+
+def _startup_marker_path() -> Path:
+    return Path(os.environ.get("BOT_STARTUP_FILE", "/usr/local/app/.bot_startup"))
+
+
+def _mark_startup_in_progress() -> None:
+    path = _startup_marker_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
 
 
 def _wait_for_database() -> None:
@@ -45,6 +56,7 @@ def _wait_for_database() -> None:
 
 def main() -> None:
     os.chdir(os.environ.get("TANJUN_APP_ROOT", "/usr/local/app"))
+    _mark_startup_in_progress()
 
     logger.info("Checking database connectivity")
     _wait_for_database()

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -164,6 +164,7 @@ class TestOnReady:
         bot = MagicMock()
         bot.user = MagicMock(id=123)
         bot.change_presence = AsyncMock()
+        monkeypatch.setattr(main_mod, "bot", bot)
 
         await main_mod.on_ready()
 

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -157,21 +157,18 @@ class TestOnReady:
     @pytest.mark.asyncio
     async def test_on_ready_writes_ready_file_and_presence(self, monkeypatch, tmp_path):
         ready_path = tmp_path / ".bot_ready"
+        startup_path = tmp_path / ".bot_startup"
         monkeypatch.setenv("BOT_READY_FILE", str(ready_path))
+        monkeypatch.setenv("BOT_STARTUP_FILE", str(startup_path))
+        startup_path.touch()
         bot = MagicMock()
         bot.user = MagicMock(id=123)
         bot.change_presence = AsyncMock()
 
-        ready_path.parent.mkdir(parents=True, exist_ok=True)
-        ready_path.touch()
-        if bot.user is not None:
-            await bot.change_presence(
-                activity=main_mod.discord.Game(
-                    name=main_mod.config.activity.format(version=main_mod.config.version)
-                )
-            )
+        await main_mod.on_ready()
 
         assert ready_path.is_file()
+        assert not startup_path.exists()
         bot.change_presence.assert_awaited_once()
 
 

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -154,22 +154,31 @@ class TestOnReady:
         monkeypatch.setenv("BOT_READY_FILE", str(ready_path))
         assert main_mod._bot_ready_path() == ready_path
 
+    def test_clear_startup_marker_removes_file(self, monkeypatch, tmp_path):
+        startup_path = tmp_path / ".bot_startup"
+        monkeypatch.setenv("BOT_STARTUP_FILE", str(startup_path))
+        startup_path.touch()
+        main_mod._clear_startup_marker()
+        assert not startup_path.exists()
+
     @pytest.mark.asyncio
     async def test_on_ready_writes_ready_file_and_presence(self, monkeypatch, tmp_path):
         ready_path = tmp_path / ".bot_ready"
-        startup_path = tmp_path / ".bot_startup"
         monkeypatch.setenv("BOT_READY_FILE", str(ready_path))
-        monkeypatch.setenv("BOT_STARTUP_FILE", str(startup_path))
-        startup_path.touch()
         bot = MagicMock()
         bot.user = MagicMock(id=123)
         bot.change_presence = AsyncMock()
-        monkeypatch.setattr(main_mod, "bot", bot)
 
-        await main_mod.on_ready()
+        ready_path.parent.mkdir(parents=True, exist_ok=True)
+        ready_path.touch()
+        if bot.user is not None:
+            await bot.change_presence(
+                activity=main_mod.discord.Game(
+                    name=main_mod.config.activity.format(version=main_mod.config.version)
+                )
+            )
 
         assert ready_path.is_file()
-        assert not startup_path.exists()
         bot.change_presence.assert_awaited_once()
 
 

--- a/tests/unit/health/test_healthcheck_script.py
+++ b/tests/unit/health/test_healthcheck_script.py
@@ -16,13 +16,17 @@ import healthcheck as hc
 def ready_file(monkeypatch):
     tmp = Path(tempfile.mkdtemp()) / "bot_ready"
     monkeypatch.setattr(hc, "READY_FILE", tmp)
+    monkeypatch.setattr(hc, "STARTUP_FILE", tmp.parent / "bot_startup")
     if tmp.exists():
         tmp.unlink()
+    startup = tmp.parent / "bot_startup"
+    startup.unlink(missing_ok=True)
     yield tmp
     if tmp.is_dir():
         tmp.rmdir()
     else:
         tmp.unlink(missing_ok=True)
+    startup.unlink(missing_ok=True)
 
 
 class TestCheckHealth:
@@ -36,6 +40,10 @@ class TestCheckHealth:
     def test_succeeds_when_metrics_health_ok(self, ready_file, monkeypatch):
         with patch.object(hc, "check_metrics_health", return_value=True):
             assert hc.check_health() is True
+
+    def test_succeeds_when_startup_marker_exists(self, ready_file):
+        hc.STARTUP_FILE.touch()
+        assert hc.check_health() is True
 
     def test_directory_named_bot_ready_is_not_ready(self, ready_file, monkeypatch):
         ready_file.mkdir()

--- a/tests/unit/scripts/test_docker_entrypoint.py
+++ b/tests/unit/scripts/test_docker_entrypoint.py
@@ -68,10 +68,19 @@ def test_main_runs_wait_migrate_and_exec(entrypoint) -> None:
         patch("utils.db_migration.ensure_database_schema") as ensure,
         patch.object(entrypoint.os, "chdir"),
         patch.object(entrypoint.os, "execvp") as execvp,
+        patch.object(entrypoint, "_mark_startup_in_progress") as mark_startup,
     ):
         entrypoint.main()
 
+    mark_startup.assert_called_once()
     wait_db.assert_called_once()
     ensure.assert_called_once()
     execvp.assert_called_once()
     assert execvp.call_args[0][1][1] == "main.py"
+
+
+def test_mark_startup_in_progress_creates_marker(entrypoint, tmp_path, monkeypatch) -> None:
+    marker = tmp_path / "startup"
+    monkeypatch.setenv("BOT_STARTUP_FILE", str(marker))
+    entrypoint._mark_startup_in_progress()
+    assert marker.is_file()


### PR DESCRIPTION
## Summary

- Deployment on `ver/1.2` built successfully but Coolify rolled back because the Docker healthcheck failed while the entrypoint was still running Alembic migrations (logs stopped at `002_legacy_schema_patches` with 50 drift items).
- The healthcheck only accepted `.bot_ready` or the metrics `/health` endpoint, neither of which exist until migrations finish and Discord connects.
- The entrypoint now touches `.bot_startup` at boot; `healthcheck.py` treats that marker as healthy until `on_ready` removes it and writes `.bot_ready`. Dockerfile start-period/retries are increased as a safety margin.

## Test plan

- [ ] Deploy to Coolify and confirm the container stays up through migration `002`+ (indexes on large tables can take several minutes).
- [ ] Confirm healthcheck passes with only `.bot_startup` present (before Discord ready).
- [ ] Confirm `.bot_startup` is removed and `.bot_ready` appears after the bot connects.
- [ ] `pytest tests/unit/health/test_healthcheck_script.py tests/unit/scripts/test_docker_entrypoint.py tests/unit/core/test_main.py::TestOnReady`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced container startup handling with extended health check grace period (300 seconds from 180 seconds) and increased retry attempts to accommodate startup and migration processes
  * Added startup state detection allowing health checks to properly distinguish between initialization and ready states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->