### PR TITLE
fix(logs): emit member update details when attributes change

### DIFF
--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -876,7 +876,7 @@ class LogsCog(commands.Cog):
                 description_parts.append(l10n.logs.memberUpdate.timeout(locale, timeout=utility.date_time_to_timestamp(after.timed_out_until)))
             else:
                 description_parts.append(l10n.logs.memberUpdate.timeoutRemoved(locale))
-        if len(description_parts) >= 2:
+        if len(description_parts) == 1:
             return
         description = '\n'.join(description_parts)
         embed = discord.Embed(color=EmbedColor.WARNING, title=l10n.logs.memberUpdate.title(locale), description=description)

--- a/tests/integration/extensions/test_logs_comprehensive.py
+++ b/tests/integration/extensions/test_logs_comprehensive.py
@@ -826,7 +826,7 @@ async def test_message_delete_audit_match(log_api_mocks, logs_cog):
     await cog.on_message_delete(message)
 
 
-async def test_member_update_only_name_emits(log_api_mocks, logs_cog):
+async def test_member_update_skips_when_nothing_changed(log_api_mocks, logs_cog):
     cog = await logs_cog()
     guild = make_guild()
     before = make_member()
@@ -839,6 +839,27 @@ async def test_member_update_only_name_emits(log_api_mocks, logs_cog):
     before.pending = after.pending = False
     before.timed_out_until = after.timed_out_until = None
     await cog.on_member_update(before, after)
+    log_api_mocks.assert_not_called()
+
+
+async def test_member_update_display_name_emits(log_api_mocks, logs_cog):
+    cog = await logs_cog()
+    guild = make_guild()
+    before = make_member()
+    after = make_member()
+    before.guild = after.guild = guild
+    before.display_name = "OldNick"
+    after.display_name = "NewNick"
+    before.display_avatar = after.display_avatar
+    before.banner = after.banner
+    before.roles = after.roles = []
+    before.pending = after.pending = False
+    before.timed_out_until = after.timed_out_until = None
+    await cog.on_member_update(before, after)
+    log_api_mocks.assert_called_once()
+    embed = log_api_mocks.call_args[0][1]
+    assert "OldNick" in embed.description
+    assert "NewNick" in embed.description
 
 
 async def test_user_update_skips_blacklisted_role(log_api_mocks, logs_cog):


### PR DESCRIPTION
## Summary

- Fixes inverted guard in `on_member_update` that suppressed logs when nickname, roles, avatar, timeout, or other tracked fields changed, while still emitting empty "Member updated" embeds when nothing meaningful changed.
- Adds regression tests to skip logging on no-op updates and to assert display name changes appear in the embed description.

## Test plan

- [x] `pytest tests/integration/extensions/test_logs_comprehensive.py::test_member_update_skips_when_nothing_changed`
- [x] `pytest tests/integration/extensions/test_logs_comprehensive.py::test_member_update_display_name_emits`
- [ ] After deploy: change a member nickname and confirm the log channel shows "Display name changed" with before/after values


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined member update logging to accurately skip entries when no changes occur and properly capture display name modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->