### PR TITLE
fix(twitch): use attribute access for LiveStreamInfo objects

### DIFF
--- a/commands/utility/twitch/twitch_api.py
+++ b/commands/utility/twitch/twitch_api.py
@@ -6,11 +6,10 @@ The service itself is in services/twitch_service.py.
 from __future__ import annotations
 
 from locale_keys import locale
-from typing import Any
 import discord
-from services.twitch_service import get_twitch_service
+from services.twitch_service import LiveStreamInfo, get_twitch_service
 
-async def notify_twitch_online(client: discord.Client, uuid: str, data: dict[str, Any]) -> None:
+async def notify_twitch_online(client: discord.Client, uuid: str, data: LiveStreamInfo) -> None:
     """Send a Twitch live notification using the TwitchService."""
     service = get_twitch_service()
     if service is None:

--- a/extensions/loops.py
+++ b/extensions/loops.py
@@ -148,7 +148,7 @@ class LoopCog(commands.Cog):
                 return  # Skip notifications on first check
 
             streams = await twitch_service.get_streams(user_ids)
-            live_streams = {stream["user_id"]: stream for stream in streams}
+            live_streams = {stream.user_id: stream for stream in streams}
 
             # Batch notification for streams going live simultaneously
             newly_live = [

--- a/services/twitch_service.py
+++ b/services/twitch_service.py
@@ -171,7 +171,7 @@ class TwitchService:
             rows.append(TwitchNotification(*row))
         return rows
 
-    async def send_live_notification(self, client: discord.Client, twitch_uuid: str, stream_data: dict[str, Any]) -> None:
+    async def send_live_notification(self, client: discord.Client, twitch_uuid: str, stream_data: LiveStreamInfo) -> None:
         """Send Twitch live notifications to all configured channels for this user."""
         notifications = await self.get_notification_by_twitch_uuid(twitch_uuid)
         if not notifications:
@@ -183,12 +183,12 @@ class TwitchService:
             guild = client.get_guild(int(guild_id))
             if guild is None:
                 continue
-            message = self.parse_notification_message(notification_message, str(guild.preferred_locale), stream_data['user_name'])
+            message = self.parse_notification_message(notification_message, str(guild.preferred_locale), stream_data.user_name)
             channel = guild.get_channel(int(channel_id))
             if channel is None or isinstance(channel, (discord.ForumChannel, discord.CategoryChannel)):
                 continue
-            embed = tanjunEmbed(description=f"[{stream_data['title']}](https://www.twitch.tv/{stream_data['user_name']})")
-            embed.set_image(url=stream_data['thumbnail_url'].replace('{width}', '1920').replace('{height}', '1080'))
+            embed = tanjunEmbed(description=f"[{stream_data.title}](https://www.twitch.tv/{stream_data.user_name})")
+            embed.set_image(url=stream_data.thumbnail_url.replace('{width}', '1920').replace('{height}', '1080'))
             await channel.send(message, embed=embed)
 
     def parse_notification_message(self, message: str | None, locale_str: str, twitch_name: str) -> str:

--- a/tests/integration/extensions/test_loops_comprehensive.py
+++ b/tests/integration/extensions/test_loops_comprehensive.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from services.twitch_service import LiveStreamInfo
 from tests.helpers.discord import make_guild, make_text_channel
 from tests.integration.extensions.conftest import load_extension_bot
 
@@ -118,7 +119,7 @@ async def test_poll_twitch_newly_live(loop_cog) -> None:
     svc.get_all_notification_uuids = AsyncMock(return_value=["user1"])
     svc.initial_check_done = True
     svc.stream_status = {"user1": False}
-    svc.get_streams = AsyncMock(return_value=[{"user_id": "user1", "title": "live"}])
+    svc.get_streams = AsyncMock(return_value=[LiveStreamInfo("user1", "user1", "live", 0, "", "")])
     with (
         patch.object(loops_mod, "get_twitch_service", return_value=svc),
         patch.object(loops_mod, "notify_twitch_online", new=AsyncMock()) as notify,

--- a/tests/unit/services/test_twitch_service.py
+++ b/tests/unit/services/test_twitch_service.py
@@ -322,7 +322,7 @@ class TestTwitchServiceSendLiveNotification:
         client = MagicMock()
         with patch.object(service, "get_notification_by_twitch_uuid", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = []
-            await service.send_live_notification(client, "uuid", {"user_name": "s", "title": "t", "thumbnail_url": "u"})
+            await service.send_live_notification(client, "uuid", LiveStreamInfo("uuid", "s", "t", 0, "", "u"))
         client.get_guild.assert_not_called()
 
     @pytest.mark.asyncio
@@ -333,7 +333,7 @@ class TestTwitchServiceSendLiveNotification:
         with patch.object(service, "get_notification_by_twitch_uuid", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = [notification]
             await service.send_live_notification(
-                client, "uuid", {"user_name": "s", "title": "t", "thumbnail_url": "https://x/{width}/{height}"}
+                client, "uuid", LiveStreamInfo("uuid", "s", "t", 0, "", "https://x/{width}/{height}")
             )
 
     @pytest.mark.asyncio
@@ -344,11 +344,7 @@ class TestTwitchServiceSendLiveNotification:
         client = MagicMock()
         client.get_guild.return_value = guild
         notification = TwitchNotification("1", CHANNEL_ID, GUILD_ID, "uuid", "name", "Watch {name}")
-        stream_data = {
-            "user_name": "streamer",
-            "title": "Playing games",
-            "thumbnail_url": "https://x/{width}x{height}.jpg",
-        }
+        stream_data = LiveStreamInfo("uuid", "streamer", "Playing games", 0, "", "https://x/{width}x{height}.jpg")
         with patch.object(service, "get_notification_by_twitch_uuid", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = [notification]
             await service.send_live_notification(client, "uuid", stream_data)
@@ -366,7 +362,7 @@ class TestTwitchServiceSendLiveNotification:
         notification = TwitchNotification("1", CHANNEL_ID, GUILD_ID, "uuid", "name", None)
         with patch.object(service, "get_notification_by_twitch_uuid", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = [notification]
-            await service.send_live_notification(client, "uuid", {"user_name": "s", "title": "t", "thumbnail_url": "u"})
+            await service.send_live_notification(client, "uuid", LiveStreamInfo("uuid", "s", "t", 0, "", "u"))
 
 
 class TestTwitchServiceSingleton:


### PR DESCRIPTION
## Problem
`pollTwitchStreams` crashed with `TypeError: 'LiveStreamInfo' object is not subscriptable` (reported in #3272) at `extensions/loops.py:151`:

```python
live_streams = {stream["user_id"]: stream for stream in streams}
```

`twitch_service.get_streams()` returns `list[LiveStreamInfo]` dataclasses (not dicts), so `stream["user_id"]` fails.

## Root cause
The Twitch path was written against raw dicts but the service layer returns `LiveStreamInfo` dataclasses (see `services/twitch_service.py`). The loop crashed at the dict comprehension; fixing only that would expose a **cascading latent bug** in `TwitchService.send_live_notification`, which subscripts the same object (`stream_data['user_name']`, `['title']`, `['thumbnail_url']`) — it would crash identically once the loop progressed further.

## Fix
- `extensions/loops.py` — `stream["user_id"]` → `stream.user_id`.
- `services/twitch_service.py` — `send_live_notification` now takes `stream_data: LiveStreamInfo` and accesses `.user_name` / `.title` / `.thumbnail_url` via attributes (was dict subscripts that crash the same way).
- `commands/utility/twitch/twitch_api.py` — `notify_twitch_online` now typed `LiveStreamInfo` (it forwards the same object to the service); dropped the now-unused `Any` import.
- `tests/unit/services/test_twitch_service.py` — pass `LiveStreamInfo` objects to `send_live_notification` (matching the corrected contract).

## Verification
- `pytest tests/unit/services/test_twitch_service.py tests/integration/extensions/test_loops.py tests/unit/commands/test_twitch_api_deep.py tests/integration/commands/utility/twitch/test_utility_twitch_twitch_api.py tests/integration/commands/utility/test_twitch_coverage.py` → 76 passed
- `mypy extensions/loops.py services/twitch_service.py commands/utility/twitch/twitch_api.py` → no issues

Closes #3272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch live notification handling for more reliable stream alerts.
  * Fixed stream monitoring so live updates are processed consistently across channels.
* **Tests**
  * Updated automated coverage for Twitch notification scenarios, including missing channels and forum channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->