### PR TITLE
fix: legacy guildId column for migration 004

### DIFF
--- a/migrations/versions/004_schema_fk_and_guild_keys.py
+++ b/migrations/versions/004_schema_fk_and_guild_keys.py
@@ -47,6 +47,17 @@ def _primary_key_columns(conn: Connection, table: str) -> list[str]:
     return [row[0] for row in rows]
 
 
+def _has_column(conn: Connection, table: str, column: str) -> bool:
+    row = conn.execute(
+        text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    return bool(row and row[0])
+
+
 def _has_unique_guild_id(conn: Connection, table: str) -> bool:
     row = conn.execute(
         text(
@@ -82,6 +93,40 @@ def _dedupe_guild_config_table(table: str) -> None:
 
     _execute_idempotent(f"ALTER TABLE `{table}` DROP PRIMARY KEY")
     _execute_idempotent(f"ALTER TABLE `{table}` ADD PRIMARY KEY (`guild_id`)")
+
+
+def _normalize_guild_id_column(conn: Connection, table: str) -> None:
+    if _has_column(conn, table, "guild_id"):
+        return
+    if _has_column(conn, table, "guildId"):
+        _execute_idempotent(
+            f"ALTER TABLE `{table}` CHANGE COLUMN `guildId` `guild_id` VARCHAR(20) DEFAULT NULL"
+        )
+
+
+def _ensure_guild_id_column(
+    conn: Connection, table: str, child_table: str | None, child_fk_column: str | None
+) -> None:
+    _normalize_guild_id_column(conn, table)
+    if not _has_column(conn, table, "guild_id"):
+        _execute_idempotent(f"ALTER TABLE `{table}` ADD COLUMN `guild_id` VARCHAR(20) DEFAULT NULL")
+
+    if child_table and child_fk_column:
+        _normalize_guild_id_column(conn, child_table)
+        conn.execute(
+            text(
+                f"UPDATE `{table}` parent "
+                f"INNER JOIN ("
+                f"  SELECT `{child_fk_column}` AS parent_id, MIN(`guild_id`) AS guild_id "
+                f"  FROM `{child_table}` WHERE `guild_id` IS NOT NULL "
+                f"  GROUP BY `{child_fk_column}`"
+                f") child ON parent.`id` = child.parent_id "
+                f"SET parent.`guild_id` = child.guild_id "
+                f"WHERE parent.`guild_id` IS NULL"
+            )
+        )
+
+    conn.execute(text(f"DELETE FROM `{table}` WHERE `guild_id` IS NULL"))
 
 
 def _drop_foreign_keys_to(conn: Connection, child_table: str, parent_table: str) -> None:
@@ -122,6 +167,9 @@ def _repair_guild_scoped_parent(table: str, child_table: str, fk_columns: tuple[
     ).fetchone()
     if child_exists and child_exists[0]:
         _drop_foreign_keys_to(conn, child_table, table)
+
+    child_fk_column = fk_columns[1] if child_exists and child_exists[0] else None
+    _ensure_guild_id_column(conn, table, child_table if child_exists and child_exists[0] else None, child_fk_column)
 
     _execute_idempotent(f"ALTER TABLE `{table}` MODIFY COLUMN `guild_id` VARCHAR(20) NOT NULL")
     if pk_cols == ["guild_id", "id"]:

--- a/tests/fixtures/schema_legacy/trigger_messages_guild_id.sql
+++ b/tests/fixtures/schema_legacy/trigger_messages_guild_id.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `triggerMessages` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `guildId` varchar(20) DEFAULT NULL,
+  `trigger` varchar(128) DEFAULT NULL,
+  `response` varchar(1024) DEFAULT NULL,
+  `caseSensitive` tinyint(1) DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `idx_guild` (`guildId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `triggerMessagesChannel` (
+  `guild_id` varchar(20) NOT NULL,
+  `channel_id` varchar(20) NOT NULL,
+  `triggerId` int(11) NOT NULL,
+  PRIMARY KEY (`guild_id`, `channel_id`, `triggerId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -134,6 +134,55 @@ async def test_legacy_giveaway_with_id_auto_pk_upgrades_to_current(integration_d
     assert list(data) == [(1, "111"), (2, "222")]
 
 
+async def test_legacy_trigger_messages_guild_id_column_upgrades(integration_db_pool) -> None:
+    pool = integration_db_pool
+    legacy_sql = (_LEGACY_DIR / "trigger_messages_guild_id.sql").read_text(encoding="utf-8")
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute("DROP TABLE IF EXISTS `triggerMessagesChannel`")
+        await cursor.execute("DROP TABLE IF EXISTS `triggerMessages`")
+        for statement in legacy_sql.split(";"):
+            stmt = statement.strip()
+            if stmt:
+                await cursor.execute(stmt)
+        await cursor.execute(
+            "INSERT INTO `triggerMessages` (`guildId`, `trigger`, `response`) VALUES ('999', 'hi', 'bye')"
+        )
+        await cursor.execute(
+            "INSERT INTO `triggerMessagesChannel` (`guild_id`, `channel_id`, `triggerId`) "
+            "VALUES ('999', '111', 1)"
+        )
+        await conn.commit()
+
+    _rerun_migrations_from("003_giveaway_legacy_column")
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = 'triggerMessages' "
+            "AND column_name IN ('guild_id', 'guildId')"
+        )
+        cols = {row[0] for row in await cursor.fetchall()}
+        await cursor.execute(
+            "SELECT is_nullable FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = 'triggerMessages' AND column_name = 'guild_id'"
+        )
+        nullable = await cursor.fetchone()
+        await cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.statistics "
+            "WHERE table_schema = DATABASE() AND table_name = 'triggerMessages' "
+            "AND index_name = 'uk_guild_id' AND non_unique = 0"
+        )
+        uk = await cursor.fetchone()
+        await cursor.execute("SELECT `guild_id` FROM `triggerMessages` WHERE `id` = 1")
+        row = await cursor.fetchone()
+
+    assert cols == {"guild_id"}
+    assert nullable and nullable[0] == "NO"
+    assert uk and uk[0] == 1
+    assert row == ("999",)
+
+
 async def test_legacy_reports_gets_status_columns(integration_db_pool) -> None:
     from utils.schema_conformance import fetch_existing_columns
 


### PR DESCRIPTION
## Summary
- Migration 004 failed on deploy because production `triggerMessages` uses legacy `guildId` instead of `guild_id`.
- Rename `guildId` to `guild_id`, backfill from child tables when missing, and remove orphan rows before enforcing NOT NULL and composite FK keys.

## Test plan
- [x] Added integration fixture `trigger_messages_guild_id.sql` and `test_legacy_trigger_messages_guild_id_column_upgrades`
- [ ] Re-deploy `ver/1.2` after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema migration to handle legacy guild ID column format upgrades, properly renaming affected columns to current standards with comprehensive validation and data integrity preservation.
  * Ensures all existing data is correctly transformed and validated during system upgrades without data loss.
  * Integration testing added to verify the schema migration process succeeds for all affected tables and data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->