### PR TITLE
fix(mypy): resolve 4 unreachable-statement errors

### DIFF
--- a/extensions/setup_wizards.py
+++ b/extensions/setup_wizards.py
@@ -356,9 +356,8 @@ class BoosterSetupView(View):
             return
         if not select.values:
             return
-        role = select.values[0]
-        if not isinstance(role, discord.Role):
-            role = self.guild.get_role(role.id)
+        selected: discord.Role | discord.Object = select.values[0]
+        role: discord.Role | None = selected if isinstance(selected, discord.Role) else self.guild.get_role(selected.id)
         if role is None:
             embed = utility.tanjunEmbed(title='Role Not Found', description='Could not find that role in this server.')
             await interaction.response.send_message(embed=_discord_embed(embed), ephemeral=True)

--- a/services/booster_service.py
+++ b/services/booster_service.py
@@ -172,7 +172,7 @@ class BoosterService:
             rows = await self._fetch_all_claims_from_db(claimed_type)
             return rows if rows is not None else []
 
-        result = await _claimed_all_cache.get_or_fetch(claimed_type.name, fetch)
+        result: list | None = await _claimed_all_cache.get_or_fetch(claimed_type.name, fetch)
         if result is not None:
             return result
         _claimed_all_cache.invalidate(claimed_type.name)

--- a/utils/command_tree_audit.py
+++ b/utils/command_tree_audit.py
@@ -35,7 +35,7 @@ def audit_root_command_payloads(
     safe_limit: int = DISCORD_COMMAND_PAYLOAD_SAFE_LIMIT,
     hard_limit: int = DISCORD_COMMAND_PAYLOAD_LIMIT,
 ) -> list[CommandPayloadAudit]:
-    tree = bot.tree
+    tree: discord.app_commands.CommandTree[Any] | None = bot.tree
     if tree is None:
         return []
 


### PR DESCRIPTION
## Problem
The type-check issue-management workflow (`mypy --warn-unreachable`) reported 4 `Statement is unreachable` errors in #3309:

- `utils/command_tree_audit.py:40` — `if tree is None: return []`
- `services/booster_service.py:178` — cached-`None` recovery fallback in `get_all_claims`
- `extensions/setup_wizards.py:361` and `:363` — `isinstance(role, discord.Role)` re-fetch + `if role is None` guard in the booster role-select handler

mypy proved each branch unreachable from the declared types (`bot.tree` is non-Optional, `get_or_fetch` returns non-None `V`, `RoleSelect.values` is `list[discord.Role]`).

## Approach
These guards and their tests are intentional — the tests force the "impossible" state via mocks (`bot.tree = None`, `get_or_fetch → None`, non-Role `select.values`). Rather than delete tested defensive code or sprinkle `# type: ignore[unreachable]` (the repo has zero `[unreachable]` ignores today), **widen the local type annotations** so the guards are statically reachable. Behavior and tests are unchanged.

- `utils/command_tree_audit.py` — `tree: CommandTree[Any] | None = bot.tree` → the `if tree is None` guard stays reachable.
- `services/booster_service.py` — `result: list | None = await ...get_or_fetch(...)` → the cached-`None` recovery (`invalidate` + refetch) stays reachable.
- `extensions/setup_wizards.py` — `selected: discord.Role | discord.Object = select.values[0]` and `role: discord.Role | None = selected if isinstance(selected, discord.Role) else self.guild.get_role(selected.id)` → the non-Role re-fetch and `if role is None` guard stay reachable.

## Verification
- `mypy . --explicit-package-bases --no-error-summary --show-error-codes --soft-error-limit -1 --warn-unreachable` (the workflow's flags) → the 4 reported errors are gone. (Remaining `build/lib/...` unreachable notes are from a local gitignored build artifact dir, not present in CI.)
- `mypy` on the 3 files with `--warn-unreachable` → no issues.
- Previously-failing tests now pass: `test_audit_root_command_payloads_tree_is_none`, `test_find_oversized_root_commands_no_tree`, `test_get_all_claims_recovers_from_cached_none`, `test_booster_role_select_paths` (68 passed across the three modules' test suites).
- Diff is 3 files, +4/-5 — surgical, no behavior change.

Closes #3309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of role selection and cached fetch results for better code clarity and consistency.
  * Added explicit type annotations in command tree auditing and booster claim lookup logic.
  * No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->