### PR TITLE
fix(setup): level wizard step 2 cooldown descriptions

### DIFF
--- a/extensions/setup_wizards.py
+++ b/extensions/setup_wizards.py
@@ -208,7 +208,7 @@ class LevelSetupView(View):
             await _not_admin_reply(interaction)
             return
         await api_set_xp_scaling(str(self.guild.id), scaling)
-        embed = utility.tanjunEmbed(title='XP Scaling Set', description=f"XP difficulty set to **{scaling}**. Now let's configure cooldowns.")
+        embed = utility.tanjunEmbed(title='XP Scaling Set', description=f"XP difficulty set to **{scaling}**.\n\n**Step 2:** Choose how often members can earn XP again.\n• **Fast** — 30s text, 60s voice\n• **Normal** — 60s text, 120s voice\n• **Slow** — 120s text, 300s voice")
         view = LevelCooldownView(self.locale, self.guild, self)
         await interaction.response.edit_message(embed=_discord_embed(embed), view=view)
 

--- a/extensions/setup_wizards.py
+++ b/extensions/setup_wizards.py
@@ -239,7 +239,7 @@ class LevelCooldownView(View):
             return
         await api_set_text_cooldown(str(self.guild.id), text_cd)
         await api_set_voice_cooldown(str(self.guild.id), voice_cd)
-        embed = utility.tanjunEmbed(title='Cooldowns Configured', description=f"Text XP cooldown: **{text_cd}s**\nVoice XP cooldown: **{voice_cd}s**\n\nNow let's set a level-up announcement channel (optional).")
+        embed = utility.tanjunEmbed(title='Cooldowns Configured', description=f"Text XP cooldown: **{text_cd}s**\nVoice XP cooldown: **{voice_cd}s**\n\n**Step 3 (optional):** Choose where level-up messages are sent.\n• **Select a channel** — all announcements go to that channel\n• **Skip** — announcements are sent in the channel where each member leveled up")
         view = LevelChannelView(self.locale, self.guild, self.setup_view)
         await interaction.response.edit_message(embed=_discord_embed(embed), view=view)
 
@@ -252,7 +252,7 @@ class LevelChannelView(View):
         self.guild = guild
         self.setup_view = setup_view
 
-    @discord.ui.select(cls=discord.ui.ChannelSelect, placeholder='Select a channel for level-up announcements...', channel_types=[discord.ChannelType.text])
+    @discord.ui.select(cls=discord.ui.ChannelSelect, placeholder='Optional: pick a fixed level-up channel...', channel_types=[discord.ChannelType.text])
     async def on_channel_select(self, interaction: discord.Interaction, select: discord.ui.ChannelSelect[Any]) -> None:
         if not _require_admin(interaction):
             await _not_admin_reply(interaction)
@@ -274,7 +274,7 @@ class LevelChannelView(View):
             await api_set_levelup_channel(str(self.guild.id), str(channel.id))
             msg = f'Level-up announcements will be sent to {channel_mention(selected, channel)}.'
         else:
-            msg = 'No level-up channel set.'
+            msg = 'No fixed channel set. Level-up messages will be sent in the channel where each member leveled up.'
         self.setup_view.completed = True
         embed = utility.tanjunEmbed(title='Channel Set', description=msg + '\n\nLevel system setup is complete! 🎉')
         for item in self.children:
@@ -288,7 +288,7 @@ class LevelChannelView(View):
             await _not_admin_reply(interaction)
             return
         self.setup_view.completed = True
-        embed = utility.tanjunEmbed(title='✅ Level Setup Complete', description='The leveling system is now active! Members earn XP by chatting.\n\nTip: Use `/level add-level-role` to reward roles at specific levels.')
+        embed = utility.tanjunEmbed(title='✅ Level Setup Complete', description='The leveling system is now active! Members earn XP by chatting.\n\nLevel-up messages will be sent in the channel where each member leveled up. You can set a fixed channel later with `/level setlevelupchannel`.\n\nTip: Use `/level add-level-role` to reward roles at specific levels.')
         for item in self.children:
             item.disabled = True
         await interaction.response.edit_message(embed=_discord_embed(embed), view=self)

--- a/tests/integration/extensions/test_setup_level_wizard_flow.py
+++ b/tests/integration/extensions/test_setup_level_wizard_flow.py
@@ -22,8 +22,12 @@ class TestLevelSetupWizardFlow:
         view = sw.LevelSetupView("en-US", MagicMock())
         ix = admin_interaction()
         await view.easy(ix, MagicMock())
-        embed = embed_from_edit(ix)
-        assert "XP difficulty" in (embed.description or "") or "cooldown" in edit_description(ix).lower()
+        desc = edit_description(ix)
+        assert "XP difficulty" in desc
+        assert "**Step 2:**" in desc
+        assert "**Fast**" in desc and "30s text" in desc
+        assert "**Normal**" in desc and "120s voice" in desc
+        assert "**Slow**" in desc and "300s voice" in desc
         kwargs = ix.response.edit_message.await_args.kwargs
         assert isinstance(kwargs.get("view"), sw.LevelCooldownView)
 

--- a/tests/integration/extensions/test_setup_level_wizard_flow.py
+++ b/tests/integration/extensions/test_setup_level_wizard_flow.py
@@ -39,6 +39,8 @@ class TestLevelSetupWizardFlow:
         await view.normal(ix, MagicMock())
         desc = edit_description(ix)
         assert "60" in desc
+        assert "**Step 3 (optional):**" in desc
+        assert "Skip" in desc and "leveled up" in desc
         kwargs = ix.response.edit_message.await_args.kwargs
         assert isinstance(kwargs.get("view"), sw.LevelChannelView)
 
@@ -63,6 +65,7 @@ class TestLevelSetupWizardFlow:
         ix = admin_interaction()
         await view.skip(ix, MagicMock())
         assert parent.completed is True
+        assert "leveled up" in edit_description(ix)
 
     async def test_scaling_not_admin(self, setup_wizards_module, wizard_api_mocks) -> None:
         sw = setup_wizards_module


### PR DESCRIPTION
## Summary
- After step 1 (XP scaling), the level setup wizard showed only “Now let’s configure cooldowns” with Fast/Normal/Slow buttons but no explanatory bullets.
- Add **Step 2** copy matching step 1’s style, including text and voice cooldown seconds for each preset.
- Extend `test_setup_level_wizard_flow` to assert the step 2 description is present.

## Test plan
- [x] `pytest tests/integration/extensions/test_setup_level_wizard_flow.py`
- [ ] Run `/setup level` in Discord: pick a scaling, confirm step 2 embed lists Fast/Normal/Slow with cooldown details


Made with [Cursor](https://cursor.com)