### PR TITLE
fix: legacy giveaway migration with AUTO_INCREMENT primary key

### DIFF
--- a/migrations/versions/003_giveaway_legacy_column.py
+++ b/migrations/versions/003_giveaway_legacy_column.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 from alembic import op
 from sqlalchemy import text
+from sqlalchemy.engine import Connection
 
 revision: str = "003_giveaway_legacy_column"
 down_revision: str | None = "002_legacy_schema_patches"
@@ -18,6 +19,7 @@ _BENIGN = (
     "already exists",
     "can't drop",
     "doesn't exist",
+    "does not exist",
 )
 
 
@@ -31,31 +33,119 @@ def _execute_idempotent(sql: str) -> None:
         raise
 
 
-def upgrade() -> None:
-    conn = op.get_bind()
-    result = conn.execute(
-        text(
-            "SELECT COUNT(*) FROM information_schema.columns "
-            "WHERE table_schema = DATABASE() AND table_name = 'giveaway' AND column_name = 'giveaway_id'"
-        )
-    )
-    row = result.fetchone()
-    if row and row[0]:
-        return
-
-    exists = conn.execute(
+def _table_exists(conn: Connection, table: str) -> bool:
+    row = conn.execute(
         text(
             "SELECT COUNT(*) FROM information_schema.tables "
-            "WHERE table_schema = DATABASE() AND table_name = 'giveaway'"
-        )
+            "WHERE table_schema = DATABASE() AND table_name = :table"
+        ),
+        {"table": table},
     ).fetchone()
-    if not exists or not exists[0]:
+    return bool(row and row[0])
+
+
+def _has_column(conn: Connection, table: str, column: str) -> bool:
+    row = conn.execute(
+        text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def _auto_increment_columns(conn: Connection, table: str) -> list[str]:
+    rows = conn.execute(
+        text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table "
+            "AND extra LIKE '%auto_increment%'"
+        ),
+        {"table": table},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _primary_key_columns(conn: Connection, table: str) -> list[str]:
+    rows = conn.execute(
+        text(
+            "SELECT column_name FROM information_schema.statistics "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND index_name = 'PRIMARY' "
+            "ORDER BY seq_in_index"
+        ),
+        {"table": table},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _strip_auto_increment(conn: Connection, table: str, column: str) -> None:
+    row = conn.execute(
+        text(
+            "SELECT column_type, is_nullable FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    if not row:
+        return
+    nullable = "NULL" if row[1] == "YES" else "NOT NULL"
+    _execute_idempotent(f"ALTER TABLE `{table}` MODIFY COLUMN `{column}` {row[0]} {nullable}")
+
+
+def _assign_remaining_giveaway_ids(conn: Connection) -> None:
+    row = conn.execute(text("SELECT COALESCE(MAX(`giveaway_id`), 0) FROM `giveaway`")).fetchone()
+    start = int(row[0]) if row else 0
+    conn.execute(text(f"SET @giveaway_row := {start}"))
+    conn.execute(
+        text(
+            "UPDATE `giveaway` SET `giveaway_id` = (@giveaway_row := @giveaway_row + 1) "
+            "WHERE `giveaway_id` IS NULL ORDER BY `guild_id`, `endtime`"
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if _has_column(conn, "giveaway", "giveaway_id"):
+        return
+    if not _table_exists(conn, "giveaway"):
         return
 
-    _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+    ai_cols = _auto_increment_columns(conn, "giveaway")
+    pk_cols = _primary_key_columns(conn, "giveaway")
+
+    if not ai_cols:
+        if pk_cols:
+            _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+        _execute_idempotent(
+            "ALTER TABLE `giveaway` ADD COLUMN `giveaway_id` INT UNSIGNED NOT NULL "
+            "AUTO_INCREMENT PRIMARY KEY FIRST"
+        )
+        return
+
+    _execute_idempotent("ALTER TABLE `giveaway` ADD COLUMN `giveaway_id` INT UNSIGNED NULL FIRST")
+
+    source = ai_cols[0]
+    if source != "giveaway_id":
+        conn.execute(text(f"UPDATE `giveaway` SET `giveaway_id` = `{source}` WHERE `giveaway_id` IS NULL"))
+
+    _assign_remaining_giveaway_ids(conn)
+
+    for column in ai_cols:
+        if column != "giveaway_id":
+            _strip_auto_increment(conn, "giveaway", column)
+
+    if pk_cols:
+        _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+
     _execute_idempotent(
-        "ALTER TABLE `giveaway` ADD COLUMN `giveaway_id` INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST"
+        "ALTER TABLE `giveaway` MODIFY COLUMN `giveaway_id` INT UNSIGNED NOT NULL "
+        "AUTO_INCREMENT PRIMARY KEY"
     )
+
+    if source == "id" and _has_column(conn, "giveaway", "id"):
+        _execute_idempotent("ALTER TABLE `giveaway` DROP COLUMN `id`")
 
 
 def downgrade() -> None:

--- a/tests/fixtures/schema_legacy/giveaway_with_id_auto_pk.sql
+++ b/tests/fixtures/schema_legacy/giveaway_with_id_auto_pk.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `giveaway` (
+    `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `guild_id` VARCHAR(20) NOT NULL,
+    `title` VARCHAR(128) NOT NULL,
+    `endtime` DATETIME NOT NULL,
+    `ended` TINYINT(1) DEFAULT 0,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB;

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -116,15 +116,17 @@ async def test_legacy_giveaway_with_id_auto_pk_upgrades_to_current(integration_d
 
     _rerun_migrations_from("001_initial_schema")
 
-    async with pool.acquire() as conn, conn.cursor() as cursor:
-        await cursor.execute(
-            "SELECT column_name, extra FROM information_schema.columns "
-            "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
-            "AND column_name IN ('giveaway_id', 'id')"
-        )
-        rows = {row[0]: row[1] for row in await cursor.fetchall()}
-        await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` ORDER BY `giveaway_id`")
-        data = await cursor.fetchall()
+    async with pool.acquire() as conn:
+        await conn.ping(reconnect=True)
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "SELECT column_name, extra FROM information_schema.columns "
+                "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
+                "AND column_name IN ('giveaway_id', 'id')"
+            )
+            rows = {row[0]: row[1] for row in await cursor.fetchall()}
+            await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` ORDER BY `giveaway_id`")
+            data = await cursor.fetchall()
 
     assert "giveaway_id" in rows
     assert "auto_increment" in rows["giveaway_id"].lower()

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -114,19 +114,19 @@ async def test_legacy_giveaway_with_id_auto_pk_upgrades_to_current(integration_d
         )
         await conn.commit()
 
+    await pool.clear()
     _rerun_migrations_from("001_initial_schema")
+    await pool.clear()
 
-    async with pool.acquire() as conn:
-        await conn.ping(reconnect=True)
-        async with conn.cursor() as cursor:
-            await cursor.execute(
-                "SELECT column_name, extra FROM information_schema.columns "
-                "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
-                "AND column_name IN ('giveaway_id', 'id')"
-            )
-            rows = {row[0]: row[1] for row in await cursor.fetchall()}
-            await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` ORDER BY `giveaway_id`")
-            data = await cursor.fetchall()
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT column_name, extra FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
+            "AND column_name IN ('giveaway_id', 'id')"
+        )
+        rows = {row[0]: row[1] for row in await cursor.fetchall()}
+        await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` ORDER BY `giveaway_id`")
+        data = await cursor.fetchall()
 
     assert "giveaway_id" in rows
     assert "auto_increment" in rows["giveaway_id"].lower()

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -131,7 +131,7 @@ async def test_legacy_giveaway_with_id_auto_pk_upgrades_to_current(integration_d
     assert "giveaway_id" in rows
     assert "auto_increment" in rows["giveaway_id"].lower()
     assert "id" not in rows
-    assert data == [(1, "111"), (2, "222")]
+    assert list(data) == [(1, "111"), (2, "222")]
 
 
 async def test_legacy_reports_gets_status_columns(integration_db_pool) -> None:

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -100,6 +100,38 @@ async def test_legacy_giveaway_schema_upgrades_to_current(integration_db_pool) -
     assert row and row[0] == 1
 
 
+async def test_legacy_giveaway_with_id_auto_pk_upgrades_to_current(integration_db_pool) -> None:
+    pool = integration_db_pool
+    legacy_sql = (_LEGACY_DIR / "giveaway_with_id_auto_pk.sql").read_text(encoding="utf-8")
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute("DROP TABLE IF EXISTS `giveaway`")
+        await cursor.execute(legacy_sql)
+        await cursor.execute(
+            "INSERT INTO `giveaway` (`guild_id`, `title`, `endtime`) VALUES "
+            "('111', 'legacy', '2030-01-01 00:00:00'), "
+            "('222', 'legacy2', '2031-01-01 00:00:00')"
+        )
+        await conn.commit()
+
+    _rerun_migrations_from("001_initial_schema")
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT column_name, extra FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
+            "AND column_name IN ('giveaway_id', 'id')"
+        )
+        rows = {row[0]: row[1] for row in await cursor.fetchall()}
+        await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` ORDER BY `giveaway_id`")
+        data = await cursor.fetchall()
+
+    assert "giveaway_id" in rows
+    assert "auto_increment" in rows["giveaway_id"].lower()
+    assert "id" not in rows
+    assert data == [(1, "111"), (2, "222")]
+
+
 async def test_legacy_reports_gets_status_columns(integration_db_pool) -> None:
     from utils.schema_conformance import fetch_existing_columns
 


### PR DESCRIPTION
## Summary

- Fixes production crash in migration `003_giveaway_legacy_column` when `giveaway` still has a legacy `id` (or other) AUTO_INCREMENT primary key.
- MariaDB error 1075 occurs if `DROP PRIMARY KEY` runs before AUTO_INCREMENT is removed from the old column.
- Migration now copies existing IDs into `giveaway_id`, strips AUTO_INCREMENT from the legacy column, then promotes `giveaway_id` as the PK.

## Test plan

- [x] Integration test for `giveaway_with_id_auto_pk` legacy fixture
- [ ] Merge to `development` and `ver/1.2`, redeploy Coolify


Made with [Cursor](https://cursor.com)