### PR TITLE
fix(logs): tolerate bare Object in permission-overwrite targets

### DIFF
--- a/extensions/logs.py
+++ b/extensions/logs.py
@@ -55,6 +55,24 @@ async def _find_audit_log_entry(guild: discord.Guild, action: discord.AuditLogAc
     except discord.Forbidden:
         pass
     return None
+
+def _overwrite_target_str(target: discord.Role | discord.Member | discord.Object) -> str:
+    """Best-effort display string for a permission-overwrite target.
+
+    Overwrite keys are normally a Role or Member (which expose ``.mention``
+    and ``.name``), but can be a bare ``discord.Object`` when the referenced
+    role/member is uncached or was deleted. ``Object`` has neither attribute,
+    so naively falling back to ``target.name`` raises ``AttributeError``
+    (issue #3266). Fall back to the snowflake id instead.
+    """
+    mention = getattr(target, 'mention', None)
+    if mention:
+        return str(mention)
+    name = getattr(target, 'name', None)
+    if name:
+        return str(name)
+    return f'ID: {getattr(target, "id", "?")}'
+
 embeds = {}
 _log_queue: asyncio.Queue[tuple[str, discord.Embed]] = asyncio.Queue(maxsize=200)
 
@@ -454,7 +472,7 @@ class LogsCog(commands.Cog):
                         allowed.append(f'`{local_perm}`')
                     elif value is False:
                         denied.append(f'`{local_perm}`')
-                target_str = target.mention if hasattr(target, 'mention') else target.name
+                target_str = _overwrite_target_str(target)
                 description_parts.append(l10n.logs.guildChannelDelete.permissionOverwriteTarget(locale, target=target_str))
                 if allowed:
                     description_parts.append(l10n.logs.guildChannelDelete.permissionOverwriteAllowed(locale, permissions=', '.join(allowed)))
@@ -495,7 +513,7 @@ class LogsCog(commands.Cog):
                         allowed.append(f'`{local_perm}`')
                     elif value is False:
                         denied.append(f'`{local_perm}`')
-                target_str = target.mention if hasattr(target, 'mention') else target.name
+                target_str = _overwrite_target_str(target)
                 description_parts.append(f'### {target_str}')
                 if allowed:
                     description_parts.append('✅ ' + ', '.join(allowed))
@@ -530,11 +548,11 @@ class LogsCog(commands.Cog):
         if before.overwrites != after.overwrites:
             for target in before.overwrites:
                 if target not in after.overwrites:
-                    target_str = target.mention if hasattr(target, 'mention') else target.name
+                    target_str = _overwrite_target_str(target)
                     description_parts.append(l10n.logs.guildChannelUpdate.permissionOverwriteRemoved(locale, target=target_str))
             for target, new_overwrite in after.overwrites.items():
                 old_overwrite = before.overwrites.get(target, None)
-                target_str = target.mention if hasattr(target, 'mention') else target.name
+                target_str = _overwrite_target_str(target)
                 if old_overwrite is None:
                     allowed = []
                     denied = []

--- a/tests/unit/extensions/test_logs_overwrite_target.py
+++ b/tests/unit/extensions/test_logs_overwrite_target.py
@@ -1,0 +1,46 @@
+"""Regression tests for extensions.logs._overwrite_target_str.
+
+See issue #3266: permission-overwrite targets can be a bare ``discord.Object``
+(neither ``.name`` nor ``.mention``) when the referenced role/member is
+uncached or deleted, which previously raised ``AttributeError``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import tests.mock_config as mock_config
+
+mock_config.patch_config_module()
+
+from extensions.logs import _overwrite_target_str  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_object_without_name_or_mention_falls_back_to_id() -> None:
+    # A bare overwrite target (e.g. an uncached discord.Object) exposes an
+    # id but neither .name nor .mention.
+    target = SimpleNamespace(id=123456789)
+    assert _overwrite_target_str(target) == 'ID: 123456789'
+
+
+def test_target_with_mention_uses_mention() -> None:
+    target = SimpleNamespace(mention='<@&5>')
+    assert _overwrite_target_str(target) == '<@&5>'
+
+
+def test_target_with_name_but_no_mention_uses_name() -> None:
+    target = SimpleNamespace(name='somebody')
+    assert _overwrite_target_str(target) == 'somebody'
+
+
+def test_target_prefers_mention_over_name() -> None:
+    target = SimpleNamespace(mention='<@42>', name='ignored')
+    assert _overwrite_target_str(target) == '<@42>'
+
+
+def test_target_without_name_or_mention_or_id_is_unknown() -> None:
+    target = SimpleNamespace()
+    assert _overwrite_target_str(target) == 'ID: ?'


### PR DESCRIPTION
## Problem
`on_guild_channel_update` (and the sibling create/delete handlers) crashed with `AttributeError: 'Object' object has no attribute 'name'` (reported in #3266):

```python
target_str = target.mention if hasattr(target, 'mention') else target.name
```

`channel.overwrites` keys are normally a `Role`/`Member`, but Discord hands back a bare `discord.Object` when the referenced role/member is uncached or was deleted. Such an `Object` has neither `.mention` nor `.name`, so the `else target.name` branch raised `AttributeError`, aborting the log handler (the exception surfaced in `logger:discord.client` / `on_guild_channel_update`).

## Fix
Introduce a small helper `_overwrite_target_str(target)` that prefers `.mention`, then `.name`, then falls back to the snowflake id (`f'ID: {target.id}'`), and use it in all four overwrite-rendering sites (the same latent bug existed at `extensions/logs.py` lines 457, 498, 533, 537 — guild channel delete, create, and update).

```python
def _overwrite_target_str(target: discord.Role | discord.Member | discord.Object) -> str:
    mention = getattr(target, 'mention', None)
    if mention:
        return str(mention)
    name = getattr(target, 'name', None)
    if name:
        return str(name)
    return f'ID: {getattr(target, "id", "?")}'
```

## Verification
- New regression tests `tests/unit/extensions/test_logs_overwrite_target.py` (5 cases: bare Object → id fallback, mention preferred, name path, mention-over-name, no-id → `ID: ?`) — all pass.
- Existing logs tests: `pytest tests/integration/extensions/test_logs.py test_logs_deep.py test_logs_comprehensive.py test_logs_extended_coverage.py tests/unit/extensions/test_logs_message_edit.py` → 101 passed.
- `mypy extensions/logs.py` → no issues.

Closes #3266
