### PR TITLE
feat(db): opt-in database connection debug logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,6 +187,17 @@ def _database_connect_hint() -> str:
 
 async def _init_database_pool() -> asyncmy.Pool | None:
     """Initialize and return the database connection pool."""
+    from utils.db_migration import log_database_connection_debug
+
+    log_database_connection_debug(
+        context="main.py asyncmy pool init",
+        extra={
+            "connect_timeout_sec": database_connect_timeout_sec,
+            "max_retries": database_connect_max_retries,
+            "retry_delay_sec": database_connect_retry_delay_sec,
+        },
+    )
+
     max_retries = database_connect_max_retries
     delay = database_connect_retry_delay_sec
     last_error: BaseException | None = None

--- a/scripts/docker_entrypoint.py
+++ b/scripts/docker_entrypoint.py
@@ -29,7 +29,16 @@ def _mark_startup_in_progress() -> None:
 def _wait_for_database() -> None:
     from sqlalchemy import create_engine, text
 
-    from utils.db_migration import get_database_url
+    from utils.db_migration import get_database_url, log_database_connection_debug
+
+    log_database_connection_debug(
+        context="docker entrypoint database wait",
+        log=logger,
+        extra={
+            "wait_attempts": _DB_WAIT_ATTEMPTS,
+            "wait_delay_sec": _DB_WAIT_DELAY_SEC,
+        },
+    )
 
     url = get_database_url()
     engine = create_engine(url, pool_pre_ping=True)
@@ -49,6 +58,12 @@ def _wait_for_database() -> None:
                 _DB_WAIT_ATTEMPTS,
                 exc,
             )
+            if attempt == _DB_WAIT_ATTEMPTS:
+                log_database_connection_debug(
+                    context="docker entrypoint database wait (final failure)",
+                    log=logger,
+                    extra={"last_error": str(exc)},
+                )
             time.sleep(_DB_WAIT_DELAY_SEC)
 
     raise RuntimeError("Database not reachable before startup timeout") from last_error

--- a/tests/unit/utils/test_db_migration.py
+++ b/tests/unit/utils/test_db_migration.py
@@ -13,9 +13,14 @@ import tests.mock_config as mock_config
 mock_config.patch_config_module()
 
 from utils.db_migration import (  # noqa: E402
+    DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV,
     _revision_state,
+    dangerously_debug_print_database_enabled,
     ensure_database_schema,
+    format_database_connection_debug,
     get_database_url,
+    log_database_connection_debug,
+    resolve_database_connection_params,
     run_alembic_upgrade_head,
 )
 
@@ -198,6 +203,72 @@ def test_get_database_url_falls_back_to_settings() -> None:
         url = get_database_url()
     assert "127.0.0.1:3306/tanjun" in url
     assert "@127.0.0.1" in url
+
+
+def test_resolve_database_connection_params_from_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TANJUN_TEST_DB_HOST", "db.example")
+    monkeypatch.setenv("TANJUN_TEST_DB_PORT", "3308")
+    monkeypatch.setenv("TANJUN_TEST_DB_USER", "u")
+    monkeypatch.setenv("TANJUN_TEST_DB_PASSWORD", "secret")
+    monkeypatch.setenv("TANJUN_TEST_DB_NAME", "mydb")
+
+    params = resolve_database_connection_params()
+
+    assert params.host == "db.example"
+    assert params.port == 3308
+    assert params.user == "u"
+    assert params.password == "secret"
+    assert params.database == "mydb"
+    assert params.sources["host"] == "TANJUN_TEST_DB_HOST"
+
+
+def test_dangerously_debug_print_database_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV, raising=False)
+    assert not dangerously_debug_print_database_enabled()
+
+    monkeypatch.setenv(DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV, "true")
+    assert dangerously_debug_print_database_enabled()
+
+
+def test_log_database_connection_debug_prints_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("TANJUN_TEST_DB_HOST", "debug-host")
+    monkeypatch.setenv("TANJUN_TEST_DB_PORT", "3306")
+    monkeypatch.setenv("TANJUN_TEST_DB_USER", "u")
+    monkeypatch.setenv("TANJUN_TEST_DB_PASSWORD", "p")
+    monkeypatch.setenv("TANJUN_TEST_DB_NAME", "db")
+    monkeypatch.setenv(DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV, "1")
+
+    log_database_connection_debug(context="unit test")
+
+    captured = capsys.readouterr()
+    assert "debug-host" in captured.err
+    assert "TANJUN_TEST_DB_HOST" in captured.err
+    assert "password=SET (length=1)" in captured.err
+    assert "***" in captured.err
+
+
+def test_format_database_connection_debug_masks_password() -> None:
+    from utils.db_migration import DatabaseConnectionParams
+
+    params = DatabaseConnectionParams(
+        host="h",
+        port=3306,
+        user="u",
+        password="secret",
+        database="d",
+        sources={
+            "host": "database_ip",
+            "port": "database_port",
+            "user": "database_user",
+            "password": "database_password",
+            "database": "database_schema",
+        },
+    )
+    text = format_database_connection_debug(params, context="ctx")
+    assert "secret" not in text
+    assert "***" in text
 
 
 def test_get_database_url_raises_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/utils/db_migration.py
+++ b/utils/db_migration.py
@@ -2,50 +2,111 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
+from dataclasses import dataclass
+from typing import Any
 from urllib.parse import quote_plus
 
 from alembic.config import Config
 
 logger = logging.getLogger(__name__)
 
+DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV = "DANGEROUSLY_DEBUG_PRINT_DATABASE_DONT_ENABLE"
+
+_HOST_ENV_KEYS = ("TANJUN_TEST_DB_HOST", "database_ip", "DATABASE_IP", "MARIADB_HOST", "MYSQL_HOST")
+_PORT_ENV_KEYS = ("TANJUN_TEST_DB_PORT", "database_port", "DATABASE_PORT", "MARIADB_PORT", "MYSQL_PORT")
+_USER_ENV_KEYS = ("TANJUN_TEST_DB_USER", "database_user", "DATABASE_USER", "MARIADB_USER", "MYSQL_USER")
+_PASSWORD_ENV_KEYS = (
+    "TANJUN_TEST_DB_PASSWORD",
+    "database_password",
+    "DATABASE_PASSWORD",
+    "MARIADB_PASSWORD",
+    "MYSQL_PASSWORD",
+)
+_DATABASE_ENV_KEYS = (
+    "TANJUN_TEST_DB_NAME",
+    "database_schema",
+    "DATABASE_SCHEMA",
+    "MARIADB_DATABASE",
+    "MYSQL_DATABASE",
+)
+
+
+@dataclass(frozen=True)
+class DatabaseConnectionParams:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+    sources: dict[str, str]
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def dangerously_debug_print_database_enabled() -> bool:
+    return _truthy_env(DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV)
+
 
 def _first_env(*keys: str, default: str | None = None) -> str | None:
+    value, _ = _first_env_with_source(*keys, default=default)
+    return value
+
+
+def _first_env_with_source(*keys: str, default: str | None = None) -> tuple[str | None, str | None]:
     for key in keys:
         value = os.environ.get(key)
         if value:
-            return value
-    return default
+            return value, key
+    return default, None
 
 
-def get_database_url() -> str:
-    """Build a SQLAlchemy URL for Alembic (sync PyMySQL driver)."""
-    host = _first_env("TANJUN_TEST_DB_HOST", "database_ip", "DATABASE_IP", "MARIADB_HOST", "MYSQL_HOST")
-    port = _first_env("TANJUN_TEST_DB_PORT", "database_port", "DATABASE_PORT", "MARIADB_PORT", "MYSQL_PORT", default="3306")
-    user = _first_env("TANJUN_TEST_DB_USER", "database_user", "DATABASE_USER", "MARIADB_USER", "MYSQL_USER")
-    password = _first_env(
-        "TANJUN_TEST_DB_PASSWORD",
-        "database_password",
-        "DATABASE_PASSWORD",
-        "MARIADB_PASSWORD",
-        "MYSQL_PASSWORD",
-    )
-    database = _first_env(
-        "TANJUN_TEST_DB_NAME",
-        "database_schema",
-        "DATABASE_SCHEMA",
-        "MARIADB_DATABASE",
-        "MYSQL_DATABASE",
-    )
+def _password_debug_label(password: str | None) -> str:
+    if password is None:
+        return "NOT SET"
+    if password == "":
+        return "SET (empty string)"
+    return f"SET (length={len(password)})"
+
+
+def resolve_database_connection_params() -> DatabaseConnectionParams:
+    """Resolve host/port/user/password/database from env vars, then config.settings."""
+    host, host_source = _first_env_with_source(*_HOST_ENV_KEYS)
+    port_raw, port_source = _first_env_with_source(*_PORT_ENV_KEYS, default="3306")
+    user, user_source = _first_env_with_source(*_USER_ENV_KEYS)
+    password, password_source = _first_env_with_source(*_PASSWORD_ENV_KEYS)
+    database, database_source = _first_env_with_source(*_DATABASE_ENV_KEYS)
+
+    sources: dict[str, str] = {
+        "host": host_source or "missing",
+        "port": port_source or "default",
+        "user": user_source or "missing",
+        "password": password_source or "missing",
+        "database": database_source or "missing",
+    }
 
     if host is None or user is None or password is None or database is None:
         try:
             from config import settings
 
-            host = host or settings.database_ip
-            port = str(port or settings.database_port)
-            user = user or settings.database_user
-            password = password if password is not None else settings.database_password.get_secret_value()
-            database = database or settings.database_schema
+            if host is None:
+                host = settings.database_ip
+                sources["host"] = "config.settings.database_ip"
+            port_before_settings = port_raw
+            port_raw = str(port_raw or settings.database_port)
+            if not port_source and str(port_before_settings or "") != str(port_raw):
+                sources["port"] = "config.settings.database_port"
+            if user is None:
+                user = settings.database_user
+                sources["user"] = "config.settings.database_user"
+            if password is None:
+                password = settings.database_password.get_secret_value()
+                sources["password"] = "config.settings.database_password"
+            if database is None:
+                database = settings.database_schema
+                sources["database"] = "config.settings.database_schema"
         except Exception:
             pass
 
@@ -54,9 +115,80 @@ def get_database_url() -> str:
             "Database credentials missing for migrations. Set database_* env vars or TANJUN_TEST_DB_*."
         )
 
-    safe_user = quote_plus(str(user))
-    safe_password = quote_plus(str(password))
-    return f"mysql+pymysql://{safe_user}:{safe_password}@{host}:{port}/{database}"
+    return DatabaseConnectionParams(
+        host=str(host),
+        port=int(port_raw or 3306),
+        user=str(user),
+        password=str(password),
+        database=str(database),
+        sources=sources,
+    )
+
+
+def format_database_connection_debug(
+    params: DatabaseConnectionParams,
+    *,
+    context: str,
+    extra: dict[str, Any] | None = None,
+) -> str:
+    url = (
+        f"mysql+pymysql://{quote_plus(params.user)}:***@"
+        f"{params.host}:{params.port}/{params.database}"
+    )
+    lines = [
+        f"[{DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV}] {context}",
+        f"  host={params.host!r} (from {params.sources['host']})",
+        f"  port={params.port} (from {params.sources['port']})",
+        f"  user={params.user!r} (from {params.sources['user']})",
+        f"  password={_password_debug_label(params.password)} (from {params.sources['password']})",
+        f"  database={params.database!r} (from {params.sources['database']})",
+        f"  sqlalchemy_url={url}",
+    ]
+    for key in (
+        *_HOST_ENV_KEYS,
+        *_PORT_ENV_KEYS,
+        *_USER_ENV_KEYS,
+        *_PASSWORD_ENV_KEYS,
+        *_DATABASE_ENV_KEYS,
+    ):
+        if key in os.environ:
+            lines.append(f"  env_present[{key!r}]=yes")
+    if extra:
+        for name, value in extra.items():
+            lines.append(f"  {name}={value!r}")
+    return "\n".join(lines)
+
+
+def log_database_connection_debug(
+    *,
+    context: str,
+    log: logging.Logger | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    if not dangerously_debug_print_database_enabled():
+        return
+    try:
+        params = resolve_database_connection_params()
+    except Exception as exc:
+        message = f"[{DANGEROUSLY_DEBUG_PRINT_DATABASE_ENV}] {context}\n  resolve_failed={exc!r}"
+        if log is not None:
+            log.warning(message)
+        else:
+            print(message, file=sys.stderr)
+        return
+    message = format_database_connection_debug(params, context=context, extra=extra)
+    if log is not None:
+        log.warning("%s", message)
+    else:
+        print(message, file=sys.stderr)
+
+
+def get_database_url() -> str:
+    """Build a SQLAlchemy URL for Alembic (sync PyMySQL driver)."""
+    params = resolve_database_connection_params()
+    safe_user = quote_plus(params.user)
+    safe_password = quote_plus(params.password)
+    return f"mysql+pymysql://{safe_user}:{safe_password}@{params.host}:{params.port}/{params.database}"
 
 
 def _alembic_config() -> Config:


### PR DESCRIPTION
## Summary

- Adds `DANGEROUSLY_DEBUG_PRINT_DATABASE_DONT_ENABLE` to log resolved database host, port, user, schema, and which env var supplied each value (password length only, never the secret).
- Logs at Docker entrypoint DB wait (start + final failure) and before asyncmy pool init in `main.py`.

## Usage

On Development Bot (or any environment), set:

```env
DANGEROUSLY_DEBUG_PRINT_DATABASE_DONT_ENABLE=true
```

Restart and check logs for `[DANGEROUSLY_DEBUG_PRINT_DATABASE_DONT_ENABLE]` blocks to compare dev vs prod DB targets.

## Test plan

- [x] `pytest tests/unit/utils/test_db_migration.py tests/unit/scripts/test_docker_entrypoint.py`
- [ ] Enable env on dev bot, confirm startup logs show host/source before timeout
- [ ] Remove env after debugging


Made with [Cursor](https://cursor.com)