### PR TITLE
fix(migrations): enforce NOT NULL giveaway_id (006)

### DIFF
--- a/migrations/versions/006_giveaway_id_not_null.py
+++ b/migrations/versions/006_giveaway_id_not_null.py
@@ -1,0 +1,167 @@
+"""Ensure giveaway.giveaway_id is NOT NULL AUTO_INCREMENT after legacy renames."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+revision: str = "006_giveaway_id_not_null"
+down_revision: str | None = "005_legacy_camelcase_columns"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_BENIGN = (
+    "duplicate column",
+    "multiple primary key",
+    "already exists",
+    "doesn't exist",
+    "does not exist",
+    "check that column/key exists",
+    "can't drop",
+)
+
+
+def _execute_idempotent(sql: str) -> None:
+    conn = op.get_bind()
+    try:
+        conn.execute(text(sql))
+    except Exception as exc:
+        if any(fragment in str(exc).lower() for fragment in _BENIGN):
+            return
+        raise
+
+
+def _table_exists(conn: Connection, table: str) -> bool:
+    row = conn.execute(
+        text(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = DATABASE() AND table_name = :table"
+        ),
+        {"table": table},
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def _has_column(conn: Connection, table: str, column: str) -> bool:
+    row = conn.execute(
+        text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    return bool(row and row[0])
+
+
+def _column_nullable(conn: Connection, table: str, column: str) -> bool | None:
+    row = conn.execute(
+        text(
+            "SELECT is_nullable FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    if not row:
+        return None
+    return row[0] == "YES"
+
+
+def _primary_key_columns(conn: Connection, table: str) -> list[str]:
+    rows = conn.execute(
+        text(
+            "SELECT column_name FROM information_schema.statistics "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND index_name = 'PRIMARY' "
+            "ORDER BY seq_in_index"
+        ),
+        {"table": table},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _auto_increment_columns(conn: Connection, table: str) -> list[str]:
+    rows = conn.execute(
+        text(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table "
+            "AND extra LIKE '%auto_increment%'"
+        ),
+        {"table": table},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _strip_auto_increment(conn: Connection, table: str, column: str) -> None:
+    row = conn.execute(
+        text(
+            "SELECT column_type, is_nullable FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    ).fetchone()
+    if not row:
+        return
+    nullable = "NULL" if row[1] == "YES" else "NOT NULL"
+    _execute_idempotent(f"ALTER TABLE `{table}` MODIFY COLUMN `{column}` {row[0]} {nullable}")
+
+
+def _assign_remaining_giveaway_ids(conn: Connection) -> None:
+    row = conn.execute(text("SELECT COALESCE(MAX(`giveaway_id`), 0) FROM `giveaway`")).fetchone()
+    start = int(row[0]) if row else 0
+    conn.execute(text(f"SET @giveaway_row := {start}"))
+    conn.execute(
+        text(
+            "UPDATE `giveaway` SET `giveaway_id` = (@giveaway_row := @giveaway_row + 1) "
+            "WHERE `giveaway_id` IS NULL ORDER BY `guild_id`, `endtime`"
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if not _table_exists(conn, "giveaway") or not _has_column(conn, "giveaway", "giveaway_id"):
+        return
+
+    if _has_column(conn, "giveaway", "giveawayId"):
+        conn.execute(
+            text(
+                "UPDATE `giveaway` SET `giveaway_id` = `giveawayId` "
+                "WHERE `giveaway_id` IS NULL AND `giveawayId` IS NOT NULL"
+            )
+        )
+        _execute_idempotent("ALTER TABLE `giveaway` DROP COLUMN `giveawayId`")
+
+    for legacy in ("id", "giveawayId"):
+        if legacy != "giveaway_id" and _has_column(conn, "giveaway", legacy):
+            pk_cols = _primary_key_columns(conn, "giveaway")
+            if pk_cols == [legacy]:
+                _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+            elif legacy in pk_cols:
+                _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+            conn.execute(
+                text(f"UPDATE `giveaway` SET `giveaway_id` = `{legacy}` WHERE `giveaway_id` IS NULL")
+            )
+            _execute_idempotent(f"ALTER TABLE `giveaway` DROP COLUMN `{legacy}`")
+
+    _assign_remaining_giveaway_ids(conn)
+
+    for column in _auto_increment_columns(conn, "giveaway"):
+        if column != "giveaway_id":
+            _strip_auto_increment(conn, "giveaway", column)
+
+    pk_cols = _primary_key_columns(conn, "giveaway")
+    needs_pk = pk_cols != ["giveaway_id"]
+    needs_not_null = _column_nullable(conn, "giveaway", "giveaway_id") is not False
+    if needs_pk:
+        _execute_idempotent("ALTER TABLE `giveaway` DROP PRIMARY KEY")
+    if needs_pk or needs_not_null:
+        _execute_idempotent(
+            "ALTER TABLE `giveaway` MODIFY COLUMN `giveaway_id` INT UNSIGNED NOT NULL "
+            "AUTO_INCREMENT PRIMARY KEY"
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/tests/fixtures/schema_legacy/giveaway_nullable_id_with_legacy_pk.sql
+++ b/tests/fixtures/schema_legacy/giveaway_nullable_id_with_legacy_pk.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS `giveaway` (
+    `giveaway_id` INT UNSIGNED NULL,
+    `giveawayId` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `guildId` VARCHAR(20) NOT NULL,
+    `channelId` VARCHAR(20) DEFAULT NULL,
+    `title` VARCHAR(128) NOT NULL,
+    `endtime` DATETIME NOT NULL,
+    `ended` TINYINT(1) DEFAULT 0,
+    PRIMARY KEY (`giveawayId`)
+) ENGINE=InnoDB;
+
+INSERT INTO `giveaway` (`giveawayId`, `guildId`, `title`, `endtime`)
+VALUES (7, '111', 'Legacy giveaway', '2030-01-01 00:00:00');

--- a/tests/integration/api/test_schema_conformance.py
+++ b/tests/integration/api/test_schema_conformance.py
@@ -216,6 +216,41 @@ async def test_legacy_camelcase_columns_renamed(integration_db_pool) -> None:
     assert auto_cols == {"channel_id"}
 
 
+async def test_giveaway_nullable_id_repaired_at_head(integration_db_pool) -> None:
+    pool = integration_db_pool
+    legacy_sql = (_LEGACY_DIR / "giveaway_nullable_id_with_legacy_pk.sql").read_text(encoding="utf-8")
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute("DROP TABLE IF EXISTS `giveaway`")
+        for statement in legacy_sql.split(";"):
+            stmt = statement.strip()
+            if stmt:
+                await cursor.execute(stmt)
+        await conn.commit()
+
+    _rerun_migrations_from("004_schema_fk_and_guild_keys")
+
+    from utils.schema_conformance import assert_schema_conformance
+
+    await assert_schema_conformance(pool)
+
+    async with pool.acquire() as conn, conn.cursor() as cursor:
+        await cursor.execute(
+            "SELECT column_name, extra, is_nullable FROM information_schema.columns "
+            "WHERE table_schema = DATABASE() AND table_name = 'giveaway' "
+            "AND column_name IN ('giveaway_id', 'giveawayId', 'id')"
+        )
+        rows = {row[0]: (row[1], row[2]) for row in await cursor.fetchall()}
+        await cursor.execute("SELECT `giveaway_id`, `guild_id` FROM `giveaway` WHERE `giveaway_id` = 7")
+        data = await cursor.fetchone()
+
+    assert "giveaway_id" in rows
+    assert rows["giveaway_id"][1] == "NO"
+    assert "auto_increment" in rows["giveaway_id"][0].lower()
+    assert "giveawayId" not in rows
+    assert data == (7, "111")
+
+
 async def test_legacy_reports_gets_status_columns(integration_db_pool) -> None:
     from utils.schema_conformance import fetch_existing_columns
 

--- a/tests/unit/utils/test_db_migration.py
+++ b/tests/unit/utils/test_db_migration.py
@@ -22,7 +22,7 @@ from utils.db_migration import (  # noqa: E402
 pytestmark = pytest.mark.unit
 
 ROOT = Path(__file__).resolve().parents[3]
-HEAD = "005_legacy_camelcase_columns"
+HEAD = "006_giveaway_id_not_null"
 
 
 def _engine_context(connection: MagicMock) -> MagicMock:


### PR DESCRIPTION
## Summary
- Adds Alembic revision `006_giveaway_id_not_null` to repair production drift after `005_legacy_camelcase_columns`.
- Handles the case where `giveaway_id` exists as nullable (migration 003 early-exit) while `giveawayId` remains the AUTO_INCREMENT primary key.
- Backfills IDs, drops legacy `giveawayId`/`id` columns, and sets `giveaway_id` as `NOT NULL AUTO_INCREMENT PRIMARY KEY`.

## Context
Coolify deploy on `ver/1.2` (`3566d4c`) failed with:
```
Schema drift detected at Alembic head (005_legacy_camelcase_columns, 1 issue(s))
table `giveaway` column `giveaway_id` nullability mismatch: expected NOT NULL, got NULL
```

## Test plan
- [ ] Merge to `development`
- [ ] Merge/push to `ver/1.2` and redeploy on Coolify
- [ ] Confirm container passes schema conformance and healthcheck
- [ ] `pytest tests/integration/api/test_schema_conformance.py::test_giveaway_nullable_id_repaired_at_head` (with integration DB)


Made with [Cursor](https://cursor.com)