### PR TITLE
fix(i18n): improve English source strings in en.json

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,160 +1,160 @@
 [
   {
     "identifier": "Administrate the Server",
-    "source_string": "manage_the_server",
-    "translation": "manage_the_server",
+    "source_string": "Manage the server",
+    "translation": "Manage the server",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the server\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask Chat GPT something",
-    "source_string": "chat_gpt_ask_something",
-    "translation": "chat_gpt_ask_something",
+    "source_string": "Chat GPT ask something",
+    "translation": "Chat GPT ask something",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Chat GPT ask something\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Ask a custom situation",
-    "source_string": "request_a_user-defined_situation",
-    "translation": "request_a_user-defined_situation",
+    "source_string": "Request a user-defined situation",
+    "translation": "Request a user-defined situation",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Request a user-defined situation\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Awst Tanjuwun something uwu",
-    "source_string": "awst_tanjuwun_somethim_uwu",
-    "translation": "awst_tanjuwun_somethim_uwu",
+    "source_string": "Awst Tanjuwun somethim uwu",
+    "translation": "Awst Tanjuwun somethim uwu",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Awst Tanjuwun somethim uwu\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Blacklist Commands",
-    "source_string": "blacklist_commands",
-    "translation": "blacklist_commands",
+    "source_string": "Blacklist commands",
+    "translation": "Blacklist commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Fun Commands",
-    "source_string": "fun_commands",
-    "translation": "fun_commands",
+    "source_string": "Fun commands",
+    "translation": "Fun commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Fun commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Get help with the bot",
-    "source_string": "get_help_with_the_bot",
-    "translation": "get_help_with_the_bot",
+    "source_string": "Get help with the bot",
+    "translation": "Get help with the bot",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Get help with the bot\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Giveaway Commands",
-    "source_string": "giveaway_commands",
-    "translation": "giveaway_commands",
+    "source_string": "Giveaway commands",
+    "translation": "Giveaway commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Giveaway commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Level Commands",
-    "source_string": "level_commands",
-    "translation": "level_commands",
+    "source_string": "Level commands",
+    "translation": "Level commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Level commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Channels",
-    "source_string": "manage_channel",
-    "translation": "manage_channel",
+    "source_string": "Manage channel",
+    "translation": "Manage channel",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage channel\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Join-to-Create Channels",
-    "source_string": "join_to_create_manage_channels",
-    "translation": "join_to_create_manage_channels",
+    "source_string": "Join To Create Manage channels",
+    "translation": "Join To Create Manage channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Join To Create Manage channels\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Reports",
-    "source_string": "manage_reports",
-    "translation": "manage_reports",
+    "source_string": "Manage reports",
+    "translation": "Manage reports",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage reports\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Trigger Messages",
-    "source_string": "manage_trigger_messages",
-    "translation": "manage_trigger_messages",
+    "source_string": "Manage trigger messages",
+    "translation": "Manage trigger messages",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage trigger messages\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Manage Warns",
-    "source_string": "manage_warnings",
-    "translation": "manage_warnings",
+    "source_string": "Manage warnings",
+    "translation": "Manage warnings",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage warnings\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Math is fun!",
-    "source_string": "math_is_fun",
-    "translation": "math_is_fun",
+    "source_string": "Math is fun!",
+    "translation": "Math is fun!",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Math is fun!\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "Minigame Commands",
-    "source_string": "minigame_commands",
-    "translation": "minigame_commands",
+    "source_string": "Minigame commands",
+    "translation": "Minigame commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Minigame commands\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The frequency penalty setting",
-    "source_string": "the_frequency_penalty_setting",
-    "translation": "the_frequency_penalty_setting",
+    "source_string": "The frequency penalty setting",
+    "translation": "The frequency penalty setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The frequency penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The personality description",
-    "source_string": "the_personality_description",
-    "translation": "the_personality_description",
+    "source_string": "The personality description",
+    "translation": "The personality description",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The personality description\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The presence penalty setting",
-    "source_string": "the_presence_penalty_setting",
-    "translation": "the_presence_penalty_setting",
+    "source_string": "The presence penalty setting",
+    "translation": "The presence penalty setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The presence penalty setting\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "The temperature setting",
-    "source_string": "the_temperature_setting",
-    "translation": "the_temperature_setting",
+    "source_string": "The temperature setting",
+    "translation": "The temperature setting",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The temperature setting\".",
     "labels": "command_name",
     "max_length": 32
@@ -169,8 +169,8 @@
   },
   {
     "identifier": "Utility Commands",
-    "source_string": "various_commands",
-    "translation": "various_commands",
+    "source_string": "Various commands",
+    "translation": "Various commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Various commands\".",
     "labels": "command_name",
     "max_length": 32
@@ -361,8 +361,8 @@
   },
   {
     "identifier": "admin.copyrole.description",
-    "source_string": "Copies a roll",
-    "translation": "Copies a roll",
+    "source_string": "Copies a role",
+    "translation": "Copies a role",
     "context": "Short description of `/copyrole` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
     "labels": "admin, command_description",
     "max_length": 100
@@ -481,8 +481,8 @@
   },
   {
     "identifier": "admin.createemoji.params.roles.name",
-    "source_string": "roll",
-    "translation": "roll",
+    "source_string": "role",
+    "translation": "role",
     "context": "Display name of the `roles` option on `/createemoji` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
@@ -729,8 +729,8 @@
   },
   {
     "identifier": "admin.deleterole.description",
-    "source_string": "Deletes a roll",
-    "translation": "Deletes a roll",
+    "source_string": "Deletes a role",
+    "translation": "Deletes a role",
     "context": "Short description of `/deleterole` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
     "labels": "admin, command_description",
     "max_length": 100
@@ -993,8 +993,8 @@
   },
   {
     "identifier": "admin.moverole.description",
-    "source_string": "Moves a roller above or below another roller",
-    "translation": "Moves a roller above or below another roller",
+    "source_string": "Moves a role above or below another role",
+    "translation": "Moves a role above or below another role",
     "context": "Short description of `/moverole` in Discord's slash command browser (max ~100 characters). Used in `extensions/admin.py`.",
     "labels": "admin, command_description",
     "max_length": 100
@@ -1025,40 +1025,40 @@
   },
   {
     "identifier": "admin.moverole.params.position.above",
-    "source_string": "about it",
-    "translation": "about it",
+    "source_string": "Above",
+    "translation": "Above",
     "context": "Option text for `position` on `/moverole`. Used in `extensions/admin.py`.",
     "labels": "admin",
     "max_length": 100
   },
   {
     "identifier": "admin.moverole.params.position.above.description",
-    "source_string": "The roll is moved over the target roll",
-    "translation": "The roll is moved over the target roll",
+    "source_string": "Move the role above the target role",
+    "translation": "Move the role above the target role",
     "context": "Help text describing the `position` option on `/moverole` (shown when the user focuses that option).",
     "labels": "admin, command_option_description",
     "max_length": 100
   },
   {
     "identifier": "admin.moverole.params.position.above.name",
-    "source_string": "about",
-    "translation": "about",
+    "source_string": "above",
+    "translation": "above",
     "context": "Display name of the `position` option on `/moverole` (shown in Discord's slash command option list).",
     "labels": "admin, command_option_name",
     "max_length": 32
   },
   {
     "identifier": "admin.moverole.params.position.below",
-    "source_string": "including",
-    "translation": "including",
+    "source_string": "Below",
+    "translation": "Below",
     "context": "Option text for `position` on `/moverole`. Used in `extensions/admin.py`.",
     "labels": "admin",
     "max_length": 100
   },
   {
     "identifier": "admin.moverole.params.position.below.description",
-    "source_string": "The roll is moved under the target roll",
-    "translation": "The roll is moved under the target roll",
+    "source_string": "Move the role below the target role",
+    "translation": "Move the role below the target role",
     "context": "Help text describing the `position` option on `/moverole` (shown when the user focuses that option).",
     "labels": "admin, command_option_description",
     "max_length": 100
@@ -1073,8 +1073,8 @@
   },
   {
     "identifier": "admin.moverole.params.position.description",
-    "source_string": "Whether the roll should be moved above or below the target roll",
-    "translation": "Whether the roll should be moved above or below the target roll",
+    "source_string": "Whether the role should be moved above or below the target role",
+    "translation": "Whether the role should be moved above or below the target role",
     "context": "Help text describing the `position` option on `/moverole` (shown when the user focuses that option). Used in `extensions/admin.py`.",
     "labels": "admin, command_option_description",
     "max_length": 100
@@ -1369,8 +1369,8 @@
   },
   {
     "identifier": "admin.removerole.params.role.description",
-    "source_string": "The roll that is to be removed",
-    "translation": "The roll that is to be removed",
+    "source_string": "The role to remove",
+    "translation": "The role to remove",
     "context": "Help text describing the `role` option on `/removerole` (shown when the user focuses that option). Used in `extensions/admin.py`.",
     "labels": "admin, command_option_description",
     "max_length": 100
@@ -2873,8 +2873,8 @@
   },
   {
     "identifier": "channel.farewell.remove.ch.description",
-    "source_string": "Removes the bypass channel",
-    "translation": "Removes the bypass channel",
+    "source_string": "Removes the farewell channel",
+    "translation": "Removes the farewell channel",
     "context": "Slash command description for `/channel` (farewell remove ch) shown in Discord's command browser. Used in `extensions/channel.py`.",
     "labels": "channel, description",
     "max_length": 4096
@@ -2905,8 +2905,8 @@
   },
   {
     "identifier": "channel.farewell.set.ch.params.channel.description",
-    "source_string": "The channel to which members are to be adopted",
-    "translation": "The channel to which members are to be adopted",
+    "source_string": "Channel where leave messages are sent",
+    "translation": "Channel where leave messages are sent",
     "context": "Help text describing the `channel` option on `/channel` (farewell set ch params channel description) (shown when the user focuses that option). Used in `extensions/channel.py`.",
     "labels": "channel, command_option_description",
     "max_length": 100
@@ -3569,8 +3569,8 @@
   },
   {
     "identifier": "commands.admin.ban.forbidden.description",
-    "source_string": "The bot was unable to ban the member. The required authorizations may be missing.",
-    "translation": "The bot was unable to ban the member. The required authorizations may be missing.",
+    "source_string": "The bot was unable to ban the member. The required permissions may be missing.",
+    "translation": "The bot was unable to ban the member. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin ban` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/ban.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -3593,8 +3593,8 @@
   },
   {
     "identifier": "commands.admin.ban.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin ban` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -3609,8 +3609,8 @@
   },
   {
     "identifier": "commands.admin.ban.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin ban` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -3673,48 +3673,48 @@
   },
   {
     "identifier": "commands.admin.boosterRole.forbidden.description",
-    "source_string": "The bot does not have the required authorizations to set the booster role.",
-    "translation": "The bot does not have the required authorizations to set the booster role.",
+    "source_string": "The bot does not have the required permissions to set the booster role.",
+    "translation": "The bot does not have the required permissions to set the booster role.",
     "context": "Description body of the reply embed for `/admin boosterRole` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.boosterRole.forbidden.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin boosterRole` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_title, error",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.boosterRole.missingPermission.description",
-    "source_string": "You do not have the required authorizations to set the booster role. You need the 'Manage roles' authorization.",
-    "translation": "You do not have the required authorizations to set the booster role. You need the 'Manage roles' authorization.",
+    "source_string": "You do not have the required permissions to set the booster role. You need the 'Manage roles' permission.",
+    "translation": "You do not have the required permissions to set the booster role. You need the 'Manage roles' permission.",
     "context": "Description body of the reply embed for `/admin boosterRole` when the user who ran the command lacks the required permission. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.boosterRole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin boosterRole` when the user who ran the command lacks the required permission. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.boosterRole.missingPermissionBot.description",
-    "source_string": "The bot does not have the required authorizations to set the booster role. The bot requires the 'Manage roles' authorization.",
-    "translation": "The bot does not have the required authorizations to set the booster role. The bot requires the 'Manage roles' authorization.",
+    "source_string": "The bot does not have the required permissions to set the booster role. The bot requires the 'Manage roles' permission.",
+    "translation": "The bot does not have the required permissions to set the booster role. The bot requires the 'Manage roles' permission.",
     "context": "Description body of the reply embed for `/admin boosterRole` when the bot lacks the required permission in this server. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.boosterRole.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin boosterRole` when the bot lacks the required permission in this server. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -3729,8 +3729,8 @@
   },
   {
     "identifier": "commands.admin.boosterRole.roleRemoved.title",
-    "source_string": "Booster roll removed",
-    "translation": "Booster roll removed",
+    "source_string": "Booster role removed",
+    "translation": "Booster role removed",
     "context": "Title of the reply embed for `/admin boosterRole` (role Removed). Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -3761,24 +3761,24 @@
   },
   {
     "identifier": "commands.admin.boosterRole.success.descriptionWarning",
-    "source_string": "The booster role has been successfully defined. However, this role has the 'Administrator' authorization. This means that every member who boosts the server receives administrator rights.",
-    "translation": "The booster role has been successfully defined. However, this role has the 'Administrator' authorization. This means that every member who boosts the server receives administrator rights.",
+    "source_string": "The booster role has been successfully defined. However, this role has the 'Administrator' permission. This means that every member who boosts the server receives administrator rights.",
+    "translation": "The booster role has been successfully defined. However, this role has the 'Administrator' permission. This means that every member who boosts the server receives administrator rights.",
     "context": "User-visible message for `/admin boosterRole` (success) (description Warning). English: \"The booster role has been successfully defined. However, this role has the 'Administrator' authorization. This means …\". Used in `commands/admin/boosterrole.py`.",
     "labels": "commands",
     "max_length": null
   },
   {
     "identifier": "commands.admin.boosterRole.success.title",
-    "source_string": "Booster role successfully defined",
-    "translation": "Booster role successfully defined",
+    "source_string": "Booster role configured",
+    "translation": "Booster role configured",
     "context": "Title of the reply embed for `/admin boosterRole` when the command completed successfully. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.boosterRole.targetTooHigh.description",
-    "source_string": "You cannot set a booster roll that is higher than or equal to your own highest roll.",
-    "translation": "You cannot set a booster roll that is higher than or equal to your own highest roll.",
+    "source_string": "The booster role cannot be above the bot's highest role.",
+    "translation": "The booster role cannot be above the bot's highest role.",
     "context": "Description body of the reply embed for `/admin boosterRole` when the target member's highest role is above the executor's role. Used in `commands/admin/boosterrole.py`.",
     "labels": "commands, embed_description",
     "max_length": 4096
@@ -3809,8 +3809,8 @@
   },
   {
     "identifier": "commands.admin.channel.farewell.defaultFarewellMessage",
-    "source_string": "{user}, we are glad that you were with us! We hope you had a lot of fun on the server! We wish you all the best and we look forward to seeing you again soon! You are the {member}. member.",
-    "translation": "{user}, we are glad that you were with us! We hope you had a lot of fun on the server! We wish you all the best and we look forward to seeing you again soon! You are the {member}. member.",
+    "source_string": "Goodbye {user}! You were member #{member}. We hope to see you again!",
+    "translation": "Goodbye {user}! You were member #{member}. We hope to see you again!",
     "context": "User-visible message for `/admin channel` (farewell) (default Farewell Message). English: \"{user}, we are glad that you were with us! We hope you had a lot of fun on the server! We wish you all the best and w…\".",
     "labels": "commands",
     "max_length": null
@@ -3849,24 +3849,24 @@
   },
   {
     "identifier": "commands.admin.channel.farewell.missingBotPermission.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin channel` (farewell) when the bot lacks a required permission. Used in `commands/channel/farewell.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.channel.farewell.missingPermission.description",
-    "source_string": "You do not have the required authorizations. You need `Administrator` authorizations.",
-    "translation": "You do not have the required authorizations. You need `Administrator` authorizations.",
+    "source_string": "You need the **Administrator** permission to configure the farewell channel.",
+    "translation": "You need the **Administrator** permission to configure the farewell channel.",
     "context": "Description body of the reply embed for `/admin channel` (farewell) when the user who ran the command lacks the required permission. Used in `commands/channel/farewell.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.channel.farewell.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin channel` (farewell) when the user who ran the command lacks the required permission. Used in `commands/channel/farewell.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -3897,8 +3897,8 @@
   },
   {
     "identifier": "commands.admin.channel.farewell.notSet.title",
-    "source_string": "Adoption channel not specified",
-    "translation": "Adoption channel not specified",
+    "source_string": "Farewell channel not set",
+    "translation": "Farewell channel not set",
     "context": "Title of the reply embed for `/admin channel` (farewell) when a required setting has not been configured yet. Used in `commands/channel/farewell.py`.",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -3913,8 +3913,8 @@
   },
   {
     "identifier": "commands.admin.channel.farewell.success.title",
-    "source_string": "Farewell channel successfully established",
-    "translation": "Farewell channel successfully established",
+    "source_string": "Farewell channel set",
+    "translation": "Farewell channel set",
     "context": "Title of the reply embed for `/admin channel` (farewell) when the command completed successfully. Used in `commands/channel/farewell.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -3993,8 +3993,8 @@
   },
   {
     "identifier": "commands.admin.channel.media.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin channel` (media) when the user who ran the command lacks the required permission. Used in `commands/channel/media.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4009,8 +4009,8 @@
   },
   {
     "identifier": "commands.admin.channel.media.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin channel` (media) when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4073,8 +4073,8 @@
   },
   {
     "identifier": "commands.admin.channel.media.success.title",
-    "source_string": "Media channel successfully defined",
-    "translation": "Media channel successfully defined",
+    "source_string": "Media channel enabled",
+    "translation": "Media channel enabled",
     "context": "Title of the reply embed for `/admin channel` (media) when the command completed successfully. Used in `commands/channel/media.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -4097,8 +4097,8 @@
   },
   {
     "identifier": "commands.admin.channel.welcome.defaultWelcomeMessage",
-    "source_string": "${user} is unfortunately no longer on ${guild}.\nWhat a bummer :(",
-    "translation": "${user} is unfortunately no longer on ${guild}.\nWhat a bummer :(",
+    "source_string": "Welcome {user} to {guild}!",
+    "translation": "Welcome {user} to {guild}!",
     "context": "User-visible message for `/admin channel` (welcome) (default Welcome Message). English: \"${user} is unfortunately no longer on ${guild}. What a bummer :(\".",
     "labels": "commands",
     "max_length": null
@@ -4137,24 +4137,24 @@
   },
   {
     "identifier": "commands.admin.channel.welcome.missingBotPermission.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin channel` (welcome) when the bot lacks a required permission. Used in `commands/channel/welcome.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.channel.welcome.missingPermission.description",
-    "source_string": "You do not have the required authorizations. You need `Administrator` authorizations.",
-    "translation": "You do not have the required authorizations. You need `Administrator` authorizations.",
+    "source_string": "You do not have the required permissions. You need `Administrator` permissions.",
+    "translation": "You do not have the required permissions. You need `Administrator` permissions.",
     "context": "Description body of the reply embed for `/admin channel` (welcome) when the user who ran the command lacks the required permission. Used in `commands/channel/welcome.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.channel.welcome.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin channel` (welcome) when the user who ran the command lacks the required permission. Used in `commands/channel/welcome.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4521,16 +4521,16 @@
   },
   {
     "identifier": "commands.admin.copyEmoji.missingPermission.description",
-    "source_string": "You do not have the required authorizations to execute this command. You need the `manage_emojis` authorization.",
-    "translation": "You do not have the required authorizations to execute this command. You need the `manage_emojis` authorization.",
+    "source_string": "You do not have the required permissions to execute this command. You need the `manage_emojis` permission.",
+    "translation": "You do not have the required permissions to execute this command. You need the `manage_emojis` permission.",
     "context": "Description body of the reply embed for `/admin copyEmoji` when the user who ran the command lacks the required permission. Used in `commands/admin/copy_emoji.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.copyEmoji.missingPermission.title",
-    "source_string": "Missing authorizations",
-    "translation": "Missing authorizations",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin copyEmoji` when the user who ran the command lacks the required permission. Used in `commands/admin/copy_emoji.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4545,8 +4545,8 @@
   },
   {
     "identifier": "commands.admin.copyEmoji.missingPermissionBot.title",
-    "source_string": "I am missing authorizations",
-    "translation": "I am missing authorizations",
+    "source_string": "I am missing permissionss",
+    "translation": "I am missing permissionss",
     "context": "Title of the reply embed for `/admin copyEmoji` when the bot lacks the required permission in this server. Used in `commands/admin/copy_emoji.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4609,32 +4609,32 @@
   },
   {
     "identifier": "commands.admin.copyrole.missingPermission.description",
-    "source_string": "You do not have the required permissions to copy the role. You need 'Manage roles' authorizations.",
-    "translation": "You do not have the required permissions to copy the role. You need 'Manage roles' authorizations.",
+    "source_string": "You do not have the required permissions to copy the role. You need 'Manage roles' permissions.",
+    "translation": "You do not have the required permissions to copy the role. You need 'Manage roles' permissions.",
     "context": "Description body of the reply embed for `/admin copyrole` when the user who ran the command lacks the required permission. Used in `commands/admin/copyrole.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.copyrole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin copyrole` when the user who ran the command lacks the required permission. Used in `commands/admin/copyrole.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.copyrole.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary permissions to copy the role. The bot requires the 'Manage roles' authorization.",
-    "translation": "The bot does not have the necessary permissions to copy the role. The bot requires the 'Manage roles' authorization.",
+    "source_string": "The bot does not have the necessary permissions to copy the role. The bot requires the 'Manage roles' permission.",
+    "translation": "The bot does not have the necessary permissions to copy the role. The bot requires the 'Manage roles' permission.",
     "context": "Description body of the reply embed for `/admin copyrole` when the bot lacks the required permission in this server. Used in `commands/admin/copyrole.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.copyrole.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin copyrole` when the bot lacks the required permission in this server. Used in `commands/admin/copyrole.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4697,8 +4697,8 @@
   },
   {
     "identifier": "commands.admin.createEmoji.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin createEmoji` when the user who ran the command lacks the required permission. Used in `commands/admin/createemoji.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4793,16 +4793,16 @@
   },
   {
     "identifier": "commands.admin.create_ticket.missingBotPermission.description",
-    "source_string": "The bot does not have the required permissions to send messages to the specified channel. The bot requires the 'Send messages' authorization. Also make sure that the bot can see the specified channel.",
-    "translation": "The bot does not have the required permissions to send messages to the specified channel. The bot requires the 'Send messages' authorization. Also make sure that the bot can see the specified channel.",
+    "source_string": "The bot does not have the required permissions to send messages to the specified channel. The bot requires the 'Send messages' permission. Also make sure that the bot can see the specified channel.",
+    "translation": "The bot does not have the required permissions to send messages to the specified channel. The bot requires the 'Send messages' permission. Also make sure that the bot can see the specified channel.",
     "context": "Description body of the reply embed for `/admin create_ticket` when the bot lacks a required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.create_ticket.missingBotPermission.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin create_ticket` when the bot lacks a required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -4817,8 +4817,8 @@
   },
   {
     "identifier": "commands.admin.create_ticket.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin create_ticket` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -5529,8 +5529,8 @@
   },
   {
     "identifier": "commands.admin.embed.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin embed` when the user who ran the command lacks the required permission. Used in `commands/admin/embedcreator.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -5881,8 +5881,8 @@
   },
   {
     "identifier": "commands.admin.jointocreatechannel.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin jointocreatechannel` when the user who ran the command lacks the required permission. Used in `commands/admin/join_to_create/jointocreatechannel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -5921,8 +5921,8 @@
   },
   {
     "identifier": "commands.admin.kick.forbidden.description",
-    "source_string": "The bot could not kick the member. The required authorizations may be missing.",
-    "translation": "The bot could not kick the member. The required authorizations may be missing.",
+    "source_string": "The bot could not kick the member. The required permissions may be missing.",
+    "translation": "The bot could not kick the member. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin kick` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/kick.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -5937,32 +5937,32 @@
   },
   {
     "identifier": "commands.admin.kick.missingPermission.description",
-    "source_string": "You do not have the required authorizations to kick members.",
-    "translation": "You do not have the required authorizations to kick members.",
+    "source_string": "You do not have the required permissions to kick members.",
+    "translation": "You do not have the required permissions to kick members.",
     "context": "Description body of the reply embed for `/admin kick` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.kick.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin kick` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.kick.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to kick members.",
-    "translation": "The bot does not have the necessary authorizations to kick members.",
+    "source_string": "The bot does not have the necessary permissions to kick members.",
+    "translation": "The bot does not have the necessary permissions to kick members.",
     "context": "Description body of the reply embed for `/admin kick` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.kick.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin kick` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6025,8 +6025,8 @@
   },
   {
     "identifier": "commands.admin.lock.channelLockedMessage",
-    "source_string": "🔒 This channel has been blocked by a moderator. Only administrators can send messages here.",
-    "translation": "🔒 This channel has been blocked by a moderator. Only administrators can send messages here.",
+    "source_string": "This channel has been locked by a moderator.",
+    "translation": "This channel has been locked by a moderator.",
     "context": "User-visible message for `/admin lock` (channel Locked Message). English: \"🔒 This channel has been blocked by a moderator. Only administrators can send messages here.\". Used in `commands/admin/lock.py`.",
     "labels": "commands",
     "max_length": null
@@ -6049,8 +6049,8 @@
   },
   {
     "identifier": "commands.admin.lock.forbidden.description",
-    "source_string": "The bot could not block the channel. The required authorizations may be missing.",
-    "translation": "The bot could not block the channel. The required authorizations may be missing.",
+    "source_string": "The bot could not block the channel. The required permissions may be missing.",
+    "translation": "The bot could not block the channel. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin lock` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/lock.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6065,32 +6065,32 @@
   },
   {
     "identifier": "commands.admin.lock.missingPermission.description",
-    "source_string": "You do not have the necessary authorizations to block channels.",
-    "translation": "You do not have the necessary authorizations to block channels.",
+    "source_string": "You do not have the necessary permissions to block channels.",
+    "translation": "You do not have the necessary permissions to block channels.",
     "context": "Description body of the reply embed for `/admin lock` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.lock.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin lock` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.lock.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to block channels.",
-    "translation": "The bot does not have the necessary authorizations to block channels.",
+    "source_string": "The bot does not have the necessary permissions to block channels.",
+    "translation": "The bot does not have the necessary permissions to block channels.",
     "context": "Description body of the reply embed for `/admin lock` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.lock.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot lacks permissions",
+    "translation": "Bot lacks permissions",
     "context": "Title of the reply embed for `/admin lock` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6105,16 +6105,16 @@
   },
   {
     "identifier": "commands.admin.lock.success.title",
-    "source_string": "Channel blocked",
-    "translation": "Channel blocked",
+    "source_string": "Channel locked",
+    "translation": "Channel locked",
     "context": "Title of the reply embed for `/admin lock` when the command completed successfully. Used in `commands/admin/lock.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.moverole.error.description",
-    "source_string": "An error occurred when trying to move the roll.",
-    "translation": "An error occurred when trying to move the roll.",
+    "source_string": "Could not move the role. Check role hierarchy and permissions.",
+    "translation": "Could not move the role. Check role hierarchy and permissions.",
     "context": "Description body of the reply embed for `/admin moverole` when the command failed with a generic error. Used in `commands/admin/moverole.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6129,8 +6129,8 @@
   },
   {
     "identifier": "commands.admin.moverole.forbidden.description",
-    "source_string": "The bot could not move the role. The required authorizations may be missing.",
-    "translation": "The bot could not move the role. The required authorizations may be missing.",
+    "source_string": "The bot could not move the role. The required permissions may be missing.",
+    "translation": "The bot could not move the role. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin moverole` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/moverole.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6241,8 +6241,8 @@
   },
   {
     "identifier": "commands.admin.nickname.forbidden.description",
-    "source_string": "The bot could not change the nickname. The required authorizations may be missing.",
-    "translation": "The bot could not change the nickname. The required authorizations may be missing.",
+    "source_string": "The bot could not change the nickname. The required permissions may be missing.",
+    "translation": "The bot could not change the nickname. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin nickname` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/nickname.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6265,8 +6265,8 @@
   },
   {
     "identifier": "commands.admin.nickname.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin nickname` when the user who ran the command lacks the required permission. Used in `commands/admin/nickname.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6281,8 +6281,8 @@
   },
   {
     "identifier": "commands.admin.nickname.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin nickname` when the bot lacks the required permission in this server. Used in `commands/admin/nickname.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6401,32 +6401,32 @@
   },
   {
     "identifier": "commands.admin.nuke.missingPermission.description",
-    "source_string": "You do not have the necessary authorizations to delete and recreate a channel.",
-    "translation": "You do not have the necessary authorizations to delete and recreate a channel.",
+    "source_string": "You do not have the necessary permissions to delete and recreate a channel.",
+    "translation": "You do not have the necessary permissions to delete and recreate a channel.",
     "context": "Description body of the reply embed for `/admin nuke` when the user who ran the command lacks the required permission. Used in `commands/admin/nuke.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.nuke.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin nuke` when the user who ran the command lacks the required permission. Used in `commands/admin/nuke.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.nuke.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to delete and recreate a channel.",
-    "translation": "The bot does not have the necessary authorizations to delete and recreate a channel.",
+    "source_string": "The bot does not have the necessary permissions to delete and recreate a channel.",
+    "translation": "The bot does not have the necessary permissions to delete and recreate a channel.",
     "context": "Description body of the reply embed for `/admin nuke` when the bot lacks the required permission in this server. Used in `commands/admin/nuke.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.nuke.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin nuke` when the bot lacks the required permission in this server. Used in `commands/admin/nuke.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6481,8 +6481,8 @@
   },
   {
     "identifier": "commands.admin.open_ticket.error.channelMissingPermission",
-    "source_string": "The bot does not have the required permissions to create a ticket. The bot requires the 'Send messages' authorization.",
-    "translation": "The bot does not have the required permissions to create a ticket. The bot requires the 'Send messages' authorization.",
+    "source_string": "The bot does not have the required permissions to create a ticket. The bot requires the 'Send messages' permission.",
+    "translation": "The bot does not have the required permissions to create a ticket. The bot requires the 'Send messages' permission.",
     "context": "User-visible message for `/admin open_ticket` (error) (channel Missing Permission). English: \"The bot does not have the required permissions to create a ticket. The bot requires the 'Send messages' authorization.\".",
     "labels": "commands",
     "max_length": null
@@ -6577,8 +6577,8 @@
   },
   {
     "identifier": "commands.admin.purge.forbidden.description",
-    "source_string": "The bot could not delete the messages. The required authorizations may be missing.",
-    "translation": "The bot could not delete the messages. The required authorizations may be missing.",
+    "source_string": "The bot could not delete the messages. The required permissions may be missing.",
+    "translation": "The bot could not delete the messages. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin purge` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/purge.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6617,8 +6617,8 @@
   },
   {
     "identifier": "commands.admin.purge.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin purge` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6633,8 +6633,8 @@
   },
   {
     "identifier": "commands.admin.purge.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin purge` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6681,8 +6681,8 @@
   },
   {
     "identifier": "commands.admin.remove_timeout.forbidden.description",
-    "source_string": "The bot could not cancel the timeout. The required authorizations may be missing.",
-    "translation": "The bot could not cancel the timeout. The required authorizations may be missing.",
+    "source_string": "The bot could not cancel the timeout. The required permissions may be missing.",
+    "translation": "The bot could not cancel the timeout. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin remove_timeout` when the bot lacks Discord permissions (discord.Forbidden).",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -6705,24 +6705,24 @@
   },
   {
     "identifier": "commands.admin.remove_timeout.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin remove_timeout` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.remove_timeout.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to cancel timeouts.",
-    "translation": "The bot does not have the necessary authorizations to cancel timeouts.",
+    "source_string": "The bot does not have the necessary permissions to cancel timeouts.",
+    "translation": "The bot does not have the necessary permissions to cancel timeouts.",
     "context": "Description body of the reply embed for `/admin remove_timeout` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.remove_timeout.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin remove_timeout` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -6809,8 +6809,8 @@
   },
   {
     "identifier": "commands.admin.removejointocreatechannel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin removejointocreatechannel` when the user who ran the command lacks the required permission. Used in `commands/admin/join_to_create/removejointocreatechannel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7145,32 +7145,32 @@
   },
   {
     "identifier": "commands.admin.reports.set_channel.missingPermission.description",
-    "source_string": "You do not have the required authorizations to set the report channel. You need `Administrator` authorizations.",
-    "translation": "You do not have the required authorizations to set the report channel. You need `Administrator` authorizations.",
+    "source_string": "You do not have the required permissions to set the report channel. You need `Administrator` permissions.",
+    "translation": "You do not have the required permissions to set the report channel. You need `Administrator` permissions.",
     "context": "Description body of the reply embed for `/admin reports` (set channel) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.reports.set_channel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin reports` (set channel) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.reports.set_channel.missingPermissionBot.description",
-    "source_string": "The bot does not have the required authorizations to set the report channel. The bot requires the 'Send messages' authorization.",
-    "translation": "The bot does not have the required authorizations to set the report channel. The bot requires the 'Send messages' authorization.",
+    "source_string": "The bot does not have the required permissions to set the report channel. The bot requires the 'Send messages' permission.",
+    "translation": "The bot does not have the required permissions to set the report channel. The bot requires the 'Send messages' permission.",
     "context": "Description body of the reply embed for `/admin reports` (set channel) when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.reports.set_channel.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin reports` (set channel) when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7201,16 +7201,16 @@
   },
   {
     "identifier": "commands.admin.reports.show_reports.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to see the warnings.",
-    "translation": "You need the 'Manage server' authorization to see the warnings.",
+    "source_string": "You need the 'Manage server' permission to see the warnings.",
+    "translation": "You need the 'Manage server' permission to see the warnings.",
     "context": "Description body of the reply embed for `/admin reports` (show reports) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.reports.show_reports.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin reports` (show reports) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7345,16 +7345,16 @@
   },
   {
     "identifier": "commands.admin.reports.unblock_reporter.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to execute this command.",
-    "translation": "You need the 'Manage server' authorization to execute this command.",
+    "source_string": "You need the 'Manage server' permission to execute this command.",
+    "translation": "You need the 'Manage server' permission to execute this command.",
     "context": "Description body of the reply embed for `/admin reports` (unblock reporter) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.reports.unblock_reporter.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin reports` (unblock reporter) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7417,24 +7417,24 @@
   },
   {
     "identifier": "commands.admin.say.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin say` when the user who ran the command lacks the required permission. Used in `commands/admin/say.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.say.missingPermissionBot.description",
-    "source_string": "The bot does not have the required authorizations to send messages in this channel.",
-    "translation": "The bot does not have the required authorizations to send messages in this channel.",
+    "source_string": "The bot does not have the required permissions to send messages in this channel.",
+    "translation": "The bot does not have the required permissions to send messages in this channel.",
     "context": "Description body of the reply embed for `/admin say` when the bot lacks the required permission in this server. Used in `commands/admin/say.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.say.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin say` when the bot lacks the required permission in this server. Used in `commands/admin/say.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7457,16 +7457,16 @@
   },
   {
     "identifier": "commands.admin.setLocale.missingPermission.description",
-    "source_string": "You do not have the necessary authorizations to change the language. You need the 'Manage server' authorization.",
-    "translation": "You do not have the necessary authorizations to change the language. You need the 'Manage server' authorization.",
+    "source_string": "You need the **Manage Server** permission to change the server locale.",
+    "translation": "You need the **Manage Server** permission to change the server locale.",
     "context": "Description body of the reply embed for `/admin setLocale` when the user who ran the command lacks the required permission. Used in `commands/admin/set_locale.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.setLocale.missingPermission.title",
-    "source_string": "Missing authorizations",
-    "translation": "Missing authorizations",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin setLocale` when the user who ran the command lacks the required permission. Used in `commands/admin/set_locale.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7545,8 +7545,8 @@
   },
   {
     "identifier": "commands.admin.slowmode.forbidden.description",
-    "source_string": "The bot could not change the slow mode. The required authorizations may be missing.",
-    "translation": "The bot could not change the slow mode. The required authorizations may be missing.",
+    "source_string": "The bot could not change the slow mode. The required permissions may be missing.",
+    "translation": "The bot could not change the slow mode. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin slowmode` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/slowmode.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -7577,32 +7577,32 @@
   },
   {
     "identifier": "commands.admin.slowmode.missingPermission.description",
-    "source_string": "You do not have the required authorizations to change the slow mode.",
-    "translation": "You do not have the required authorizations to change the slow mode.",
+    "source_string": "You do not have the required permissions to change the slow mode.",
+    "translation": "You do not have the required permissions to change the slow mode.",
     "context": "Description body of the reply embed for `/admin slowmode` when the user who ran the command lacks the required permission. Used in `commands/admin/slowmode.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.slowmode.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin slowmode` when the user who ran the command lacks the required permission. Used in `commands/admin/slowmode.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.slowmode.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to change the slow mode.",
-    "translation": "The bot does not have the necessary authorizations to change the slow mode.",
+    "source_string": "The bot does not have the necessary permissions to change the slow mode.",
+    "translation": "The bot does not have the necessary permissions to change the slow mode.",
     "context": "Description body of the reply embed for `/admin slowmode` when the bot lacks the required permission in this server. Used in `commands/admin/slowmode.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.slowmode.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin slowmode` when the bot lacks the required permission in this server. Used in `commands/admin/slowmode.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7665,8 +7665,8 @@
   },
   {
     "identifier": "commands.admin.timeout.forbidden.description",
-    "source_string": "The bot could not exclude the member. The required authorizations may be missing.",
-    "translation": "The bot could not exclude the member. The required authorizations may be missing.",
+    "source_string": "The bot could not exclude the member. The required permissions may be missing.",
+    "translation": "The bot could not exclude the member. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin timeout` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/timeout.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -7697,32 +7697,32 @@
   },
   {
     "identifier": "commands.admin.timeout.missingPermission.description",
-    "source_string": "You do not have the necessary authorizations to exclude members.",
-    "translation": "You do not have the necessary authorizations to exclude members.",
+    "source_string": "You do not have the necessary permissions to exclude members.",
+    "translation": "You do not have the necessary permissions to exclude members.",
     "context": "Description body of the reply embed for `/admin timeout` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.timeout.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin timeout` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.timeout.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to exclude members.",
-    "translation": "The bot does not have the necessary authorizations to exclude members.",
+    "source_string": "The bot does not have the necessary permissions to exclude members.",
+    "translation": "The bot does not have the necessary permissions to exclude members.",
     "context": "Description body of the reply embed for `/admin timeout` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.timeout.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin timeout` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7777,8 +7777,8 @@
   },
   {
     "identifier": "commands.admin.trigger_messages.add.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin trigger_messages` (add) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -7825,8 +7825,8 @@
   },
   {
     "identifier": "commands.admin.trigger_messages.configure.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin trigger_messages` (configure) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -8081,8 +8081,8 @@
   },
   {
     "identifier": "commands.admin.unban.forbidden.description",
-    "source_string": "The bot was unable to unban the member. The required authorizations may be missing.",
-    "translation": "The bot was unable to unban the member. The required authorizations may be missing.",
+    "source_string": "The bot was unable to unban the member. The required permissions may be missing.",
+    "translation": "The bot was unable to unban the member. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin unban` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/unban.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -8105,8 +8105,8 @@
   },
   {
     "identifier": "commands.admin.unban.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin unban` when the user who ran the command lacks the required permission. Used in `commands/admin/unban.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -8121,8 +8121,8 @@
   },
   {
     "identifier": "commands.admin.unban.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin unban` when the bot lacks the required permission in this server. Used in `commands/admin/unban.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -8169,8 +8169,8 @@
   },
   {
     "identifier": "commands.admin.unlock.channelUnlockedMessage",
-    "source_string": "🔓 This channel has been unblocked by a moderator. The original permissions have been restored.",
-    "translation": "🔓 This channel has been unblocked by a moderator. The original permissions have been restored.",
+    "source_string": "🔓 This channel has been unlocked by a moderator. The original permissions have been restored.",
+    "translation": "🔓 This channel has been unlocked by a moderator. The original permissions have been restored.",
     "context": "User-visible message for `/admin unlock` (channel Unlocked Message). English: \"🔓 This channel has been unblocked by a moderator. The original permissions have been restored.\". Used in `commands/admin/unlock.py`.",
     "labels": "commands",
     "max_length": null
@@ -8193,8 +8193,8 @@
   },
   {
     "identifier": "commands.admin.unlock.forbidden.description",
-    "source_string": "The bot was unable to unblock the channel. The required authorizations may be missing.",
-    "translation": "The bot was unable to unblock the channel. The required authorizations may be missing.",
+    "source_string": "The bot was unable to unblock the channel. The required permissions may be missing.",
+    "translation": "The bot was unable to unblock the channel. The required permissions may be missing.",
     "context": "Description body of the reply embed for `/admin unlock` when the bot lacks Discord permissions (discord.Forbidden). Used in `commands/admin/unlock.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -8209,40 +8209,40 @@
   },
   {
     "identifier": "commands.admin.unlock.missingPermission.description",
-    "source_string": "You do not have the required authorizations to unblock channels.",
-    "translation": "You do not have the required authorizations to unblock channels.",
+    "source_string": "You do not have the required permissions to unblock channels.",
+    "translation": "You do not have the required permissions to unblock channels.",
     "context": "Description body of the reply embed for `/admin unlock` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.unlock.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin unlock` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.unlock.missingPermissionBot.description",
-    "source_string": "The bot does not have the necessary authorizations to unblock channels.",
-    "translation": "The bot does not have the necessary authorizations to unblock channels.",
+    "source_string": "The bot does not have the necessary permissions to unblock channels.",
+    "translation": "The bot does not have the necessary permissions to unblock channels.",
     "context": "Description body of the reply embed for `/admin unlock` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.unlock.missingPermissionBot.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/admin unlock` when the bot lacks the required permission in this server.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.admin.unlock.notLocked.description",
-    "source_string": "The channel ${channel} is not blocked or no stored authorizations were found.",
-    "translation": "The channel ${channel} is not blocked or no stored authorizations were found.",
+    "source_string": "The channel ${channel} is not blocked or no stored permissions were found.",
+    "translation": "The channel ${channel} is not blocked or no stored permissions were found.",
     "context": "Description body of the reply embed for `/admin unlock` when the channel is not locked.",
     "labels": "commands, embed_description",
     "max_length": 4096
@@ -8257,8 +8257,8 @@
   },
   {
     "identifier": "commands.admin.unlock.success.description",
-    "source_string": "The channel ${channel} has been successfully unblocked and the original authorizations have been restored.",
-    "translation": "The channel ${channel} has been successfully unblocked and the original authorizations have been restored.",
+    "source_string": "The channel ${channel} has been successfully unblocked and the original permissions have been restored.",
+    "translation": "The channel ${channel} has been successfully unblocked and the original permissions have been restored.",
     "context": "Description body of the reply embed for `/admin unlock` when the command completed successfully. Used in `commands/admin/unlock.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
@@ -8345,16 +8345,16 @@
   },
   {
     "identifier": "commands.admin.viewwarns.missingPermission.description",
-    "source_string": "You need the authorization to kick members in order to display warnings.",
-    "translation": "You need the authorization to kick members in order to display warnings.",
+    "source_string": "You need the permission to kick members in order to display warnings.",
+    "translation": "You need the permission to kick members in order to display warnings.",
     "context": "Description body of the reply embed for `/admin viewwarns` when the user who ran the command lacks the required permission. Used in `commands/admin/viewwarns.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.viewwarns.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin viewwarns` when the user who ran the command lacks the required permission. Used in `commands/admin/viewwarns.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -8473,16 +8473,16 @@
   },
   {
     "identifier": "commands.admin.warn.missingPermission.description",
-    "source_string": "You need the authorization to kick members in order to perform this action.",
-    "translation": "You need the authorization to kick members in order to perform this action.",
+    "source_string": "You need the permission to kick members in order to perform this action.",
+    "translation": "You need the permission to kick members in order to perform this action.",
     "context": "Description body of the reply embed for `/admin warn` when the user who ran the command lacks the required permission. Used in `commands/admin/warn.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.admin.warn.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin warn` when the user who ran the command lacks the required permission. Used in `commands/admin/warn.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -8577,8 +8577,8 @@
   },
   {
     "identifier": "commands.admin.warnconfig.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/admin warnconfig` when the user who ran the command lacks the required permission. Used in `commands/admin/warnconfig.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -9081,24 +9081,24 @@
   },
   {
     "identifier": "commands.channel.dynamicslowmode.missingBotPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/channel dynamicslowmode` when the bot lacks a required permission. Used in `commands/channel/dynamicslowmode.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.channel.dynamicslowmode.missingPermission.description",
-    "source_string": "You do not have the necessary authorizations to use this command. You need the 'Manage channels' authorization.",
-    "translation": "You do not have the necessary authorizations to use this command. You need the 'Manage channels' authorization.",
+    "source_string": "You do not have the necessary permissions to use this command. You need the 'Manage channels' permission.",
+    "translation": "You do not have the necessary permissions to use this command. You need the 'Manage channels' permission.",
     "context": "Description body of the reply embed for `/channel dynamicslowmode` when the user who ran the command lacks the required permission. Used in `commands/channel/dynamicslowmode.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.channel.dynamicslowmode.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/channel dynamicslowmode` when the user who ran the command lacks the required permission. Used in `commands/channel/dynamicslowmode.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -9833,8 +9833,8 @@
   },
   {
     "identifier": "commands.games.hangman.failure.description",
-    "source_string": "You haven't guessed the word you were looking for in 11 attempts. Maybe you'll manage it next time! The word you were looking for was: ${word}\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
-    "translation": "You haven't guessed the word you were looking for in 11 attempts. Maybe you'll manage it next time! The word you were looking for was: ${word}\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "source_string": "You haven't guessed the correct word was in 11 attempts. Maybe you'll manage it next time! The correct word was was: ${word}\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "translation": "You haven't guessed the correct word was in 11 attempts. Maybe you'll manage it next time! The correct word was was: ${word}\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
     "context": "Description body of the reply embed for `/games hangman` when the operation failed. Used in `commands/games/hangman.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -9913,8 +9913,8 @@
   },
   {
     "identifier": "commands.games.hangman.success.description",
-    "source_string": "You have guessed the word you were looking for in ${guesses} attempts!\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
-    "translation": "You have guessed the word you were looking for in ${guesses} attempts!\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "source_string": "You have guessed the correct word was in ${guesses} attempts!\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "translation": "You have guessed the correct word was in ${guesses} attempts!\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
     "context": "Description body of the reply embed for `/games hangman` when the command completed successfully. Used in `commands/games/hangman.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
@@ -9937,8 +9937,8 @@
   },
   {
     "identifier": "commands.games.hangman.wrongGuess.description",
-    "source_string": "Try to guess the word in 11 attempts. Have fun!\nThat was not the word you were looking for.\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
-    "translation": "Try to guess the word in 11 attempts. Have fun!\nThat was not the word you were looking for.\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "source_string": "Try to guess the word in 11 attempts. Have fun!\nThat was not the correct word was.\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
+    "translation": "Try to guess the word in 11 attempts. Have fun!\nThat was not the correct word was.\n```\n${guessed_letters}\n\n${hanged_man}\n${used_letters}\n```",
     "context": "Description body of the reply embed for `/games hangman` (wrong Guess). Used in `commands/games/hangman.py`.",
     "labels": "commands, embed_description",
     "max_length": 4096
@@ -10105,8 +10105,8 @@
   },
   {
     "identifier": "commands.games.rps.rock",
-    "source_string": "Stone 🪨",
-    "translation": "Stone 🪨",
+    "source_string": "Rock 🪨",
+    "translation": "Rock 🪨",
     "context": "User-visible message for `/games rps` (rock). English: \"Stone 🪨\". Used in `commands/games/rps.py`.",
     "labels": "commands",
     "max_length": 80
@@ -10121,8 +10121,8 @@
   },
   {
     "identifier": "commands.games.rps.title",
-    "source_string": "Rock Scissors Paper",
-    "translation": "Rock Scissors Paper",
+    "source_string": "Rock, Paper, Scissors",
+    "translation": "Rock, Paper, Scissors",
     "context": "Title of a reply embed for `/games rps`. Used in `commands/games/rps.py`.",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -10337,8 +10337,8 @@
   },
   {
     "identifier": "commands.games.wordle.description",
-    "source_string": "Try to guess the word you are looking for in 6 attempts. Have fun!",
-    "translation": "Try to guess the word you are looking for in 6 attempts. Have fun!",
+    "source_string": "Guess the hidden word",
+    "translation": "Guess the hidden word",
     "context": "Description text for `/games wordle` (response embed or command help). English: \"Try to guess the word you are looking for in 6 attempts. Have fun!\". Used in `commands/games/wordle.py`.",
     "labels": "commands, description",
     "max_length": 100
@@ -10369,8 +10369,8 @@
   },
   {
     "identifier": "commands.games.wordle.failure.description",
-    "source_string": "You haven't guessed the word you were looking for in 6 attempts. Maybe you'll manage it next time! The word you were looking for was: ${word}",
-    "translation": "You haven't guessed the word you were looking for in 6 attempts. Maybe you'll manage it next time! The word you were looking for was: ${word}",
+    "source_string": "The correct word was **${word}**.",
+    "translation": "The correct word was **${word}**.",
     "context": "Description body of the reply embed for `/games wordle` when the operation failed. Used in `commands/games/wordle.py`.",
     "labels": "commands, embed_description, error",
     "max_length": 4096
@@ -10409,8 +10409,8 @@
   },
   {
     "identifier": "commands.games.wordle.initial.description",
-    "source_string": "Try to guess the word you are looking for in 6 attempts. Have fun!",
-    "translation": "Try to guess the word you are looking for in 6 attempts. Have fun!",
+    "source_string": "Try to guess the hidden word in 6 attempts. Have fun!",
+    "translation": "Try to guess the hidden word in 6 attempts. Have fun!",
     "context": "Description body of the reply embed for `/games wordle` when initial wizard or setup step. Used in `commands/games/wordle.py`.",
     "labels": "commands, embed_description",
     "max_length": 4096
@@ -10489,8 +10489,8 @@
   },
   {
     "identifier": "commands.games.wordle.success.description",
-    "source_string": "You have guessed the word you were looking for in ${guesses} attempts!",
-    "translation": "You have guessed the word you were looking for in ${guesses} attempts!",
+    "source_string": "You have guessed the correct word was in ${guesses} attempts!",
+    "translation": "You have guessed the correct word was in ${guesses} attempts!",
     "context": "Description body of the reply embed for `/games wordle` when the command completed successfully. Used in `commands/games/wordle.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
@@ -10529,16 +10529,16 @@
   },
   {
     "identifier": "commands.giveaway.add_blacklist_role.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to add roles to the blacklist.",
-    "translation": "You need the 'Manage server' authorization to add roles to the blacklist.",
+    "source_string": "You need the 'Manage server' permission to add roles to the blacklist.",
+    "translation": "You need the 'Manage server' permission to add roles to the blacklist.",
     "context": "Description body of the reply embed for `/giveaway add_blacklist_role` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.add_blacklist_role.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway add_blacklist_role` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -10593,16 +10593,16 @@
   },
   {
     "identifier": "commands.giveaway.add_blacklist_user.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to add users to the blacklist.",
-    "translation": "You need the 'Manage server' authorization to add users to the blacklist.",
+    "source_string": "You need the 'Manage server' permission to add users to the blacklist.",
+    "translation": "You need the 'Manage server' permission to add users to the blacklist.",
     "context": "Description body of the reply embed for `/giveaway add_blacklist_user` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.add_blacklist_user.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway add_blacklist_user` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -11369,8 +11369,8 @@
   },
   {
     "identifier": "commands.giveaway.editor.no_permission",
-    "source_string": "You do not have the required authorizations to edit competitions.",
-    "translation": "You do not have the required authorizations to edit competitions.",
+    "source_string": "You do not have the required permissions to edit competitions.",
+    "translation": "You do not have the required permissions to edit competitions.",
     "context": "User-visible message for `/giveaway editor` (no permission). English: \"You do not have the required authorizations to edit competitions.\".",
     "labels": "commands",
     "max_length": null
@@ -11465,32 +11465,32 @@
   },
   {
     "identifier": "commands.giveaway.end_giveaway.error.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to end competitions.",
-    "translation": "You need the 'Manage server' authorization to end competitions.",
+    "source_string": "You need the 'Manage server' permission to end competitions.",
+    "translation": "You need the 'Manage server' permission to end competitions.",
     "context": "Description body of the reply embed for `/giveaway end_giveaway` (error) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.end_giveaway.error.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway end_giveaway` (error) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.giveaway.end_giveaway.error.no_permission.description",
-    "source_string": "You need the 'Manage server' authorization to end competitions.",
-    "translation": "You need the 'Manage server' authorization to end competitions.",
+    "source_string": "You need the 'Manage server' permission to end competitions.",
+    "translation": "You need the 'Manage server' permission to end competitions.",
     "context": "Description body of the reply embed for `/giveaway end_giveaway` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.end_giveaway.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway end_giveaway` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -11873,16 +11873,16 @@
   },
   {
     "identifier": "commands.giveaway.list_blacklist.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to display the blacklist for competitions.",
-    "translation": "You need the 'Manage server' authorization to display the blacklist for competitions.",
+    "source_string": "You need the 'Manage server' permission to display the blacklist for competitions.",
+    "translation": "You need the 'Manage server' permission to display the blacklist for competitions.",
     "context": "Description body of the reply embed for `/giveaway list_blacklist` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.list_blacklist.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway list_blacklist` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -11929,16 +11929,16 @@
   },
   {
     "identifier": "commands.giveaway.remove_blacklist_role.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to remove roles from the blacklist.",
-    "translation": "You need the 'Manage server' authorization to remove roles from the blacklist.",
+    "source_string": "You need the 'Manage server' permission to remove roles from the blacklist.",
+    "translation": "You need the 'Manage server' permission to remove roles from the blacklist.",
     "context": "Description body of the reply embed for `/giveaway remove_blacklist_role` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.remove_blacklist_role.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway remove_blacklist_role` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -11977,16 +11977,16 @@
   },
   {
     "identifier": "commands.giveaway.remove_blacklist_user.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to remove users from the blacklist.",
-    "translation": "You need the 'Manage server' authorization to remove users from the blacklist.",
+    "source_string": "You need the 'Manage server' permission to remove users from the blacklist.",
+    "translation": "You need the 'Manage server' permission to remove users from the blacklist.",
     "context": "Description body of the reply embed for `/giveaway remove_blacklist_user` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.remove_blacklist_user.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway remove_blacklist_user` when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12025,16 +12025,16 @@
   },
   {
     "identifier": "commands.giveaway.reroll_giveaway.error.missingPermission.description",
-    "source_string": "You need the 'Manage server' authorization to redraw prize draws.",
-    "translation": "You need the 'Manage server' authorization to redraw prize draws.",
+    "source_string": "You need the 'Manage server' permission to redraw prize draws.",
+    "translation": "You need the 'Manage server' permission to redraw prize draws.",
     "context": "Description body of the reply embed for `/giveaway reroll_giveaway` (error) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.giveaway.reroll_giveaway.error.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/giveaway reroll_giveaway` (error) when the user who ran the command lacks the required permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12529,16 +12529,16 @@
   },
   {
     "identifier": "commands.level.addlevelrole.error.no_permission.description",
-    "source_string": "You need the 'Manage roles' authorization to add level roles.",
-    "translation": "You need the 'Manage roles' authorization to add level roles.",
+    "source_string": "You need the 'Manage roles' permission to add level roles.",
+    "translation": "You need the 'Manage roles' permission to add level roles.",
     "context": "Description body of the reply embed for `/level addlevelrole` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.addlevelrole.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level addlevelrole` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12601,8 +12601,8 @@
   },
   {
     "identifier": "commands.level.blacklist.add_channel.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (add channel error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12649,8 +12649,8 @@
   },
   {
     "identifier": "commands.level.blacklist.add_role.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (add role error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12681,8 +12681,8 @@
   },
   {
     "identifier": "commands.level.blacklist.add_user.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (add user error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12721,8 +12721,8 @@
   },
   {
     "identifier": "commands.level.blacklist.remove_channel.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (remove channel error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12753,8 +12753,8 @@
   },
   {
     "identifier": "commands.level.blacklist.remove_role.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (remove role error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12785,8 +12785,8 @@
   },
   {
     "identifier": "commands.level.blacklist.remove_user.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level blacklist` (remove user error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -12897,8 +12897,8 @@
   },
   {
     "identifier": "commands.level.boosts.add_role.success.title",
-    "source_string": "Roll boost added",
-    "translation": "Roll boost added",
+    "source_string": "Role boost added",
+    "translation": "Role boost added",
     "context": "Title of the reply embed for `/level boosts` (add role) when the command completed successfully.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -12993,8 +12993,8 @@
   },
   {
     "identifier": "commands.level.boosts.remove_role.success.title",
-    "source_string": "Roller boost removed",
-    "translation": "Roller boost removed",
+    "source_string": "Role boost removed",
+    "translation": "Role boost removed",
     "context": "Title of the reply embed for `/level boosts` (remove role) when the command completed successfully.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -13041,8 +13041,8 @@
   },
   {
     "identifier": "commands.level.boosts.show.roles",
-    "source_string": "Roller boosts",
-    "translation": "Roller boosts",
+    "source_string": "Role boosts",
+    "translation": "Role boosts",
     "context": "User-visible message for `/level boosts` (show) (roles). English: \"Roller boosts\". Used in `commands/level/level_boosts.py`.",
     "labels": "commands",
     "max_length": null
@@ -13089,8 +13089,8 @@
   },
   {
     "identifier": "commands.level.changelevelupmessage.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level changelevelupmessage` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13169,8 +13169,8 @@
   },
   {
     "identifier": "commands.level.changexpscaling.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level changexpscaling` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13377,8 +13377,8 @@
   },
   {
     "identifier": "commands.level.disablelevelsystem.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level disablelevelsystem` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13433,8 +13433,8 @@
   },
   {
     "identifier": "commands.level.disablelevelupmessage.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level disablelevelupmessage` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13505,8 +13505,8 @@
   },
   {
     "identifier": "commands.level.enablelevelsystem.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level enablelevelsystem` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13561,8 +13561,8 @@
   },
   {
     "identifier": "commands.level.enablelevelupmessage.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level enablelevelupmessage` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13617,16 +13617,16 @@
   },
   {
     "identifier": "commands.level.givexp.error.no_permission.description",
-    "source_string": "You need the 'Manage server' authorization to assign XP.",
-    "translation": "You need the 'Manage server' authorization to assign XP.",
+    "source_string": "You need the 'Manage server' permission to assign XP.",
+    "translation": "You need the 'Manage server' permission to assign XP.",
     "context": "Description body of the reply embed for `/level givexp` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.givexp.error.no_permission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level givexp` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13753,16 +13753,16 @@
   },
   {
     "identifier": "commands.level.removelevelrole.error.no_permission.description",
-    "source_string": "You need the 'Manage roles' authorization to remove level roles.",
-    "translation": "You need the 'Manage roles' authorization to remove level roles.",
+    "source_string": "You need the 'Manage roles' permission to remove level roles.",
+    "translation": "You need the 'Manage roles' permission to remove level roles.",
     "context": "Description body of the reply embed for `/level removelevelrole` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.removelevelrole.error.no_permission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level removelevelrole` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13873,8 +13873,8 @@
   },
   {
     "identifier": "commands.level.setlevelupchannel.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level setlevelupchannel` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -13961,8 +13961,8 @@
   },
   {
     "identifier": "commands.level.settextcooldown.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level settextcooldown` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14041,8 +14041,8 @@
   },
   {
     "identifier": "commands.level.setvoicecooldown.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level setvoicecooldown` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14105,16 +14105,16 @@
   },
   {
     "identifier": "commands.level.setxp.error.no_permission.description",
-    "source_string": "You need the 'Manage server' authorization to set XP.",
-    "translation": "You need the 'Manage server' authorization to set XP.",
+    "source_string": "You need the 'Manage server' permission to set XP.",
+    "translation": "You need the 'Manage server' permission to set XP.",
     "context": "Description body of the reply embed for `/level setxp` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.setxp.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level setxp` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14225,16 +14225,16 @@
   },
   {
     "identifier": "commands.level.showlevelroles.error.no_permission.description",
-    "source_string": "You need the 'Manage roles' authorization to display level roles.",
-    "translation": "You need the 'Manage roles' authorization to display level roles.",
+    "source_string": "You need the 'Manage roles' permission to display level roles.",
+    "translation": "You need the 'Manage roles' permission to display level roles.",
     "context": "Description body of the reply embed for `/level showlevelroles` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.showlevelroles.error.no_permission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level showlevelroles` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14297,16 +14297,16 @@
   },
   {
     "identifier": "commands.level.showlevelroles.remove_button",
-    "source_string": "Remove roll",
-    "translation": "Remove roll",
+    "source_string": "Remove role",
+    "translation": "Remove role",
     "context": "User-visible message for `/level showlevelroles` (remove button). English: \"Remove roll\".",
     "labels": "commands",
     "max_length": 80
   },
   {
     "identifier": "commands.level.showlevelroles.remove_role_cancelled",
-    "source_string": "Removal of the level roll(s) canceled.",
-    "translation": "Removal of the level roll(s) canceled.",
+    "source_string": "Removal of the level role(s) canceled.",
+    "translation": "Removal of the level role(s) canceled.",
     "context": "User-visible message for `/level showlevelroles` (remove role cancelled). English: \"Removal of the level roll(s) canceled.\".",
     "labels": "commands",
     "max_length": null
@@ -14449,16 +14449,16 @@
   },
   {
     "identifier": "commands.level.takexp.error.no_permission.description",
-    "source_string": "You need the 'Manage server' authorization to remove XP.",
-    "translation": "You need the 'Manage server' authorization to remove XP.",
+    "source_string": "You need the 'Manage server' permission to remove XP.",
+    "translation": "You need the 'Manage server' permission to remove XP.",
     "context": "Description body of the reply embed for `/level takexp` (error) when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.level.takexp.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/level takexp` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14673,16 +14673,16 @@
   },
   {
     "identifier": "commands.logs.blacklistChannel.missingPermission.description",
-    "source_string": "You do not have the required authorizations to ignore a channel for the logs. You need `Administrator` permissions.",
-    "translation": "You do not have the required authorizations to ignore a channel for the logs. You need `Administrator` permissions.",
+    "source_string": "You do not have the required permissions to ignore a channel for the logs. You need `Administrator` permissions.",
+    "translation": "You do not have the required permissions to ignore a channel for the logs. You need `Administrator` permissions.",
     "context": "Description body of the reply embed for `/logs blacklistChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_channel/blacklist_channel.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.logs.blacklistChannel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_channel/blacklist_channel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14785,8 +14785,8 @@
   },
   {
     "identifier": "commands.logs.blacklistListRole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistListRole` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_role/blacklist_list_role.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14801,8 +14801,8 @@
   },
   {
     "identifier": "commands.logs.blacklistListRole.title",
-    "source_string": "Roll blacklist",
-    "translation": "Roll blacklist",
+    "source_string": "Role blacklist",
+    "translation": "Role blacklist",
     "context": "Title of the reply embed for `/logs` (blacklist List Role). Used in `commands/logs/blacklist_role/blacklist_list_role.py`.",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -14825,8 +14825,8 @@
   },
   {
     "identifier": "commands.logs.blacklistListUser.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistListUser` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_user/blacklist_list_user.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -14953,16 +14953,16 @@
   },
   {
     "identifier": "commands.logs.blacklistRemoveChannel.missingPermission.description",
-    "source_string": "You do not have the required authorizations to stop ignoring a channel for the logs. You need `Administrator` permissions.",
-    "translation": "You do not have the required authorizations to stop ignoring a channel for the logs. You need `Administrator` permissions.",
+    "source_string": "You do not have the required permissions to stop ignoring a channel for the logs. You need `Administrator` permissions.",
+    "translation": "You do not have the required permissions to stop ignoring a channel for the logs. You need `Administrator` permissions.",
     "context": "Description body of the reply embed for `/logs blacklistRemoveChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_channel/blacklist_remove_channel.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.logs.blacklistRemoveChannel.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistRemoveChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_channel/blacklist_remove_channel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15009,8 +15009,8 @@
   },
   {
     "identifier": "commands.logs.blacklistRemoveRole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistRemoveRole` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_role/blacklist_remove_role.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15057,8 +15057,8 @@
   },
   {
     "identifier": "commands.logs.blacklistRemoveUser.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistRemoveUser` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_user/blacklist_remove_user.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15201,8 +15201,8 @@
   },
   {
     "identifier": "commands.logs.blacklistRole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistRole` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_role/blacklist_role.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15249,8 +15249,8 @@
   },
   {
     "identifier": "commands.logs.blacklistUser.missingPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs blacklistUser` when the user who ran the command lacks the required permission. Used in `commands/logs/blacklist_user/blacklist_user.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15617,8 +15617,8 @@
   },
   {
     "identifier": "commands.logs.removeLogChannel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs removeLogChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/remove_log_channel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -15673,32 +15673,32 @@
   },
   {
     "identifier": "commands.logs.setLogChannel.botMissingPermission.description",
-    "source_string": "The bot does not have the required authorizations to set the log channel. The bot requires the 'Send messages' authorization.",
-    "translation": "The bot does not have the required authorizations to set the log channel. The bot requires the 'Send messages' authorization.",
+    "source_string": "The bot does not have the required permissions to set the log channel. The bot requires the 'Send messages' permission.",
+    "translation": "The bot does not have the required permissions to set the log channel. The bot requires the 'Send messages' permission.",
     "context": "Description body of the reply embed for `/logs setLogChannel` (bot Missing Permission). Used in `commands/logs/set_log_channel.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.logs.setLogChannel.botMissingPermission.title",
-    "source_string": "Bot has missing authorization",
-    "translation": "Bot has missing authorization",
+    "source_string": "Bot has missing permissions",
+    "translation": "Bot has missing permissions",
     "context": "Title of the reply embed for `/logs setLogChannel` (bot Missing Permission). Used in `commands/logs/set_log_channel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.logs.setLogChannel.missingPermission.description",
-    "source_string": "You do not have the required authorizations to set the log channel. You need `Administrator` authorizations.",
-    "translation": "You do not have the required authorizations to set the log channel. You need `Administrator` authorizations.",
+    "source_string": "You do not have the required permissions to set the log channel. You need `Administrator` permissions.",
+    "translation": "You do not have the required permissions to set the log channel. You need `Administrator` permissions.",
     "context": "Description body of the reply embed for `/logs setLogChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/configure_logs.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.logs.setLogChannel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/logs setLogChannel` when the user who ran the command lacks the required permission. Used in `commands/logs/configure_logs.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -16585,8 +16585,8 @@
   },
   {
     "identifier": "commands.math.plotfunction.messages.no_permission",
-    "source_string": "You do not have authorization to perform this action",
-    "translation": "You do not have authorization to perform this action",
+    "source_string": "You do not have permission to perform this action",
+    "translation": "You do not have permission to perform this action",
     "context": "User-visible message for `/math plotfunction` (messages) (no permission). English: \"You do not have authorization to perform this action\".",
     "labels": "commands",
     "max_length": null
@@ -17073,8 +17073,8 @@
   },
   {
     "identifier": "commands.utility.autopublish.error.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility autopublish` (error) when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -17177,8 +17177,8 @@
   },
   {
     "identifier": "commands.utility.boosterchannelinfo.info.description",
-    "source_string": "Booster channels are special channels that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These channels are automatically deleted as soon as the booster no longer boosts the server.\nThe booster channel can be set using the setup command. The channel specified there serves as a template. Authorizations and all channel-specific settings are adopted from this for the new booster channel. Booster channels are placed above the template channel. Due to Discord, it can happen that the channel is not placed exactly above the template channel.",
-    "translation": "Booster channels are special channels that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These channels are automatically deleted as soon as the booster no longer boosts the server.\nThe booster channel can be set using the setup command. The channel specified there serves as a template. Authorizations and all channel-specific settings are adopted from this for the new booster channel. Booster channels are placed above the template channel. Due to Discord, it can happen that the channel is not placed exactly above the template channel.",
+    "source_string": "Permissions and settings are copied from the template channel.",
+    "translation": "Permissions and settings are copied from the template channel.",
     "context": "Description text for `/utility boosterchannelinfo` (info) (response embed or command help). English: \"Booster channels are special channels that a server booster can configure according to his/her wishes as soon as he/s…\". Used in `extensions/utility.py`.",
     "labels": "commands, description",
     "max_length": 4096
@@ -17193,16 +17193,16 @@
   },
   {
     "identifier": "commands.utility.boosterroleinfo.info.description",
-    "source_string": "Booster roles are special roles that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These roles are automatically deleted as soon as the booster no longer boosts the server.\nThe booster role can be set using the setup command. The role specified there serves as a template. Authorizations and all role-specific settings are adopted from this for the new booster role. Booster roles are placed above the template role. Due to Discord, it can happen that the role is not placed exactly above the template role.",
-    "translation": "Booster roles are special roles that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These roles are automatically deleted as soon as the booster no longer boosts the server.\nThe booster role can be set using the setup command. The role specified there serves as a template. Authorizations and all role-specific settings are adopted from this for the new booster role. Booster roles are placed above the template role. Due to Discord, it can happen that the role is not placed exactly above the template role.",
+    "source_string": "Booster roles are special roles that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These roles are automatically deleted as soon as the booster no longer boosts the server.\nThe booster role can be set using the setup command. The role specified there serves as a template. Permissions and all role-specific settings are adopted from this for the new booster role. Booster roles are placed above the template role. Due to Discord, it can happen that the role is not placed exactly above the template role.",
+    "translation": "Booster roles are special roles that a server booster can configure according to his/her wishes as soon as he/she boosts the server. These roles are automatically deleted as soon as the booster no longer boosts the server.\nThe booster role can be set using the setup command. The role specified there serves as a template. Permissions and all role-specific settings are adopted from this for the new booster role. Booster roles are placed above the template role. Due to Discord, it can happen that the role is not placed exactly above the template role.",
     "context": "Description text for `/utility boosterroleinfo` (info) (response embed or command help). English: \"Booster roles are special roles that a server booster can configure according to his/her wishes as soon as he/she boo…\". Used in `extensions/utility.py`.",
     "labels": "commands, description",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.boosterroleinfo.info.title",
-    "source_string": "What are booster rolls?",
-    "translation": "What are booster rolls?",
+    "source_string": "What are booster roles?",
+    "translation": "What are booster roles?",
     "context": "Title of a reply embed for `/utility boosterroleinfo` (info). Used in `extensions/utility.py`.",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -18905,8 +18905,8 @@
   },
   {
     "identifier": "commands.utility.claimboosterchannel.success.description",
-    "source_string": "The booster channel has been successfully used.",
-    "translation": "The booster channel has been successfully used.",
+    "source_string": "Booster channel successfully claimed.",
+    "translation": "Booster channel successfully claimed.",
     "context": "Description body of the reply embed for `/utility claimboosterchannel` when the command completed successfully. Used in `commands/utility/claim_booster_channel.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
@@ -18929,16 +18929,16 @@
   },
   {
     "identifier": "commands.utility.claimboosterrole.already_claimed.description",
-    "source_string": "You have already received the booster roll. Please wait until the role is automatically deleted.",
-    "translation": "You have already received the booster roll. Please wait until the role is automatically deleted.",
+    "source_string": "You have already claimed a booster role on this server.",
+    "translation": "You have already claimed a booster role on this server.",
     "context": "Description text for `/utility claimboosterrole` (already claimed) (response embed or command help). English: \"You have already received the booster roll. Please wait until the role is automatically deleted.\".",
     "labels": "commands, description",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.claimboosterrole.already_claimed.title",
-    "source_string": "Booster roll already received",
-    "translation": "Booster roll already received",
+    "source_string": "Booster role already received",
+    "translation": "Booster role already received",
     "context": "Title of a reply embed for `/utility claimboosterrole` (already claimed).",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -19001,24 +19001,24 @@
   },
   {
     "identifier": "commands.utility.claimboosterrole.role_not_found.description",
-    "source_string": "The booster roll was not found. It may have been deleted.",
-    "translation": "The booster roll was not found. It may have been deleted.",
+    "source_string": "The booster role was not found. It may have been deleted.",
+    "translation": "The booster role was not found. It may have been deleted.",
     "context": "Description text for `/utility claimboosterrole` (role not found) (response embed or command help). English: \"The booster roll was not found. It may have been deleted.\".",
     "labels": "commands, description",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.claimboosterrole.role_not_found.title",
-    "source_string": "Booster roll not found",
-    "translation": "Booster roll not found",
+    "source_string": "Booster role not found",
+    "translation": "Booster role not found",
     "context": "Title of a reply embed for `/utility claimboosterrole` (role not found).",
     "labels": "commands, embed_title",
     "max_length": 256
   },
   {
     "identifier": "commands.utility.claimboosterrole.success.description",
-    "source_string": "The booster role has been successfully received. \n-# In order to avoid possible undesirable influences on the role, it is not possible to edit the role subsequently via the bot. To do this, you must ask the server administrator for help.\nYou keep the role as long as you boost the server. As soon as you stop boosting the server, the role is automatically deleted.",
-    "translation": "The booster role has been successfully received. \n-# In order to avoid possible undesirable influences on the role, it is not possible to edit the role subsequently via the bot. To do this, you must ask the server administrator for help.\nYou keep the role as long as you boost the server. As soon as you stop boosting the server, the role is automatically deleted.",
+    "source_string": "Booster role successfully claimed.",
+    "translation": "Booster role successfully claimed.",
     "context": "Description body of the reply embed for `/utility claimboosterrole` when the command completed successfully. Used in `commands/utility/claim_booster_role.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
@@ -19097,8 +19097,8 @@
   },
   {
     "identifier": "commands.utility.deleteboosterrole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility deleteboosterrole` when the user who ran the command lacks the required permission. Used in `commands/utility/delete_booster_role.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -19121,16 +19121,16 @@
   },
   {
     "identifier": "commands.utility.deleteboosterrole.success.description",
-    "source_string": "The booster roll has been successfully deleted.",
-    "translation": "The booster roll has been successfully deleted.",
+    "source_string": "The booster role has been successfully deleted.",
+    "translation": "The booster role has been successfully deleted.",
     "context": "Description body of the reply embed for `/utility deleteboosterrole` when the command completed successfully. Used in `commands/utility/delete_booster_role.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.deleteboosterrole.success.title",
-    "source_string": "Booster roll successfully deleted",
-    "translation": "Booster roll successfully deleted",
+    "source_string": "Booster role successfully deleted",
+    "translation": "Booster role successfully deleted",
     "context": "Title of the reply embed for `/utility deleteboosterrole` when the command completed successfully. Used in `commands/utility/delete_booster_role.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -19345,8 +19345,8 @@
   },
   {
     "identifier": "commands.utility.listscheduled.error.not_authorized",
-    "source_string": "You do not have the authorization to see the scheduled messages.",
-    "translation": "You do not have the authorization to see the scheduled messages.",
+    "source_string": "You do not have the permission to see the scheduled messages.",
+    "translation": "You do not have the permission to see the scheduled messages.",
     "context": "User-visible message for `/utility listscheduled` (error) (not authorized). English: \"You do not have the authorization to see the scheduled messages.\".",
     "labels": "commands",
     "max_length": null
@@ -19713,8 +19713,8 @@
   },
   {
     "identifier": "commands.utility.report.no_permission.title",
-    "source_string": "No authorizations",
-    "translation": "No authorizations",
+    "source_string": "No permissions",
+    "translation": "No permissions",
     "context": "Title of the reply embed for `/utility report` when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -19889,16 +19889,16 @@
   },
   {
     "identifier": "commands.utility.reports.no_permission.description",
-    "source_string": "I would like to send the report, but this is not possible. I do not have the 'Send messages' authorization in the report channel set up by the server administrators. Please contact the server administrators so that they can set up the 'Send messages' authorization for me.",
-    "translation": "I would like to send the report, but this is not possible. I do not have the 'Send messages' authorization in the report channel set up by the server administrators. Please contact the server administrators so that they can set up the 'Send messages' authorization for me.",
+    "source_string": "I would like to send the report, but this is not possible. I do not have the 'Send messages' permission in the report channel set up by the server administrators. Please contact the server administrators so that they can set up the 'Send messages' permission for me.",
+    "translation": "I would like to send the report, but this is not possible. I do not have the 'Send messages' permission in the report channel set up by the server administrators. Please contact the server administrators so that they can set up the 'Send messages' permission for me.",
     "context": "Description body of the reply embed for `/utility reports` when the user lacks permission.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.reports.no_permission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility reports` when the user lacks permission.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20057,48 +20057,48 @@
   },
   {
     "identifier": "commands.utility.schedulemessage.noBotChannelPermission.description",
-    "source_string": "I need the 'Send messages' authorization to schedule messages in this channel.",
-    "translation": "I need the 'Send messages' authorization to schedule messages in this channel.",
+    "source_string": "I need the 'Send messages' permission to schedule messages in this channel.",
+    "translation": "I need the 'Send messages' permission to schedule messages in this channel.",
     "context": "Description body of the reply embed for `/utility schedulemessage` (no Bot Channel Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.schedulemessage.noBotChannelPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility schedulemessage` (no Bot Channel Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.utility.schedulemessage.noChannelPermission.description",
-    "source_string": "You need the 'Send messages' authorization to schedule messages in this channel.",
-    "translation": "You need the 'Send messages' authorization to schedule messages in this channel.",
+    "source_string": "You need the 'Send messages' permission to schedule messages in this channel.",
+    "translation": "You need the 'Send messages' permission to schedule messages in this channel.",
     "context": "Description body of the reply embed for `/utility schedulemessage` (no Channel Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.schedulemessage.noChannelPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility schedulemessage` (no Channel Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.utility.schedulemessage.noDMPermission.description",
-    "source_string": "You need the 'Send messages' authorization to schedule messages as direct messages.",
-    "translation": "You need the 'Send messages' authorization to schedule messages as direct messages.",
+    "source_string": "You need the 'Send messages' permission to schedule messages as direct messages.",
+    "translation": "You need the 'Send messages' permission to schedule messages as direct messages.",
     "context": "Description body of the reply embed for `/utility schedulemessage` (no DM Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.schedulemessage.noDMPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility schedulemessage` (no DM Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20113,8 +20113,8 @@
   },
   {
     "identifier": "commands.utility.schedulemessage.noRepeatPermission.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility schedulemessage` (no Repeat Permission). Used in `commands/utility/schedulemessage.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20201,8 +20201,8 @@
   },
   {
     "identifier": "commands.utility.setupboosterchannel.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility setupboosterchannel` when the user who ran the command lacks the required permission. Used in `commands/utility/setup_booster_channel.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20225,16 +20225,16 @@
   },
   {
     "identifier": "commands.utility.setupboosterrole.already_set.description",
-    "source_string": "The booster roll has already been set. Please delete the old booster role before setting a new one. \n-# It is not enough to delete the role, but you must execute the command to delete the booster role, even if the role no longer exists. The role does not necessarily have to be deleted.",
-    "translation": "The booster roll has already been set. Please delete the old booster role before setting a new one. \n-# It is not enough to delete the role, but you must execute the command to delete the booster role, even if the role no longer exists. The role does not necessarily have to be deleted.",
+    "source_string": "The booster role has already been set. Please delete the old booster role before setting a new one. \n-# It is not enough to delete the role, but you must execute the command to delete the booster role, even if the role no longer exists. The role does not necessarily have to be deleted.",
+    "translation": "The booster role has already been set. Please delete the old booster role before setting a new one. \n-# It is not enough to delete the role, but you must execute the command to delete the booster role, even if the role no longer exists. The role does not necessarily have to be deleted.",
     "context": "Description text for `/utility setupboosterrole` (already set) (response embed or command help). English: \"The booster roll has already been set. Please delete the old booster role before setting a new one.  -# It is not eno…\".",
     "labels": "commands, description",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.setupboosterrole.already_set.title",
-    "source_string": "Booster roll already set",
-    "translation": "Booster roll already set",
+    "source_string": "Booster role already set",
+    "translation": "Booster role already set",
     "context": "Title of a reply embed for `/utility setupboosterrole` (already set).",
     "labels": "commands, embed_title",
     "max_length": 256
@@ -20249,24 +20249,24 @@
   },
   {
     "identifier": "commands.utility.setupboosterrole.missingPermission.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility setupboosterrole` when the user who ran the command lacks the required permission. Used in `commands/utility/setup_booster_role.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
   },
   {
     "identifier": "commands.utility.setupboosterrole.success.description",
-    "source_string": "The booster roll has been successfully adjusted.",
-    "translation": "The booster roll has been successfully adjusted.",
+    "source_string": "The booster role has been successfully adjusted.",
+    "translation": "The booster role has been successfully adjusted.",
     "context": "Description body of the reply embed for `/utility setupboosterrole` when the command completed successfully. Used in `commands/utility/setup_booster_role.py`.",
     "labels": "commands, embed_description, success",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.setupboosterrole.success.title",
-    "source_string": "Booster roller set",
-    "translation": "Booster roller set",
+    "source_string": "Booster roleer set",
+    "translation": "Booster roleer set",
     "context": "Title of the reply embed for `/utility setupboosterrole` when the command completed successfully. Used in `commands/utility/setup_booster_role.py`.",
     "labels": "commands, embed_title, success",
     "max_length": 256
@@ -20321,16 +20321,16 @@
   },
   {
     "identifier": "commands.utility.twitch.addTwitchLiveNotification.errors.missingBotPermissions.description",
-    "source_string": "The bot requires the 'Send messages' and 'Embed links' authorization to perform this action.",
-    "translation": "The bot requires the 'Send messages' and 'Embed links' authorization to perform this action.",
+    "source_string": "The bot requires the 'Send messages' and 'Embed links' permission to perform this action.",
+    "translation": "The bot requires the 'Send messages' and 'Embed links' permission to perform this action.",
     "context": "Description body of the reply embed for `/utility twitch` (add Twitch Live Notification errors) (missing Bot Permissions).",
     "labels": "commands, embed_description, warning",
     "max_length": 4096
   },
   {
     "identifier": "commands.utility.twitch.addTwitchLiveNotification.errors.missingBotPermissions.title",
-    "source_string": "Missing bot authorization",
-    "translation": "Missing bot authorization",
+    "source_string": "Missing bot permission",
+    "translation": "Missing bot permission",
     "context": "Title of the reply embed for `/utility twitch` (add Twitch Live Notification errors) (missing Bot Permissions).",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20345,8 +20345,8 @@
   },
   {
     "identifier": "commands.utility.twitch.addTwitchLiveNotification.errors.missingPermissions.title",
-    "source_string": "Lack of authorization",
-    "translation": "Lack of authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility twitch` (add Twitch Live Notification errors) when required permissions are missing.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -20425,8 +20425,8 @@
   },
   {
     "identifier": "commands.utility.twitch.listTwitchLiveNotifications.error.missingPermissions.title",
-    "source_string": "Missing authorization",
-    "translation": "Missing authorization",
+    "source_string": "Missing permissions",
+    "translation": "Missing permissions",
     "context": "Title of the reply embed for `/utility twitch` (list Twitch Live Notifications error) when required permissions are missing. Used in `commands/utility/twitch/see_twitch_live_notifications.py`.",
     "labels": "commands, embed_title, warning",
     "max_length": 256
@@ -22681,8 +22681,8 @@
   },
   {
     "identifier": "errors.guildOnly.title",
-    "source_string": "Guild Only",
-    "translation": "Guild Only",
+    "source_string": "Server only",
+    "translation": "Server only",
     "context": "Title of the global guild Only error embed (shown by the error handler, not one command). Used in `commands/utility/autopublish.py`.",
     "labels": "errors, embed_title",
     "max_length": 256
@@ -22729,8 +22729,8 @@
   },
   {
     "identifier": "errors.http.title",
-    "source_string": "Discord API Error",
-    "translation": "Discord API Error",
+    "source_string": "Discord API error",
+    "translation": "Discord API error",
     "context": "Title of the global http error embed (shown by the error handler, not one command).",
     "labels": "errors, embed_title",
     "max_length": 256
@@ -24121,8 +24121,8 @@
   },
   {
     "identifier": "games.rps.name",
-    "source_string": "scissors_stone_paper",
-    "translation": "scissors_stone_paper",
+    "source_string": "rock_paper_scissors",
+    "translation": "rock_paper_scissors",
     "context": "Display name (games.rps). Used in `extensions/games.py`.",
     "labels": "",
     "max_length": 32
@@ -24385,11 +24385,11 @@
   },
   {
     "identifier": "games.memory.description",
-    "source_string": "play_a_memory_matching_game",
-    "translation": "play_a_memory_matching_game",
+    "source_string": "Play a memory matching game",
+    "translation": "Play a memory matching game",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Play a memory matching game\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "games.memory.name",
@@ -24401,11 +24401,11 @@
   },
   {
     "identifier": "games.memory.params.user.description",
-    "source_string": "the_user_to_play_against",
-    "translation": "the_user_to_play_against",
+    "source_string": "The user to play against",
+    "translation": "The user to play against",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The user to play against\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "giveaway.bl.add.role.description",
@@ -24753,8 +24753,8 @@
   },
   {
     "identifier": "help",
-    "source_string": "help",
-    "translation": "help",
+    "source_string": "Help",
+    "translation": "Help",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Help\".",
     "labels": "command_name",
     "max_length": 32
@@ -26049,8 +26049,8 @@
   },
   {
     "identifier": "level.boosts.removerole.params.role.description",
-    "source_string": "The roll from which the boost is to be removed",
-    "translation": "The roll from which the boost is to be removed",
+    "source_string": "The role from which the boost is to be removed",
+    "translation": "The role from which the boost is to be removed",
     "context": "Help text describing the `role` option on `/level boosts` (shown when the user focuses that option). Used in `extensions/level.py`.",
     "labels": "leveling, command_option_description",
     "max_length": 100
@@ -26401,8 +26401,8 @@
   },
   {
     "identifier": "level.removelevelrole.params.level.description",
-    "source_string": "The level from which the roll is to be removed",
-    "translation": "The level from which the roll is to be removed",
+    "source_string": "The level from which the role is to be removed",
+    "translation": "The level from which the role is to be removed",
     "context": "Help text describing the `level` option on `/level removelevelrole` (shown when the user focuses that option).",
     "labels": "leveling, command_option_description",
     "max_length": 100
@@ -26417,8 +26417,8 @@
   },
   {
     "identifier": "level.removelevelrole.params.role.description",
-    "source_string": "The roll that is to be removed",
-    "translation": "The roll that is to be removed",
+    "source_string": "The role that is to be removed",
+    "translation": "The role that is to be removed",
     "context": "Help text describing the `role` option on `/level removelevelrole` (shown when the user focuses that option). Used in `extensions/level.py`.",
     "labels": "leveling, command_option_description",
     "max_length": 100
@@ -26889,8 +26889,8 @@
   },
   {
     "identifier": "logs.automodRuleCreate.allow_list",
-    "source_string": "Allowed list:\n${allow_list}",
-    "translation": "Allowed list:\n${allow_list}",
+    "source_string": "Allowlist:\n${allow_list}",
+    "translation": "Allowlist:\n${allow_list}",
     "context": "Logging feature copy: automod Rule Create.allow list.",
     "labels": "logs",
     "max_length": null
@@ -26921,8 +26921,8 @@
   },
   {
     "identifier": "logs.automodRuleCreate.enabled",
-    "source_string": "Activated: ${enabled}",
-    "translation": "Activated: ${enabled}",
+    "source_string": "Enabled: ${enabled}",
+    "translation": "Enabled: ${enabled}",
     "context": "Logging feature copy: automod Rule Create.enabled. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -26977,16 +26977,16 @@
   },
   {
     "identifier": "logs.automodRuleCreate.presets",
-    "source_string": "Templates:\n- Obscenity filter: ${profanityFilter}\n- Sexual content filter: ${sexualContentFilter}\n- Offense filter: ${slurFilter}",
-    "translation": "Templates:\n- Obscenity filter: ${profanityFilter}\n- Sexual content filter: ${sexualContentFilter}\n- Offense filter: ${slurFilter}",
+    "source_string": "Presets — Profanity: ${profanityFilter}, Sexual content: ${sexualContentFilter}, Slurs: ${slurFilter}",
+    "translation": "Presets — Profanity: ${profanityFilter}, Sexual content: ${sexualContentFilter}, Slurs: ${slurFilter}",
     "context": "Logging feature copy: automod Rule Create.presets. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.automodRuleCreate.regexPatterns",
-    "source_string": "Regex pattern:\n`${regexPatterns}`",
-    "translation": "Regex pattern:\n`${regexPatterns}`",
+    "source_string": "Regex patterns:\n`${regexPatterns}`",
+    "translation": "Regex patterns:\n`${regexPatterns}`",
     "context": "Logging feature copy: automod Rule Create.regex Patterns. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -27081,8 +27081,8 @@
   },
   {
     "identifier": "logs.automodRuleDelete.deleted_by",
-    "source_string": "Deleted from ${deleter}",
-    "translation": "Deleted from ${deleter}",
+    "source_string": "Deleted by ${deleter}",
+    "translation": "Deleted by ${deleter}",
     "context": "Logging feature copy: automod Rule Delete.deleted by.",
     "labels": "logs",
     "max_length": null
@@ -27113,8 +27113,8 @@
   },
   {
     "identifier": "logs.automodRuleUpdate.updated_by",
-    "source_string": "Updated from ${updater}",
-    "translation": "Updated from ${updater}",
+    "source_string": "Updated by ${updater}",
+    "translation": "Updated by ${updater}",
     "context": "Logging feature copy: automod Rule Update.updated by.",
     "labels": "logs",
     "max_length": null
@@ -27133,7 +27133,7 @@
     "translation": "blacklist",
     "context": "Logging feature copy: blacklist. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistc.add.description",
@@ -27149,7 +27149,7 @@
     "translation": "add",
     "context": "Logging feature copy: blacklistc.add. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistc.add.params.channel.description",
@@ -27173,7 +27173,7 @@
     "translation": "blacklist",
     "context": "Logging feature copy: blacklistc.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistc.remove.description",
@@ -27189,7 +27189,7 @@
     "translation": "remove",
     "context": "Logging feature copy: blacklistc.remove. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistc.remove.params.channel.description",
@@ -27213,7 +27213,7 @@
     "translation": "show",
     "context": "Logging feature copy: blacklistc.show. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistr.add.description",
@@ -27229,7 +27229,7 @@
     "translation": "add",
     "context": "Logging feature copy: blacklistr.add. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistr.add.params.role.description",
@@ -27253,7 +27253,7 @@
     "translation": "roles_blacklist",
     "context": "Logging feature copy: blacklistr. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistr.remove.description",
@@ -27269,7 +27269,7 @@
     "translation": "remove",
     "context": "Logging feature copy: blacklistr.remove. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistr.remove.params.role.description",
@@ -27293,7 +27293,7 @@
     "translation": "show",
     "context": "Logging feature copy: blacklistr.show. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistu.add.description",
@@ -27309,7 +27309,7 @@
     "translation": "add",
     "context": "Logging feature copy: blacklistu.add. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistu.add.params.user.description",
@@ -27333,7 +27333,7 @@
     "translation": "user_blacklist",
     "context": "Logging feature copy: blacklistu. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistu.remove.description",
@@ -27349,7 +27349,7 @@
     "translation": "remove",
     "context": "Logging feature copy: blacklistu.remove. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistu.remove.params.user.description",
@@ -27373,7 +27373,7 @@
     "translation": "show",
     "context": "Logging feature copy: blacklistu.show. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.configure.description",
@@ -27433,16 +27433,16 @@
   },
   {
     "identifier": "logs.guildChannelCreate.permissionOverwriteAllowed",
-    "source_string": "✅ Permitted: ${permissions}",
-    "translation": "✅ Permitted: ${permissions}",
+    "source_string": "Allowed: ${permissions}",
+    "translation": "Allowed: ${permissions}",
     "context": "Logging feature copy: guild Channel Create.permission Overwrite Allowed.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.guildChannelCreate.permissionOverwriteDenied",
-    "source_string": "❌ Refused: ${permissions}",
-    "translation": "❌ Refused: ${permissions}",
+    "source_string": "Denied: ${permissions}",
+    "translation": "Denied: ${permissions}",
     "context": "Logging feature copy: guild Channel Create.permission Overwrite Denied.",
     "labels": "logs",
     "max_length": null
@@ -27465,8 +27465,8 @@
   },
   {
     "identifier": "logs.guildChannelCreate.permissionOverwrites",
-    "source_string": "Authorizations:",
-    "translation": "Authorizations:",
+    "source_string": "Permissions:",
+    "translation": "Permissions:",
     "context": "Logging feature copy: guild Channel Create.permission Overwrites.",
     "labels": "logs",
     "max_length": null
@@ -27513,8 +27513,8 @@
   },
   {
     "identifier": "logs.guildChannelCreate.types.news",
-    "source_string": "News channel",
-    "translation": "News channel",
+    "source_string": "Announcement channel",
+    "translation": "Announcement channel",
     "context": "Logging feature copy: guild Channel Create.types.news.",
     "labels": "logs",
     "max_length": null
@@ -27561,8 +27561,8 @@
   },
   {
     "identifier": "logs.guildChannelDelete.deleted_by",
-    "source_string": "Deleted from ${deleter}",
-    "translation": "Deleted from ${deleter}",
+    "source_string": "Deleted by ${deleter}",
+    "translation": "Deleted by ${deleter}",
     "context": "Logging feature copy: guild Channel Delete.deleted by.",
     "labels": "logs",
     "max_length": null
@@ -27577,16 +27577,16 @@
   },
   {
     "identifier": "logs.guildChannelDelete.permissionOverwriteAllowed",
-    "source_string": "✅ Permitted: ${permissions}",
-    "translation": "✅ Permitted: ${permissions}",
+    "source_string": "Allowed: ${permissions}",
+    "translation": "Allowed: ${permissions}",
     "context": "Logging feature copy: guild Channel Delete.permission Overwrite Allowed.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.guildChannelDelete.permissionOverwriteDenied",
-    "source_string": "❌ Refused: ${permissions}",
-    "translation": "❌ Refused: ${permissions}",
+    "source_string": "Denied: ${permissions}",
+    "translation": "Denied: ${permissions}",
     "context": "Logging feature copy: guild Channel Delete.permission Overwrite Denied.",
     "labels": "logs",
     "max_length": null
@@ -27609,8 +27609,8 @@
   },
   {
     "identifier": "logs.guildChannelDelete.permissionOverwrites",
-    "source_string": "Authorizations:",
-    "translation": "Authorizations:",
+    "source_string": "Permissions:",
+    "translation": "Permissions:",
     "context": "Logging feature copy: guild Channel Delete.permission Overwrites.",
     "labels": "logs",
     "max_length": null
@@ -27717,7 +27717,7 @@
     "translation": "Name changed: \n<:empty:1312126155897442416>Before: ${before}\n<:empty:1312126155897442416>After: ${after}",
     "context": "Logging feature copy: guild Channel Update.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.guildChannelUpdate.no",
@@ -27761,24 +27761,24 @@
   },
   {
     "identifier": "logs.guildChannelUpdate.permissionOverwriteAllowed",
-    "source_string": "✅ Permitted: ${permissions}",
-    "translation": "✅ Permitted: ${permissions}",
+    "source_string": "Allowed: ${permissions}",
+    "translation": "Allowed: ${permissions}",
     "context": "Logging feature copy: guild Channel Update.permission Overwrite Allowed.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.guildChannelUpdate.permissionOverwriteDenied",
-    "source_string": "❌ Refused: ${permissions}",
-    "translation": "❌ Refused: ${permissions}",
+    "source_string": "Denied: ${permissions}",
+    "translation": "Denied: ${permissions}",
     "context": "Logging feature copy: guild Channel Update.permission Overwrite Denied.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.guildChannelUpdate.permissionOverwriteModified",
-    "source_string": "Authorizations changed for ${target}:",
-    "translation": "Authorizations changed for ${target}:",
+    "source_string": "Permissions for ${target}:",
+    "translation": "Permissions for ${target}:",
     "context": "Logging feature copy: guild Channel Update.permission Overwrite Modified.",
     "labels": "logs",
     "max_length": null
@@ -27793,8 +27793,8 @@
   },
   {
     "identifier": "logs.guildChannelUpdate.permissionOverwriteNew",
-    "source_string": "New authorization overrides",
-    "translation": "New authorization overrides",
+    "source_string": "New permission overrides",
+    "translation": "New permission overrides",
     "context": "Logging feature copy: guild Channel Update.permission Overwrite New.",
     "labels": "logs",
     "max_length": null
@@ -27841,8 +27841,8 @@
   },
   {
     "identifier": "logs.guildChannelUpdate.permissionOverwrites",
-    "source_string": "Authorizations:",
-    "translation": "Authorizations:",
+    "source_string": "Permissions:",
+    "translation": "Permissions:",
     "context": "Logging feature copy: guild Channel Update.permission Overwrites.",
     "labels": "logs",
     "max_length": null
@@ -27921,8 +27921,8 @@
   },
   {
     "identifier": "logs.guildChannelUpdate.updated_by",
-    "source_string": "Updated from ${updater}",
-    "translation": "Updated from ${updater}",
+    "source_string": "Updated by ${updater}",
+    "translation": "Updated by ${updater}",
     "context": "Logging feature copy: guild Channel Update.updated by.",
     "labels": "logs",
     "max_length": null
@@ -27993,8 +27993,8 @@
   },
   {
     "identifier": "logs.guildRoleCreate.permissions",
-    "source_string": "Authorizations: ${permissions}",
-    "translation": "Authorizations: ${permissions}",
+    "source_string": "Permissions:\n${permissions}",
+    "translation": "Permissions:\n${permissions}",
     "context": "Logging feature copy: guild Role Create.permissions. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -28025,8 +28025,8 @@
   },
   {
     "identifier": "logs.guildRoleDelete.permissions",
-    "source_string": "Authorizations: ${permissions}",
-    "translation": "Authorizations: ${permissions}",
+    "source_string": "Permissions: ${permissions}",
+    "translation": "Permissions: ${permissions}",
     "context": "Logging feature copy: guild Role Delete.permissions. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -28041,8 +28041,8 @@
   },
   {
     "identifier": "logs.guildRoleUpdate.addedPermissions",
-    "source_string": "Added authorizations:\n${permissions}",
-    "translation": "Added authorizations:\n${permissions}",
+    "source_string": "Added permissions:\n${permissions}",
+    "translation": "Added permissions:\n${permissions}",
     "context": "Logging feature copy: guild Role Update.added Permissions. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -28129,8 +28129,8 @@
   },
   {
     "identifier": "logs.guildRoleUpdate.removedPermissions",
-    "source_string": "Remote authorizations:\n${permissions}",
-    "translation": "Remote authorizations:\n${permissions}",
+    "source_string": "Removed permissions:\n${permissions}",
+    "translation": "Removed permissions:\n${permissions}",
     "context": "Logging feature copy: guild Role Update.removed Permissions. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -28257,8 +28257,8 @@
   },
   {
     "identifier": "logs.guildUpdate.explicitContentFilter",
-    "source_string": "Explicit content Filter: \n<:empty:1312126155897442416>Before: ${before}\n<:empty:1312126155897442416>After: ${after}",
-    "translation": "Explicit content Filter: \n<:empty:1312126155897442416>Before: ${before}\n<:empty:1312126155897442416>After: ${after}",
+    "source_string": "Explicit content filter: ${before} → ${after}",
+    "translation": "Explicit content filter: ${before} → ${after}",
     "context": "Logging feature copy: guild Update.explicit Content Filter. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -28321,8 +28321,8 @@
   },
   {
     "identifier": "logs.guildUpdate.featuresLocales.APPLICATION_COMMAND_PERMISSIONS_V2",
-    "source_string": "Application commands Authorizations v2",
-    "translation": "Application commands Authorizations v2",
+    "source_string": "Application command permissions v2",
+    "translation": "Application command permissions v2",
     "context": "Logging feature copy: guild Update.features Locales.APPLICATION COMMAND PERMISSIONS V2.",
     "labels": "logs",
     "max_length": null
@@ -28433,8 +28433,8 @@
   },
   {
     "identifier": "logs.guildUpdate.featuresLocales.NEWS",
-    "source_string": "News",
-    "translation": "News",
+    "source_string": "Announcement channels",
+    "translation": "Announcement channels",
     "context": "Logging feature copy: guild Update.features Locales.NEWS.",
     "labels": "logs",
     "max_length": null
@@ -28473,8 +28473,8 @@
   },
   {
     "identifier": "logs.guildUpdate.featuresLocales.ROLE_SUBSCRIPTIONS_AVAILABLE_FOR_PURCHASE",
-    "source_string": "Roll subscriptions available for purchase",
-    "translation": "Roll subscriptions available for purchase",
+    "source_string": "Role subscriptions available for purchase",
+    "translation": "Role subscriptions available for purchase",
     "context": "Logging feature copy: guild Update.features Locales.ROLE SUBSCRIPTIONS AVAILABLE FOR PURCHASE.",
     "labels": "logs",
     "max_length": null
@@ -28993,8 +28993,8 @@
   },
   {
     "identifier": "logs.guildUpdate.removedFeatures",
-    "source_string": "Remote functions:\n${removed_features}",
-    "translation": "Remote functions:\n${removed_features}",
+    "source_string": "Removed features:\n${removed_features}",
+    "translation": "Removed features:\n${removed_features}",
     "context": "Logging feature copy: guild Update.removed Features. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -29121,8 +29121,8 @@
   },
   {
     "identifier": "logs.guild_channelCreate.permissionOverwrites",
-    "source_string": "Authorizations:",
-    "translation": "Authorizations:",
+    "source_string": "Permissions:",
+    "translation": "Permissions:",
     "context": "Logging feature copy: guild channel Create.permission Overwrites.",
     "labels": "logs",
     "max_length": null
@@ -29217,8 +29217,8 @@
   },
   {
     "identifier": "logs.guild_channelDelete.permissionOverwrites",
-    "source_string": "Authorizations:",
-    "translation": "Authorizations:",
+    "source_string": "Permissions:",
+    "translation": "Permissions:",
     "context": "Logging feature copy: guild channel Delete.permission Overwrites.",
     "labels": "logs",
     "max_length": null
@@ -29641,8 +29641,8 @@
   },
   {
     "identifier": "logs.memberRemove.name",
-    "source_string": "Leave member: ${left}",
-    "translation": "Leave member: ${left}",
+    "source_string": "Member left: ${left}",
+    "translation": "Member left: ${left}",
     "context": "Logging feature copy: member Remove. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": 32
@@ -29657,16 +29657,16 @@
   },
   {
     "identifier": "logs.memberRemove.title",
-    "source_string": "Leave member",
-    "translation": "Leave member",
-    "context": "Title for a server logging / audit-log UI related to .",
+    "source_string": "Member left",
+    "translation": "Member left",
+    "context": "Embed title when a member leaves the server. Used in extensions/logs.py.",
     "labels": "logs, embed_title",
     "max_length": 256
   },
   {
     "identifier": "logs.memberUnban.name",
-    "source_string": "Banned member: ${user}",
-    "translation": "Banned member: ${user}",
+    "source_string": "Unbanned member: ${user}",
+    "translation": "Unbanned member: ${user}",
     "context": "Logging feature copy: member Unban. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": 32
@@ -29681,8 +29681,8 @@
   },
   {
     "identifier": "logs.memberUnban.unbanned_by",
-    "source_string": "Banished by: ${unbanned_by}",
-    "translation": "Banished by: ${unbanned_by}",
+    "source_string": "Unbanned by: ${unbanned_by}",
+    "translation": "Unbanned by: ${unbanned_by}",
     "context": "Logging feature copy: member Unban.unbanned by.",
     "labels": "logs",
     "max_length": null
@@ -29745,16 +29745,16 @@
   },
   {
     "identifier": "logs.memberUpdate.pending",
-    "source_string": "The user is now verified",
-    "translation": "The user is now verified",
+    "source_string": "Completed membership screening",
+    "translation": "Completed membership screening",
     "context": "Logging feature copy: member Update.pending. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.memberUpdate.pendingRemoved",
-    "source_string": "The user is no longer verified",
-    "translation": "The user is no longer verified",
+    "source_string": "Membership screening reverted",
+    "translation": "Membership screening reverted",
     "context": "Logging feature copy: member Update.pending Removed. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -29769,8 +29769,8 @@
   },
   {
     "identifier": "logs.memberUpdate.timeout",
-    "source_string": "Was sent to timeout until: <t:${timeout}:R>\n",
-    "translation": "Was sent to timeout until: <t:${timeout}:R>\n",
+    "source_string": "Timed out until: ${timeout}",
+    "translation": "Timed out until: ${timeout}",
     "context": "Logging feature copy: member Update.timeout. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -29801,9 +29801,9 @@
   },
   {
     "identifier": "logs.messageDelete.content",
-    "source_string": "News content: \n${content}",
-    "translation": "News content: \n${content}",
-    "context": "Logging feature copy: message Delete. Used in `extensions/logs.py`.",
+    "source_string": "Message content:\n${content}",
+    "translation": "Message content:\n${content}",
+    "context": "Embed line showing deleted message body. Used in extensions/logs.py on_message_delete.",
     "labels": "logs",
     "max_length": null
   },
@@ -29817,19 +29817,19 @@
   },
   {
     "identifier": "logs.messageDelete.embeds",
-    "source_string": "The message contained embeds. They can be found under this log entry",
-    "translation": "The message contained embeds. They can be found under this log entry",
+    "source_string": "The message contained embeds. They can be found in the following message(s).",
+    "translation": "The message contained embeds. They can be found in the following message(s).",
     "context": "Logging feature copy: message Delete.embeds. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.messageDelete.name",
-    "source_string": "A message from ${user} was deleted from the ${channel} channel",
-    "translation": "A message from ${user} was deleted from the ${channel} channel",
+    "source_string": "A message by ${user} was deleted in ${channel}",
+    "translation": "A message by ${user} was deleted in ${channel}",
     "context": "Logging feature copy: message Delete. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.messageDelete.title",
@@ -29897,11 +29897,11 @@
   },
   {
     "identifier": "logs.messageEdit.name",
-    "source_string": "Message edited by ${user}\n[To the message](${url})",
-    "translation": "Message edited by ${user}\n[To the message](${url})",
+    "source_string": "Message edited by ${user}\n[Jump to message](${url})",
+    "translation": "Message edited by ${user}\n[Jump to message](${url})",
     "context": "Logging feature copy: message Edit. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.messageEdit.removedAttachments",
@@ -29921,8 +29921,8 @@
   },
   {
     "identifier": "logs.messageEdit.tooLongNotice",
-    "source_string": "The message is very long. To keep the logs clean, the message content has been uploaded to Hastbin. To view the content, click [here](${url}).",
-    "translation": "The message is very long. To keep the logs clean, the message content has been uploaded to Hastbin. To view the content, click [here](${url}).",
+    "source_string": "The message was too long to display. The full diff was uploaded to Hastebin.",
+    "translation": "The message was too long to display. The full diff was uploaded to Hastebin.",
     "context": "Logging feature copy: message Edit.too Long Notice. Used in `extensions/logs.py`.",
     "labels": "logs",
     "max_length": null
@@ -29969,8 +29969,8 @@
   },
   {
     "identifier": "logs.permissions.add_reaction",
-    "source_string": "Reaction added",
-    "translation": "Reaction added",
+    "source_string": "Add reactions",
+    "translation": "Add reactions",
     "context": "Logging feature copy: permissions.add reaction.",
     "labels": "logs",
     "max_length": 32
@@ -29993,16 +29993,16 @@
   },
   {
     "identifier": "logs.permissions.attach_files",
-    "source_string": "Files attached",
-    "translation": "Files attached",
+    "source_string": "Attach files",
+    "translation": "Attach files",
     "context": "Logging feature copy: permissions.attach files.",
     "labels": "logs",
     "max_length": 32
   },
   {
     "identifier": "logs.permissions.ban_members",
-    "source_string": "Block members",
-    "translation": "Block members",
+    "source_string": "Ban members",
+    "translation": "Ban members",
     "context": "Logging feature copy: permissions.ban members.",
     "labels": "logs",
     "max_length": 32
@@ -30049,8 +30049,8 @@
   },
   {
     "identifier": "logs.permissions.create_polls",
-    "source_string": "Create surveys",
-    "translation": "Create surveys",
+    "source_string": "Create polls",
+    "translation": "Create polls",
     "context": "Logging feature copy: permissions.create polls.",
     "labels": "logs",
     "max_length": 32
@@ -30073,16 +30073,16 @@
   },
   {
     "identifier": "logs.permissions.deafen_members",
-    "source_string": "Mute members",
-    "translation": "Mute members",
+    "source_string": "Deafen members",
+    "translation": "Deafen members",
     "context": "Logging feature copy: permissions.deafen members.",
     "labels": "logs",
     "max_length": 32
   },
   {
     "identifier": "logs.permissions.embed_links",
-    "source_string": "Insert links",
-    "translation": "Insert links",
+    "source_string": "Embed links",
+    "translation": "Embed links",
     "context": "Logging feature copy: permissions.embed links.",
     "labels": "logs",
     "max_length": 32
@@ -30105,8 +30105,8 @@
   },
   {
     "identifier": "logs.permissions.kick_members",
-    "source_string": "Members kick",
-    "translation": "Members kick",
+    "source_string": "Kick members",
+    "translation": "Kick members",
     "context": "Logging feature copy: permissions.kick members.",
     "labels": "logs",
     "max_length": 32
@@ -30177,8 +30177,8 @@
   },
   {
     "identifier": "logs.permissions.manage_permissions",
-    "source_string": "Manage authorizations",
-    "translation": "Manage authorizations",
+    "source_string": "Manage permissions",
+    "translation": "Manage permissions",
     "context": "Logging feature copy: permissions.manage permissions.",
     "labels": "logs",
     "max_length": 32
@@ -30217,16 +30217,16 @@
   },
   {
     "identifier": "logs.permissions.mention_everyone",
-    "source_string": "All mention",
-    "translation": "All mention",
+    "source_string": "Mention everyone",
+    "translation": "Mention everyone",
     "context": "Logging feature copy: permissions.mention everyone.",
     "labels": "logs",
     "max_length": 32
   },
   {
     "identifier": "logs.permissions.moderate_members",
-    "source_string": "Members moderate",
-    "translation": "Members moderate",
+    "source_string": "Timeout members",
+    "translation": "Timeout members",
     "context": "Logging feature copy: permissions.moderate members.",
     "labels": "logs",
     "max_length": 32
@@ -30249,24 +30249,24 @@
   },
   {
     "identifier": "logs.permissions.priority_speaker",
-    "source_string": "Priority spokesperson",
-    "translation": "Priority spokesperson",
+    "source_string": "Priority speaker",
+    "translation": "Priority speaker",
     "context": "Logging feature copy: permissions.priority speaker.",
     "labels": "logs",
     "max_length": 32
   },
   {
     "identifier": "logs.permissions.read_message_history",
-    "source_string": "Read news story",
-    "translation": "Read news story",
+    "source_string": "Read message history",
+    "translation": "Read message history",
     "context": "Logging feature copy: permissions.read message history.",
     "labels": "logs",
     "max_length": 32
   },
   {
     "identifier": "logs.permissions.read_messages",
-    "source_string": "Read the news",
-    "translation": "Read the news",
+    "source_string": "View channel",
+    "translation": "View channel",
     "context": "Logging feature copy: permissions.read messages.",
     "labels": "logs",
     "max_length": 32
@@ -30297,8 +30297,8 @@
   },
   {
     "identifier": "logs.permissions.send_polls",
-    "source_string": "Send surveys",
-    "translation": "Send surveys",
+    "source_string": "Send polls",
+    "translation": "Send polls",
     "context": "Logging feature copy: permissions.send polls.",
     "labels": "logs",
     "max_length": 32
@@ -30337,16 +30337,16 @@
   },
   {
     "identifier": "logs.permissions.use_application_commands",
-    "source_string": "Using application commands",
-    "translation": "Using application commands",
+    "source_string": "Use application commands",
+    "translation": "Use application commands",
     "context": "Logging feature copy: permissions.use application commands.",
     "labels": "logs",
     "max_length": null
   },
   {
     "identifier": "logs.permissions.use_embedded_activities",
-    "source_string": "Use embedded activities",
-    "translation": "Use embedded activities",
+    "source_string": "Use activities",
+    "translation": "Use activities",
     "context": "Logging feature copy: permissions.use embedded activities.",
     "labels": "logs",
     "max_length": null
@@ -30369,8 +30369,8 @@
   },
   {
     "identifier": "logs.permissions.use_external_sounds",
-    "source_string": "Using external sounds",
-    "translation": "Using external sounds",
+    "source_string": "Use external sounds",
+    "translation": "Use external sounds",
     "context": "Logging feature copy: permissions.use external sounds.",
     "labels": "logs",
     "max_length": null
@@ -30385,8 +30385,8 @@
   },
   {
     "identifier": "logs.permissions.use_soundboard",
-    "source_string": "Using the soundboard",
-    "translation": "Using the soundboard",
+    "source_string": "Use soundboard",
+    "translation": "Use soundboard",
     "context": "Logging feature copy: permissions.use soundboard.",
     "labels": "logs",
     "max_length": null
@@ -30409,8 +30409,8 @@
   },
   {
     "identifier": "logs.permissions.view_channel",
-    "source_string": "Watch channel",
-    "translation": "Watch channel",
+    "source_string": "View channel",
+    "translation": "View channel",
     "context": "Logging feature copy: permissions.view channel.",
     "labels": "logs",
     "max_length": null
@@ -30461,7 +30461,7 @@
     "translation": "${user} has added a reaction to the message ${message}: ${emoji}",
     "context": "Logging feature copy: reaction Add. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.reactionAdd.title",
@@ -30477,7 +30477,7 @@
     "translation": "${user} has removed a reaction from the message ${message}: ${emoji}",
     "context": "Logging feature copy: reaction Remove. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.reactionRemove.title",
@@ -30545,8 +30545,8 @@
   },
   {
     "identifier": "logs.userUpdate.globalName",
-    "source_string": "Global nickname changed: \n<:empty:1312126155897442416>Before: ${before}\n<:empty:1312126155897442416>After: ${after}",
-    "translation": "Global nickname changed: \n<:empty:1312126155897442416>Before: ${before}\n<:empty:1312126155897442416>After: ${after}",
+    "source_string": "Display name changed: ${before} → ${after}",
+    "translation": "Display name changed: ${before} → ${after}",
     "context": "Logging feature copy: user Update.global Name.",
     "labels": "logs",
     "max_length": null
@@ -30569,11 +30569,11 @@
   },
   {
     "identifier": "logs.userUpdate.name",
-    "source_string": "The user ${user} has changed his global Discord account",
-    "translation": "The user ${user} has changed his global Discord account",
+    "source_string": "The user ${user} updated their Discord account",
+    "translation": "The user ${user} updated their Discord account",
     "context": "Logging feature copy: user Update. Used in `extensions/logs.py`.",
     "labels": "logs",
-    "max_length": 32
+    "max_length": null
   },
   {
     "identifier": "logs.userUpdate.title",
@@ -30593,11 +30593,11 @@
   },
   {
     "identifier": "logs.blacklistcat.add.description",
-    "source_string": "blacklist_a_category_from_logs",
-    "translation": "blacklist_a_category_from_logs",
+    "source_string": "Blacklist a category from logs",
+    "translation": "Blacklist a category from logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a category from logs\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.add.name",
@@ -30605,23 +30605,23 @@
     "translation": "add-category",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"add-category\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.add.params.channel.description",
-    "source_string": "the_category_to_blacklist",
-    "translation": "the_category_to_blacklist",
+    "source_string": "The category to blacklist",
+    "translation": "The category to blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to blacklist\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.description",
-    "source_string": "manage_the_category_blacklist_fo",
-    "translation": "manage_the_category_blacklist_fo",
+    "source_string": "Manage the category blacklist for logs",
+    "translation": "Manage the category blacklist for logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the category blacklist for logging\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.name",
@@ -30629,15 +30629,15 @@
     "translation": "category-blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"category-blacklist\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.remove.description",
-    "source_string": "remove_a_category_from_the_log_b",
-    "translation": "remove_a_category_from_the_log_b",
+    "source_string": "Remove a category from the log blacklist",
+    "translation": "Remove a category from the log blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a category from the log blacklist\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.remove.name",
@@ -30645,23 +30645,23 @@
     "translation": "remove-category",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"remove-category\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.remove.params.channel.description",
-    "source_string": "the_category_to_remove_from_blac",
-    "translation": "the_category_to_remove_from_blac",
+    "source_string": "The category to remove from the blacklist",
+    "translation": "The category to remove from the blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The category to remove from blacklist\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.show.description",
-    "source_string": "show_blacklisted_categories",
-    "translation": "show_blacklisted_categories",
+    "source_string": "Show blacklisted categories",
+    "translation": "Show blacklisted categories",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted categories\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistcat.show.name",
@@ -30669,15 +30669,15 @@
     "translation": "list-category",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"list-category\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.add.description",
-    "source_string": "blacklist_a_voice_channel_from_l",
-    "translation": "blacklist_a_voice_channel_from_l",
+    "source_string": "Blacklist a voice channel from logs",
+    "translation": "Blacklist a voice channel from logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Blacklist a voice channel from logs\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.add.name",
@@ -30685,23 +30685,23 @@
     "translation": "add-voice",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"add-voice\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.add.params.channel.description",
-    "source_string": "the_voice_channel_to_blacklist",
-    "translation": "the_voice_channel_to_blacklist",
+    "source_string": "The voice channel to blacklist",
+    "translation": "The voice channel to blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to blacklist\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.description",
-    "source_string": "manage_the_voice_channel_blackli",
-    "translation": "manage_the_voice_channel_blackli",
+    "source_string": "Manage the voice channel blacklist for logs",
+    "translation": "Manage the voice channel blacklist for logs",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Manage the voice channel blacklist for logging\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.name",
@@ -30709,15 +30709,15 @@
     "translation": "voice-blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"voice-blacklist\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.remove.description",
-    "source_string": "remove_a_voice_channel_from_the_",
-    "translation": "remove_a_voice_channel_from_the_",
+    "source_string": "Remove a voice channel from the log blacklist",
+    "translation": "Remove a voice channel from the log blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Remove a voice channel from the log blacklist\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.remove.name",
@@ -30725,23 +30725,23 @@
     "translation": "remove-voice",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"remove-voice\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.remove.params.channel.description",
-    "source_string": "the_voice_channel_to_remove_from",
-    "translation": "the_voice_channel_to_remove_from",
+    "source_string": "The voice channel to remove from the blacklist",
+    "translation": "The voice channel to remove from the blacklist",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"The voice channel to remove from blacklist\".",
-    "labels": "command_name",
-    "max_length": 32
+    "labels": "command_description",
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.show.description",
-    "source_string": "show_blacklisted_voice_channels",
-    "translation": "show_blacklisted_voice_channels",
+    "source_string": "Show blacklisted voice channels",
+    "translation": "Show blacklisted voice channels",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Show blacklisted voice channels\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "logs.blacklistv.show.name",
@@ -30749,7 +30749,7 @@
     "translation": "list-voice",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"list-voice\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "math.calc.description",
@@ -33153,8 +33153,8 @@
   },
   {
     "identifier": "setup.booster.description",
-    "source_string": "interactive_wizard_for_booster_p",
-    "translation": "interactive_wizard_for_booster_p",
+    "source_string": "Setup booster perks wizard",
+    "translation": "Setup booster perks wizard",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard for booster perks configuration\".",
     "labels": "command_name",
     "max_length": 32
@@ -33169,16 +33169,16 @@
   },
   {
     "identifier": "setup.description",
-    "source_string": "interactive_setup_wizards",
-    "translation": "interactive_setup_wizards",
+    "source_string": "Interactive setup wizards",
+    "translation": "Interactive setup wizards",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive setup wizards\".",
     "labels": "command_name",
     "max_length": 32
   },
   {
     "identifier": "setup.giveaway.description",
-    "source_string": "interactive_wizard_to_create_a_g",
-    "translation": "interactive_wizard_to_create_a_g",
+    "source_string": "Setup giveaway wizard",
+    "translation": "Setup giveaway wizard",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to create a giveaway\".",
     "labels": "command_name",
     "max_length": 32
@@ -33193,8 +33193,8 @@
   },
   {
     "identifier": "setup.level.description",
-    "source_string": "interactive_wizard_to_configure_",
-    "translation": "interactive_wizard_to_configure_",
+    "source_string": "Setup leveling wizard",
+    "translation": "Setup leveling wizard",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure the leveling system\".",
     "labels": "command_name",
     "max_length": 32
@@ -33209,11 +33209,11 @@
   },
   {
     "identifier": "setup.logs.description",
-    "source_string": "interactive_wizard_to_configure_",
-    "translation": "interactive_wizard_to_configure_",
+    "source_string": "Interactive wizard to configure logging",
+    "translation": "Interactive wizard to configure logging",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Interactive wizard to configure logging\".",
     "labels": "command_name",
-    "max_length": 32
+    "max_length": 100
   },
   {
     "identifier": "setup.logs.name",
@@ -33329,8 +33329,8 @@
   },
   {
     "identifier": "triggermessages",
-    "source_string": "trigger_news",
-    "translation": "trigger_news",
+    "source_string": "trigger news",
+    "translation": "trigger news",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"trigger news\".",
     "labels": "command_name",
     "max_length": 32
@@ -33577,8 +33577,8 @@
   },
   {
     "identifier": "utility.boosterchannelinfo.description",
-    "source_string": "Find out what the booster channels are",
-    "translation": "Find out what the booster channels are",
+    "source_string": "Learn about booster channels",
+    "translation": "Learn about booster channels",
     "context": "Embed or dialog description (utility.boosterchannelinfo). Used in `extensions/utility.py`.",
     "labels": "utility, description",
     "max_length": 100
@@ -33609,8 +33609,8 @@
   },
   {
     "identifier": "utility.boosterroleinfo.description",
-    "source_string": "Get some information about the booster rolls",
-    "translation": "Get some information about the booster rolls",
+    "source_string": "Get some information about the booster roles",
+    "translation": "Get some information about the booster roles",
     "context": "Embed or dialog description (utility.boosterroleinfo). Used in `extensions/utility.py`.",
     "labels": "utility, description",
     "max_length": 100
@@ -33881,8 +33881,8 @@
   },
   {
     "identifier": "utility.claimboosterrole.params.color.description",
-    "source_string": "The color of the booster roll",
-    "translation": "The color of the booster roll",
+    "source_string": "The color of the booster role",
+    "translation": "The color of the booster role",
     "context": "Help text describing the `color` option on `/utility claimboosterrole` (shown when the user focuses that option). Used in `extensions/utility.py`.",
     "labels": "utility, command_option_description",
     "max_length": 100
@@ -33897,8 +33897,8 @@
   },
   {
     "identifier": "utility.claimboosterrole.params.icon.description",
-    "source_string": "The icon of the booster roll",
-    "translation": "The icon of the booster roll",
+    "source_string": "The icon of the booster role",
+    "translation": "The icon of the booster role",
     "context": "Help text describing the `icon` option on `/utility claimboosterrole` (shown when the user focuses that option). Used in `extensions/utility.py`.",
     "labels": "utility, command_option_description",
     "max_length": 100
@@ -33913,8 +33913,8 @@
   },
   {
     "identifier": "utility.claimboosterrole.params.name.description",
-    "source_string": "The name of the booster roll",
-    "translation": "The name of the booster roll",
+    "source_string": "The name of the booster role",
+    "translation": "The name of the booster role",
     "context": "Help text describing the `name` option on `/utility claimboosterrole` (shown when the user focuses that option). Used in `extensions/utility.py`.",
     "labels": "utility, command_option_description",
     "max_length": 100
@@ -34401,8 +34401,8 @@
   },
   {
     "identifier": "utility.setupboosterrole.description",
-    "source_string": "Sets up the booster roll",
-    "translation": "Sets up the booster roll",
+    "source_string": "Sets up the booster role",
+    "translation": "Sets up the booster role",
     "context": "Embed or dialog description (utility.setupboosterrole). Used in `extensions/utility.py`.",
     "labels": "utility, description",
     "max_length": 100
@@ -34417,8 +34417,8 @@
   },
   {
     "identifier": "utility.setupboosterrole.params.role.description",
-    "source_string": "The roll to be used as a template for the booster roll",
-    "translation": "The roll to be used as a template for the booster roll",
+    "source_string": "The role to use as a template for booster roles",
+    "translation": "The role to use as a template for booster roles",
     "context": "Help text describing the `role` option on `/utility setupboosterrole` (shown when the user focuses that option). Used in `extensions/utility.py`.",
     "labels": "utility, command_option_description",
     "max_length": 100
@@ -34625,8 +34625,8 @@
   },
   {
     "identifier": "✨POGGERS✨",
-    "source_string": "ai_commands",
-    "translation": "ai_commands",
+    "source_string": "Ai commands",
+    "translation": "Ai commands",
     "context": "Discord slash command category or command name shown in the command browser (identifier is the legacy English label). English source: \"Ai commands\".",
     "labels": "command_name",
     "max_length": 32


### PR DESCRIPTION
## Summary
- Fix user-visible copy bugs (e.g. "News content" → "Message content" on message delete logs)
- Replace German-style calques (authorization → permission, roll → role)
- Restore readable slash command descriptions and legacy command browser labels from context
- Align `logs.permissions.*` labels with Discord terminology
- Fix swapped welcome/farewell default messages

## Test plan
- [ ] Delete a message with text → log shows **Message content:**
- [ ] `/setup giveaway` shows a readable description in the command browser
- [ ] Welcome/farewell defaults have correct join vs leave tone
- [ ] `python scripts/check_locales.py` passes

Pair with https://github.com/TanjunBot/new_tanjun/pull/3249 for log title/placeholder fixes; locale-only merge is safe for English display.