### PR TITLE
fix(setup-wizards): resolve ChannelSelect before permissions_for (#3227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - run: ruff check . --fix --exit-zero
       - run: ruff format .
       - run: python scripts/lint_tests.py
+      - run: python scripts/lint_channel_select.py
 
   type-check:
     name: Type Check (Mypy)

--- a/extensions/setup_wizards.py
+++ b/extensions/setup_wizards.py
@@ -5,6 +5,7 @@ Provides guided, step-by-step configuration using modals and buttons.
 from locale_keys import locale as l10n
 from typing import Any, cast
 import discord
+from utils.discord_channels import bot_can_send_messages, channel_mention, resolve_guild_channel
 from discord import app_commands
 from discord.ext import commands
 from discord.ui import Modal, TextInput, View
@@ -51,15 +52,16 @@ class LogChannelSelectView(View):
             return
         if not select.values:
             return
-        channel = cast(discord.TextChannel, select.values[0])
+        selected = select.values[0]
+        channel = await resolve_guild_channel(self.guild, selected)
         assert interaction.client is not None and interaction.client.user is not None
         self_member = self.guild.get_member(interaction.client.user.id)
-        if self_member is None or not channel.permissions_for(self_member).send_messages:
+        if self_member is None or channel is None or not bot_can_send_messages(channel, self_member):
             embed = utility.tanjunEmbed(title='Missing Permission', description="I don't have permission to send messages in that channel.")
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
         await api_set_log_channel(str(self.guild.id), str(channel.id))
-        embed = utility.tanjunEmbed(title='✅ Log Channel Set', description=f"Log channel has been set to {channel.mention}.\n\nNow let's configure which events to log.")
+        embed = utility.tanjunEmbed(title='✅ Log Channel Set', description=f"Log channel has been set to {channel_mention(selected, channel)}.\n\nNow let's configure which events to log.")
         event_view = LogEventConfigView(self.locale, self.guild)
         await interaction.response.edit_message(embed=embed, view=event_view)
 
@@ -240,10 +242,11 @@ class LevelChannelView(View):
             await _not_admin_reply(interaction)
             return
         if select.values:
-            channel = cast(discord.TextChannel, select.values[0])
+            selected = select.values[0]
+            channel = await resolve_guild_channel(self.guild, selected)
             assert interaction.client is not None and interaction.client.user is not None
             self_member = self.guild.get_member(interaction.client.user.id)
-            if self_member is None:
+            if self_member is None or channel is None:
                 embed = utility.tanjunEmbed(title='Error', description='Could not verify bot permissions.')
                 await interaction.response.send_message(embed=embed, ephemeral=True)
                 return
@@ -253,7 +256,7 @@ class LevelChannelView(View):
                 await interaction.response.send_message(embed=embed, ephemeral=True)
                 return
             await api_set_levelup_channel(str(self.guild.id), str(channel.id))
-            msg = f'Level-up announcements will be sent to {channel.mention}.'
+            msg = f'Level-up announcements will be sent to {channel_mention(selected, channel)}.'
         else:
             msg = 'No level-up channel set.'
         self.setup_view.completed = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -304,7 +304,6 @@ module = [
     "extensions.*",
     "loops.*",
     "minigames.*",
-    "utils.checks",
     "services.image_service",
     "services.twitch_service",
     "services.wordle_service",
@@ -312,3 +311,11 @@ module = [
     "main",
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "extensions.setup_wizards",
+    "utils.discord_channels",
+    "utils.checks",
+]
+ignore_errors = false

--- a/scripts/lint_channel_select.py
+++ b/scripts/lint_channel_select.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Reject unsafe ChannelSelect value handling patterns."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = (ROOT / "commands", ROOT / "extensions")
+VALUES_PATTERN = re.compile(r"select\.values")
+CAST_PATTERN = re.compile(r"cast\s*\(\s*discord\.TextChannel\s*,\s*select\.values")
+PERMISSIONS_FOR_PATTERN = re.compile(r"\.permissions_for\s*\(")
+
+
+def _line_violations(path: Path, line: str, line_no: int) -> list[str]:
+    violations: list[str] = []
+    if CAST_PATTERN.search(line):
+        violations.append(f"{path.relative_to(ROOT)}:{line_no}: cast(discord.TextChannel, select.values...) hides AppCommandChannel")
+    if VALUES_PATTERN.search(line) and PERMISSIONS_FOR_PATTERN.search(line):
+        violations.append(f"{path.relative_to(ROOT)}:{line_no}: permissions_for used on same line as select.values")
+    return violations
+
+
+def _window_violations(path: Path, lines: list[str]) -> list[str]:
+    violations: list[str] = []
+    for index, line in enumerate(lines):
+        if not VALUES_PATTERN.search(line):
+            continue
+        window = "".join(lines[index : index + 6])
+        if PERMISSIONS_FOR_PATTERN.search(window) and "resolve_guild_channel" not in window:
+            violations.append(
+                f"{path.relative_to(ROOT)}:{index + 1}: permissions_for near select.values without resolve_guild_channel"
+            )
+    return violations
+
+
+def main() -> int:
+    failures: list[str] = []
+    for base in SCAN_DIRS:
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            text = path.read_text()
+            lines = text.splitlines()
+            for line_no, line in enumerate(lines, start=1):
+                failures.extend(_line_violations(path, line, line_no))
+            failures.extend(_window_violations(path, lines))
+    failures = sorted(set(failures))
+    if failures:
+        print("lint_channel_select failed:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+    print("lint_channel_select: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/helpers/discord.py
+++ b/tests/helpers/discord.py
@@ -265,6 +265,27 @@ def make_text_channel(channel_id: int=444444444, guild: MagicMock | None=None) -
     channel.create_thread = AsyncMock(return_value=thread)
     return channel
 
+def make_app_command_channel(
+    channel_id: int=444444444,
+    guild: MagicMock | None=None,
+    *,
+    resolved: MockTextChannel | MagicMock | None=None,
+    fetch_raises: type[BaseException] | None=None,
+) -> MagicMock:
+    guild = guild or make_guild()
+    selected = MagicMock(spec=['id', 'name', 'mention', 'guild_id', 'permissions', 'resolve', 'fetch'])
+    selected.id = channel_id
+    selected.name = 'test-channel'
+    selected.mention = f'<#{channel_id}>'
+    selected.guild_id = guild.id
+    selected.permissions = make_permissions(send_messages=True, view_channel=True)
+    selected.resolve = MagicMock(return_value=resolved)
+    if fetch_raises is not None:
+        selected.fetch = AsyncMock(side_effect=fetch_raises())
+    else:
+        selected.fetch = AsyncMock(return_value=resolved)
+    return selected
+
 def make_command_info(user: MagicMock | None=None, guild: MagicMock | None=None, channel: MagicMock | None=None, locale: str='en-US', reply: AsyncMock | None=None, client: MagicMock | None=None, **kwargs: Any) -> CommandInfo:
     from utility import CommandInfo
     user = user or make_member()

--- a/tests/integration/extensions/test_setup_wizards_comprehensive.py
+++ b/tests/integration/extensions/test_setup_wizards_comprehensive.py
@@ -9,12 +9,14 @@ import extensions.setup_wizards as sw_mod
 from models import LogEnableModel
 from tests.helpers.discord import (
     MockVoiceChannel,
+    make_app_command_channel,
     make_guild,
     make_interaction,
     make_member,
     make_permissions,
     make_text_channel,
 )
+import discord
 from tests.integration.extensions.conftest import load_extension_bot
 
 pytestmark = pytest.mark.asyncio
@@ -65,6 +67,19 @@ def _admin_interaction(*, guild: MagicMock | None = None) -> MagicMock:
     )
     guild.get_member = MagicMock(return_value=user)
     return ix
+
+
+def _resolved_app_command_channel(
+    guild: MagicMock,
+    *,
+    send_messages: bool = True,
+    view_channel: bool = True,
+) -> MagicMock:
+    resolved = make_text_channel(guild=guild)
+    resolved.permissions_for = MagicMock(
+        return_value=make_permissions(send_messages=send_messages, view_channel=view_channel)
+    )
+    return make_app_command_channel(guild=guild, resolved=resolved)
 
 
 def _non_admin_interaction() -> MagicMock:
@@ -123,9 +138,8 @@ class TestLogChannelSelectView:
         guild.get_member = MagicMock(return_value=make_member())
         view = sw.LogChannelSelectView("en-US", guild)
         ix = _admin_interaction(guild=guild)
-        channel = make_text_channel(guild=guild)
-        channel.permissions_for = MagicMock(return_value=make_permissions(send_messages=True))
-        await view.on_channel_select(ix, MagicMock(values=[channel]))
+        selected = _resolved_app_command_channel(guild)
+        await view.on_channel_select(ix, MagicMock(values=[selected]))
         wizard_api_mocks["set_log"].assert_awaited_once()
         ix.response.edit_message.assert_awaited_once()
 
@@ -134,10 +148,19 @@ class TestLogChannelSelectView:
         guild.get_member = MagicMock(return_value=make_member())
         view = sw.LogChannelSelectView("en-US", guild)
         ix = _admin_interaction(guild=guild)
-        channel = make_text_channel(guild=guild)
-        channel.permissions_for = MagicMock(return_value=make_permissions(send_messages=False))
-        await view.on_channel_select(ix, MagicMock(values=[channel]))
+        selected = _resolved_app_command_channel(guild, send_messages=False)
+        await view.on_channel_select(ix, MagicMock(values=[selected]))
         ix.response.send_message.assert_awaited_once()
+
+    async def test_channel_select_unresolvable(self, sw, wizard_api_mocks) -> None:
+        guild = make_guild()
+        guild.get_member = MagicMock(return_value=make_member())
+        view = sw.LogChannelSelectView("en-US", guild)
+        ix = _admin_interaction(guild=guild)
+        selected = make_app_command_channel(guild=guild, resolved=None, fetch_raises=discord.NotFound)
+        await view.on_channel_select(ix, MagicMock(values=[selected]))
+        ix.response.send_message.assert_awaited_once()
+        wizard_api_mocks["set_log"].assert_not_awaited()
 
     async def test_channel_select_not_admin(self, sw, wizard_api_mocks) -> None:
         view = sw.LogChannelSelectView("en-US", make_guild())
@@ -191,9 +214,8 @@ class TestLevelSetupFlow:
         guild.get_member = MagicMock(return_value=make_member())
         parent = sw.LevelSetupView("en-US", guild)
         view = sw.LevelChannelView("en-US", guild, parent)
-        channel = make_text_channel(guild=guild)
-        channel.permissions_for = MagicMock(return_value=make_permissions(view_channel=True, send_messages=True))
-        await view.on_channel_select(_admin_interaction(guild=guild), MagicMock(values=[channel]))
+        selected = _resolved_app_command_channel(guild)
+        await view.on_channel_select(_admin_interaction(guild=guild), MagicMock(values=[selected]))
         assert parent.completed is True
         parent2 = sw.LevelSetupView("en-US", guild)
         view2 = sw.LevelChannelView("en-US", guild, parent2)
@@ -205,11 +227,13 @@ class TestLevelSetupFlow:
         parent = sw.LevelSetupView("en-US", guild)
         view = sw.LevelChannelView("en-US", guild, parent)
         guild.get_member = MagicMock(return_value=None)
-        await view.on_channel_select(_admin_interaction(guild=guild), MagicMock(values=[make_text_channel(guild=guild)]))
+        await view.on_channel_select(
+            _admin_interaction(guild=guild),
+            MagicMock(values=[_resolved_app_command_channel(guild)]),
+        )
         guild.get_member = MagicMock(return_value=make_member())
-        channel = make_text_channel(guild=guild)
-        channel.permissions_for = MagicMock(return_value=make_permissions(view_channel=False, send_messages=False))
-        await view.on_channel_select(_admin_interaction(guild=guild), MagicMock(values=[channel]))
+        selected = _resolved_app_command_channel(guild, send_messages=False, view_channel=False)
+        await view.on_channel_select(_admin_interaction(guild=guild), MagicMock(values=[selected]))
 
 
 class TestBoosterSetup:

--- a/tests/integration/extensions/test_setup_wizards_deep.py
+++ b/tests/integration/extensions/test_setup_wizards_deep.py
@@ -67,14 +67,14 @@ async def test_log_channel_select_view_callbacks():
         if callable(attr) and hasattr(attr, "__discord_ui_model_type__"):
             continue
         if name.startswith("on_") or (callable(attr) and inspect.iscoroutinefunction(attr)):
+            interaction = MagicMock()
+            interaction.response = MagicMock()
+            interaction.response.defer = AsyncMock()
+            interaction.followup = MagicMock()
+            interaction.followup.send = AsyncMock()
             try:
-                interaction = MagicMock()
-                interaction.response = MagicMock()
-                interaction.response.defer = AsyncMock()
-                interaction.followup = MagicMock()
-                interaction.followup.send = AsyncMock()
                 await attr(interaction)
-            except (TypeError, AttributeError):
+            except TypeError:
                 pass
 
 

--- a/tests/unit/utils/test_discord_channels.py
+++ b/tests/unit/utils/test_discord_channels.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from tests.helpers.discord import (
+    make_app_command_channel,
+    make_guild,
+    make_member,
+    make_permissions,
+    make_text_channel,
+)
+from utils.discord_channels import (
+    bot_can_send_messages,
+    channel_mention,
+    resolve_guild_channel,
+    resolve_guild_channel_sync,
+)
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_channel_passthrough_guild_channel() -> None:
+    guild = make_guild()
+    channel = make_text_channel(guild=guild)
+    result = await resolve_guild_channel(guild, channel)
+    assert result is channel
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_channel_from_app_command_resolve() -> None:
+    guild = make_guild()
+    resolved = make_text_channel(guild=guild)
+    selected = make_app_command_channel(guild=guild, resolved=resolved)
+    result = await resolve_guild_channel(guild, selected)
+    assert result is resolved
+    selected.fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_channel_from_app_command_fetch() -> None:
+    guild = make_guild()
+    resolved = make_text_channel(guild=guild)
+    selected = make_app_command_channel(guild=guild, resolved=None)
+    selected.fetch = AsyncMock(return_value=resolved)
+    result = await resolve_guild_channel(guild, selected)
+    assert result is resolved
+    selected.fetch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [discord.NotFound, discord.Forbidden])
+async def test_resolve_guild_channel_fetch_failure(exc: type[BaseException]) -> None:
+    guild = make_guild()
+    selected = make_app_command_channel(guild=guild, resolved=None, fetch_raises=exc)
+    result = await resolve_guild_channel(guild, selected)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_guild_channel_wrong_guild() -> None:
+    guild = make_guild()
+    selected = make_app_command_channel(guild=make_guild(guild_id=999))
+    result = await resolve_guild_channel(guild, selected)
+    assert result is None
+    selected.resolve.assert_not_called()
+
+
+def test_resolve_guild_channel_sync() -> None:
+    guild = make_guild()
+    channel = make_text_channel(guild=guild)
+    assert resolve_guild_channel_sync(guild, channel) is channel
+
+
+def test_bot_can_send_messages() -> None:
+    guild = make_guild()
+    channel = make_text_channel(guild=guild)
+    bot = make_member()
+    from unittest.mock import MagicMock
+
+    channel.permissions_for = MagicMock(return_value=make_permissions(send_messages=True))
+    assert bot_can_send_messages(channel, bot) is True
+    channel.permissions_for = MagicMock(return_value=make_permissions(send_messages=False))
+    assert bot_can_send_messages(channel, bot) is False
+
+
+def test_channel_mention() -> None:
+    guild = make_guild()
+    channel = make_text_channel(channel_id=123, guild=guild)
+    assert channel_mention(channel) == '<#123>'
+    selected = make_app_command_channel(channel_id=456, guild=guild)
+    assert channel_mention(selected) == '<#456>'
+    assert channel_mention(selected, channel) == '<#123>'

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 from locale_keys import locale
 from typing import Literal
 import discord
+from discord import app_commands
 from utility import CommandInfo
+from utils.discord_channels import resolve_guild_channel_sync
 from utils.embeds import ErrorEmbedCategory, categorized_error_embed, categorized_warning_embed
 _CheckResult = tuple[str, ErrorEmbedCategory, bool] | None
 
@@ -63,7 +65,7 @@ def check_user_permission(command_info: CommandInfo, permission: Literal['ban_me
         return ('missingPermission', ErrorEmbedCategory.PERMISSION, True)
     return None
 
-def check_bot_permission(command_info: CommandInfo, permission: Literal['ban_members', 'kick_members', 'moderate_members', 'manage_messages', 'manage_roles', 'manage_channels'], *, channel: discord.TextChannel | None=None) -> _CheckResult:
+def check_bot_permission(command_info: CommandInfo, permission: Literal['ban_members', 'kick_members', 'moderate_members', 'manage_messages', 'manage_roles', 'manage_channels'], *, channel: app_commands.AppCommandChannel | discord.abc.GuildChannel | None=None) -> _CheckResult:
     """Verify the bot has the required permission.
 
     Parameters
@@ -85,7 +87,10 @@ def check_bot_permission(command_info: CommandInfo, permission: Literal['ban_mem
     if guild is None:
         raise ValueError('Guild is missing in command_info')
     if channel is not None:
-        has_perm = getattr(channel.permissions_for(guild.me), permission, False)
+        resolved = resolve_guild_channel_sync(guild, channel)
+        if resolved is None or not hasattr(resolved, 'permissions_for'):
+            return ('missingPermissionBot', ErrorEmbedCategory.PERMISSION, True)
+        has_perm = getattr(resolved.permissions_for(guild.me), permission, False)
     else:
         has_perm = getattr(guild.me.guild_permissions, permission, False)
     if not has_perm:

--- a/utils/discord_channels.py
+++ b/utils/discord_channels.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+import discord
+from discord import app_commands
+
+
+def _app_command_channel_type() -> type | None:
+    cls = getattr(app_commands, 'AppCommandChannel', None)
+    return cls if isinstance(cls, type) else None
+
+
+def _is_partial_channel(selected: Any) -> bool:
+    acc_type = _app_command_channel_type()
+    if acc_type is not None and isinstance(selected, acc_type):
+        return True
+    return (
+        hasattr(selected, 'resolve')
+        and hasattr(selected, 'fetch')
+        and hasattr(selected, 'guild_id')
+        and not isinstance(selected, discord.abc.GuildChannel)
+    )
+
+
+async def resolve_guild_channel(
+    guild: discord.Guild,
+    selected: app_commands.AppCommandChannel | discord.abc.GuildChannel,
+) -> discord.abc.GuildChannel | None:
+    if isinstance(selected, discord.abc.GuildChannel):
+        return selected
+    if _is_partial_channel(selected):
+        if selected.guild_id != guild.id:
+            return None
+        resolved = selected.resolve()
+        if resolved is not None:
+            return resolved
+        try:
+            return await selected.fetch()
+        except (discord.NotFound, discord.Forbidden):
+            return None
+    return None
+
+
+def resolve_guild_channel_sync(
+    guild: discord.Guild,
+    selected: app_commands.AppCommandChannel | discord.abc.GuildChannel,
+) -> discord.abc.GuildChannel | None:
+    if isinstance(selected, discord.abc.GuildChannel):
+        return selected
+    if _is_partial_channel(selected):
+        if selected.guild_id != guild.id:
+            return None
+        return selected.resolve()
+    return None
+
+
+def channel_mention(
+    selected: app_commands.AppCommandChannel | discord.abc.GuildChannel,
+    resolved: discord.abc.GuildChannel | None = None,
+) -> str:
+    if resolved is not None:
+        return resolved.mention
+    acc_type = _app_command_channel_type()
+    if acc_type is not None and isinstance(selected, acc_type):
+        return selected.mention
+    return selected.mention
+
+
+def bot_can_send_messages(channel: discord.abc.GuildChannel, bot_member: discord.Member) -> bool:
+    return channel.permissions_for(bot_member).send_messages


### PR DESCRIPTION
## Summary
- Fix `AttributeError` when setup wizards call `permissions_for` on `AppCommandChannel` from `ChannelSelect` by resolving to a full guild channel first.
- Add `utils/discord_channels` helpers, regression tests with `AppCommandChannel`-shaped mocks, and `scripts/lint_channel_select.py` in CI.
- Harden `utils/checks.check_bot_permission` for partial channel objects; enable mypy on the touched modules.

## Test plan
- [x] `pytest tests/unit/utils/test_discord_channels.py tests/integration/extensions/test_setup_wizards_comprehensive.py -q`
- [x] `python scripts/lint_channel_select.py`
- [ ] Manual: run log/level setup wizards and select a channel via ChannelSelect

Closes #3227

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved channel selection and validation in setup wizards with enhanced reliability.

* **Bug Fixes**
  * Better bot permission checking for channels in logging and level-up announcement wizards.

* **Chores**
  * Added automated validation to prevent unsafe channel selection patterns in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->