### PR TITLE
fix(setup): use selects for booster category and role setup

### DIFF
--- a/extensions/setup_wizards.py
+++ b/extensions/setup_wizards.py
@@ -1,6 +1,6 @@
 """
 Interactive setup wizards for complex features.
-Provides guided, step-by-step configuration using modals and buttons.
+Provides guided, step-by-step configuration using selects and buttons.
 """
 from locale_keys import locale as l10n
 from typing import Any, cast
@@ -10,7 +10,7 @@ from utils.discord_channels import bot_can_send_messages, channel_mention, resol
 from utils.embeds import TanjunEmbed
 from discord import app_commands
 from discord.ext import commands
-from discord.ui import Modal, TextInput, View
+from discord.ui import View
 import utility
 from api import get_level_system_status as api_get_level_system_status
 from api import get_log_channel as api_get_log_channel
@@ -309,33 +309,64 @@ class BoosterSetupView(View):
         channel_id = await booster_service.get(BoosterType.CHANNEL, str(self.guild.id))
         role_id = await booster_service.get(BoosterType.ROLE, str(self.guild.id))
         if 'channel' in self._steps_done:
-            desc_parts.append('✅ Booster channel configured')
+            desc_parts.append('✅ Booster category configured')
         else:
-            desc_parts.append('⬜ Not configured yet — press **Set Booster Channel**')
+            desc_parts.append('⬜ Not configured yet — select a **booster category** below')
         if 'role' in self._steps_done:
             desc_parts.append('✅ Booster role configured')
         else:
-            desc_parts.append('⬜ Not configured yet — press **Set Booster Role**')
+            desc_parts.append('⬜ Not configured yet — select a **booster role** below')
         embed = utility.tanjunEmbed(title='Booster Setup', description='\n'.join(desc_parts))
         if channel_id:
-            embed.add_field(name='Current Channel', value=f'<#{channel_id}>', inline=True)
+            category = self.guild.get_channel(int(channel_id))
+            if category is not None and getattr(category, 'name', None):
+                embed.add_field(name='Current Category', value=category.name, inline=True)
+            else:
+                embed.add_field(name='Current Category', value=f'`{channel_id}`', inline=True)
         if role_id:
             embed.add_field(name='Current Role', value=f'<@&{role_id}>', inline=True)
         await interaction.response.edit_message(embed=_discord_embed(embed), view=self)
 
-    @discord.ui.button(label='🎤 Set Booster Channel', style=discord.ButtonStyle.primary)
-    async def set_channel(self, interaction: discord.Interaction, _button: discord.ui.Button[Any]) -> None:
+    @discord.ui.select(cls=discord.ui.ChannelSelect, placeholder='Select a category for booster voice channels...', channel_types=[discord.ChannelType.category])
+    async def on_category_select(self, interaction: discord.Interaction, select: discord.ui.ChannelSelect[Any]) -> None:
         if not _require_admin(interaction):
             await _not_admin_reply(interaction)
             return
-        await interaction.response.send_modal(BoosterChannelModal(self.locale, self.guild, self))
+        if not select.values:
+            return
+        selected = select.values[0]
+        category = await resolve_guild_channel(self.guild, selected)
+        if category is None:
+            embed = utility.tanjunEmbed(title='Category Not Found', description='Could not find that category in this server.')
+            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
+            return
+        if getattr(category, 'type', None) != discord.ChannelType.category:
+            embed = utility.tanjunEmbed(title='Invalid Category', description='Please select a channel category.')
+            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
+            return
+        booster_service = BoosterService()
+        await booster_service.add(BoosterType.CHANNEL, str(self.guild.id), str(category.id))
+        self._steps_done.add('channel')
+        await self._update_booster_ui(interaction)
 
-    @discord.ui.button(label='🎭 Set Booster Role', style=discord.ButtonStyle.primary)
-    async def set_role(self, interaction: discord.Interaction, _button: discord.ui.Button[Any]) -> None:
+    @discord.ui.select(cls=discord.ui.RoleSelect, placeholder='Select a role to grant booster perks...')
+    async def on_role_select(self, interaction: discord.Interaction, select: discord.ui.RoleSelect[Any]) -> None:
         if not _require_admin(interaction):
             await _not_admin_reply(interaction)
             return
-        await interaction.response.send_modal(BoosterRoleModal(self.locale, self.guild, self))
+        if not select.values:
+            return
+        role = select.values[0]
+        if not isinstance(role, discord.Role):
+            role = self.guild.get_role(role.id)
+        if role is None:
+            embed = utility.tanjunEmbed(title='Role Not Found', description='Could not find that role in this server.')
+            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
+            return
+        booster_service = BoosterService()
+        await booster_service.add(BoosterType.ROLE, str(self.guild.id), str(role.id))
+        self._steps_done.add('role')
+        await self._update_booster_ui(interaction)
 
     @discord.ui.button(label='✅ Finish Booster Setup', style=discord.ButtonStyle.green)
     async def finish(self, interaction: discord.Interaction, _button: discord.ui.Button[Any]) -> None:
@@ -347,68 +378,6 @@ class BoosterSetupView(View):
             item.disabled = True
         await interaction.response.edit_message(embed=_discord_embed(embed), view=self)
         self.stop()
-
-class BoosterChannelModal(Modal):
-
-    def __init__(self, locale: str, guild: discord.Guild, parent_view: BoosterSetupView) -> None:
-        super().__init__(title='Set Booster Channel')
-        self.locale = locale
-        self.guild = guild
-        self.parent = parent_view
-        self.add_item(TextInput(label='Voice Channel ID', placeholder='Paste the voice channel ID', required=True, max_length=20))
-
-    async def on_submit(self, interaction: discord.Interaction) -> None:
-        if not _require_admin(interaction):
-            await _not_admin_reply(interaction)
-            return
-        try:
-            channel_id = int(str(self.children[0].value))
-        except ValueError:
-            embed = utility.tanjunEmbed(title='Invalid ID', description='Please provide a valid channel ID.')
-            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
-            return
-        channel = self.guild.get_channel(channel_id)
-        if channel is None:
-            embed = utility.tanjunEmbed(title='Channel Not Found', description='Could not find that channel in this server.')
-            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
-            return
-        if not isinstance(channel, discord.VoiceChannel):
-            embed = utility.tanjunEmbed(title='Invalid Channel Type', description='Please provide a voice channel ID. The channel you selected is not a voice channel.')
-            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
-            return
-        booster_service = BoosterService()
-        await booster_service.add(BoosterType.CHANNEL, str(self.guild.id), str(channel_id))
-        self.parent._steps_done.add('channel')
-        await self.parent._update_booster_ui(interaction)
-
-class BoosterRoleModal(Modal):
-
-    def __init__(self, locale: str, guild: discord.Guild, parent_view: BoosterSetupView) -> None:
-        super().__init__(title='Set Booster Role')
-        self.locale = locale
-        self.guild = guild
-        self.parent = parent_view
-        self.add_item(TextInput(label='Role ID', placeholder='Paste the role ID', required=True, max_length=20))
-
-    async def on_submit(self, interaction: discord.Interaction) -> None:
-        if not _require_admin(interaction):
-            await _not_admin_reply(interaction)
-            return
-        try:
-            role_id = int(str(self.children[0].value))
-        except ValueError:
-            embed = utility.tanjunEmbed(title='Invalid ID', description='Please provide a valid role ID.')
-            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
-            return
-        role = self.guild.get_role(role_id)
-        if role is None:
-            embed = utility.tanjunEmbed(title='Role Not Found', description='Could not find that role in this server.')
-            await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)
-            return
-        booster_service = BoosterService()
-        await booster_service.add(BoosterType.ROLE, str(self.guild.id), str(role_id))
-        self.parent._steps_done.add('role')
-        await self.parent._update_booster_ui(interaction)
 
 class SetupWizardsCog(commands.Cog):
     """Cog that provides /setup commands for guided configuration."""
@@ -488,7 +457,7 @@ class SetupWizardCommands(discord.app_commands.Group):
             await _not_admin_reply(interaction)
             return
         assert interaction.guild is not None
-        embed = utility.tanjunEmbed(title='🎵 Booster Setup Wizard', description='Configure perks for server boosters.\n\n• **Booster Channel** — boosters get a private voice channel\n• **Booster Role** — assign a role that grants booster perks')
+        embed = utility.tanjunEmbed(title='🎵 Booster Setup Wizard', description='Configure perks for server boosters.\n\n• **Booster category** — boosters create private voice channels in this category\n• **Booster role** — select a role that grants booster perks')
         view = BoosterSetupView(_loc_or_en(interaction), interaction.guild)
         await interaction.response.send_message(embed=_discord_embed(embed), view=view)
 

--- a/tests/integration/extensions/test_setup_booster_wizard_flow.py
+++ b/tests/integration/extensions/test_setup_booster_wizard_flow.py
@@ -23,13 +23,13 @@ class TestBoosterSetupWizardFlow:
             await view._update_booster_ui(ix)
         embed = embed_from_edit(ix)
         desc = embed.description or ""
-        assert "Booster channel" in desc or "channel" in desc.lower()
-        assert "Booster role" in desc or "role" in desc.lower()
+        assert "booster category" in desc.lower() or "category" in desc.lower()
+        assert "booster role" in desc.lower() or "role" in desc.lower()
 
     async def test_booster_finish_disables_buttons(self, setup_wizards_module) -> None:
         sw = setup_wizards_module
         view = sw.BoosterSetupView("en-US", MagicMock())
-        view.children = [MagicMock(disabled=False) for _ in range(4)]
+        view.children = [MagicMock(disabled=False) for _ in range(3)]
         ix = admin_interaction()
         await view.finish(ix, MagicMock())
         assert all(item.disabled for item in view.children)

--- a/tests/integration/extensions/test_setup_wizards_comprehensive.py
+++ b/tests/integration/extensions/test_setup_wizards_comprehensive.py
@@ -8,7 +8,8 @@ import pytest
 import extensions.setup_wizards as sw_mod
 from models import LogEnableModel
 from tests.helpers.discord import (
-    MockVoiceChannel,
+    MockGuild,
+    MockRole,
     make_app_command_channel,
     make_guild,
     make_interaction,
@@ -46,9 +47,15 @@ def _log_enable(**flags: bool) -> LogEnableModel:
     return LogEnableModel(guild_id=GUILD_ID, **defaults)
 
 
-def make_voice_channel() -> MockVoiceChannel:
-    ch = MockVoiceChannel()
+class MockCategoryChannel(MockGuild):
+    pass
+
+
+def make_category_channel() -> MockCategoryChannel:
+    ch = MockCategoryChannel()
     ch.id = 777777777
+    ch.name = 'Booster Channels'
+    ch.type = discord.ChannelType.category
     return ch
 
 
@@ -246,60 +253,61 @@ class TestLevelSetupFlow:
 
 
 class TestBoosterSetup:
-    async def test_refresh_finish_and_modals(self, sw) -> None:
+    async def test_refresh_finish_and_selects(self, sw) -> None:
         guild = make_guild()
         view = sw.BoosterSetupView("en-US", guild)
         ix = _admin_interaction(guild=guild)
         svc = MagicMock()
         svc.get = AsyncMock(return_value="111")
+        guild.get_channel = MagicMock(return_value=make_category_channel())
         with patch.object(sw_mod, "BoosterService", return_value=svc):
             await view._update_booster_ui(ix)
             await view.finish(ix, MagicMock())
-            await view.set_channel(ix, MagicMock())
-            await view.set_role(ix, MagicMock())
+            await view.on_category_select(ix, MagicMock(values=[]))
+            await view.on_role_select(ix, MagicMock(values=[]))
 
-    async def test_booster_channel_modal_paths(self, sw) -> None:
+    async def test_booster_category_select_paths(self, sw) -> None:
         guild = make_guild()
-        parent = sw.BoosterSetupView("en-US", guild)
-        modal = sw.BoosterChannelModal("en-US", guild, parent)
+        view = sw.BoosterSetupView("en-US", guild)
         ix = _admin_interaction(guild=guild)
-        modal.children = [MagicMock(value="bad")]
-        await modal.on_submit(ix)
-        modal.children = [MagicMock(value="999")]
-        guild.get_channel = MagicMock(return_value=None)
-        await modal.on_submit(ix)
-        vc = make_voice_channel()
-        guild.get_channel = MagicMock(return_value=vc)
-        modal.children = [MagicMock(value="777777777")]
+        await view.on_category_select(ix, MagicMock(values=[]))
+        with patch.object(sw_mod, "resolve_guild_channel", new=AsyncMock(return_value=None)):
+            await view.on_category_select(
+                ix,
+                MagicMock(values=[make_app_command_channel(guild=guild)]),
+            )
+        ix.response.send_message.assert_awaited()
         svc = MagicMock()
         svc.add = AsyncMock()
         svc.get = AsyncMock(return_value="111")
+        category = make_category_channel()
         with (
             patch.object(sw_mod, "BoosterService", return_value=svc),
-            patch.object(sw_mod.discord, "VoiceChannel", MockVoiceChannel),
+            patch.object(sw_mod, "resolve_guild_channel", new=AsyncMock(return_value=category)),
         ):
-            await modal.on_submit(ix)
+            await view.on_category_select(
+                ix,
+                MagicMock(values=[make_app_command_channel(guild=guild)]),
+            )
         embed = ix.response.edit_message.await_args.kwargs["embed"]
-        assert "Booster channel configured" in (embed.description or "")
+        assert "Booster category configured" in (embed.description or "")
 
-    async def test_booster_role_modal_paths(self, sw) -> None:
+    async def test_booster_role_select_paths(self, sw) -> None:
         guild = make_guild()
-        parent = sw.BoosterSetupView("en-US", guild)
-        modal = sw.BoosterRoleModal("en-US", guild, parent)
+        view = sw.BoosterSetupView("en-US", guild)
         ix = _admin_interaction(guild=guild)
-        modal.children = [MagicMock(value="bad")]
-        await modal.on_submit(ix)
-        modal.children = [MagicMock(value="555555555")]
+        await view.on_role_select(ix, MagicMock(values=[]))
+        partial_role = MagicMock(id=555555555)
         guild.get_role = MagicMock(return_value=None)
-        await modal.on_submit(ix)
-        role = MagicMock()
-        role.mention = "<@&555>"
-        guild.get_role = MagicMock(return_value=role)
+        with patch.object(sw_mod, "BoosterService", return_value=MagicMock(add=AsyncMock())):
+            await view.on_role_select(ix, MagicMock(values=[partial_role]))
+        ix.response.send_message.assert_awaited()
+        role = MockRole()
         svc = MagicMock()
         svc.add = AsyncMock()
         svc.get = AsyncMock(return_value="555")
         with patch.object(sw_mod, "BoosterService", return_value=svc):
-            await modal.on_submit(ix)
+            await view.on_role_select(ix, MagicMock(values=[role]))
         embed = ix.response.edit_message.await_args.kwargs["embed"]
         assert "Booster role configured" in (embed.description or "")
 

--- a/tests/integration/extensions/test_setup_wizards_deep.py
+++ b/tests/integration/extensions/test_setup_wizards_deep.py
@@ -6,8 +6,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from extensions.setup_wizards import (
-    BoosterChannelModal,
-    BoosterRoleModal,
     BoosterSetupView,
     LevelChannelView,
     LevelCooldownView,
@@ -89,27 +87,10 @@ async def test_level_setup_views():
         assert view is not None
 
 
-async def test_booster_modals_on_submit():
-    parent = BoosterSetupView("en-US", make_guild())
-    modal = BoosterChannelModal("en-US", make_guild(), parent)
-    modal.channel_id = MagicMock(value="444444444")
-    modal.role_id = MagicMock(value="555555555")
-    interaction = MagicMock()
-    interaction.user = MagicMock()
-    interaction.user.guild_permissions = MagicMock(administrator=True)
-    interaction.guild = make_guild()
-    interaction.response = MagicMock()
-    interaction.response.defer = AsyncMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.followup = MagicMock()
-    interaction.followup.send = AsyncMock()
-    with patch("extensions.setup_wizards.BoosterService") as svc:
-        svc.return_value.set = AsyncMock()
-        await modal.on_submit(interaction)
-
-    modal2 = BoosterRoleModal("en-US", make_guild(), parent)
-    modal2.role_id = MagicMock(value="555555555")
-    await modal2.on_submit(interaction)
+async def test_booster_select_handlers_exist():
+    view = BoosterSetupView("en-US", make_guild())
+    assert hasattr(view, "on_category_select")
+    assert hasattr(view, "on_role_select")
 
 
 async def test_setup_wizards_cog_on_ready():


### PR DESCRIPTION
## Summary
- Replace booster setup ID modals with inline category and role selects, consistent with log and level setup wizards
- Fix booster channel configuration to store a category ID (matching `/utility setupboosterchannel` and claim flow) instead of a voice channel ID
- Update booster setup tests for the new select-based flow

## Test plan
- [x] `pytest tests/integration/extensions/test_setup_booster_wizard_flow.py`
- [x] `pytest tests/integration/extensions/test_setup_wizards_comprehensive.py::TestBoosterSetup`
- [x] `pytest tests/integration/extensions/test_setup_wizards_deep.py::test_booster_select_handlers_exist`
- [ ] Run `/setup booster` in Discord and verify category + role selects update the embed and persist settings


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the booster setup wizard with an improved interface using select menus instead of modal dialogs for a more intuitive flow
  * Updated booster configuration terminology from "Channel" to "Category" for better clarity
  * Added a summary view displaying currently configured booster categories and roles during setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->